### PR TITLE
Adding Security Features (UEFI SecureBoot and BootGuard) in NFD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		gcc \
 		libc6-dev \
 		make \
+		mokutil \
+		msr-tools \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GOLANG_VERSION 1.7.1

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ node-feature-discovery.
   -h --help                   Show this screen.
   --version                   Output version and exit.
   --sources=<sources>         Comma separated list of feature sources.
-                              [Default: cpuid,rdt,pstate,network]
+                              [Default: cpuid,rdt,pstate,network,security]
   --no-publish                Do not publish discovered features to the
                               cluster-local Kubernetes API server.
   --label-whitelist=<pattern> Regular expression to filter label names to
@@ -58,6 +58,7 @@ The current set of feature sources are the following:
 - [Intel Resource Director Technology][intel-rdt]
 - [Intel P-State driver][intel-pstate]
 - Network
+- Security
 
 ### Feature labels
 
@@ -79,7 +80,8 @@ the only label value published for features is the string `"true"`._
   "node.alpha.kubernetes-incubator.io/nfd-cpuid-<feature-name>": "true",
   "node.alpha.kubernetes-incubator.io/nfd-rdt-<feature-name>": "true",
   "node.alpha.kubernetes-incubator.io/nfd-pstate-<feature-name>": "true",
-  "node.alpha.kubernetes-incubator.io/nfd-network-<feature-name>": "true"
+  "node.alpha.kubernetes-incubator.io/nfd-network-<feature-name>": "true",
+  "node.alpha.kubernetes-incubator.io/nfd-security<feature-name>": "true"
 }
 ```
 
@@ -118,8 +120,15 @@ such as restricting discovered features with the --label-whitelist option._
 | :------------: | :---------------------------------------------------------------------------------: |
 | [SRIOV][sriov] | Single Root Input/Output Virtualization (SR-IOV) enabled Network Interface Card
 
-## Getting started
-### System requirements
+###  Security Features
+
+| Feature name   | Description                                                                         |
+| :------------: | :---------------------------------------------------------------------------------: |
+| [BootGuard][bootguard]         | A hardware-based boot integrity protection mechanism (New feature on Purley).
+| [UEFI Secure Boot][secureboot]  | Boot Firmware verification and authorization of OS Loader/Kernel components
+
+# Getting started
+## System requirements
 
 1. Linux (x86_64)
 1. [kubectl] [kubectl-setup] (properly set up and configured to work with your
@@ -228,7 +237,7 @@ This is open source software released under the [Apache 2.0 License](LICENSE).
 
 ## Demo
 
-A demo on the benefits of using node feature discovery can be found in [demo](demo/). 
+A demo on the benefits of using node feature discovery can be found in [demo](demo/).
 
 <!-- Links -->
 [cpuid]: http://man7.org/linux/man-pages/man4/cpuid.4.html
@@ -240,3 +249,5 @@ A demo on the benefits of using node feature discovery can be found in [demo](de
 [gcc-down]: https://gcc.gnu.org
 [kubectl-setup]: https://coreos.com/kubernetes/docs/latest/configure-kubectl.html
 [node-sel]: http://kubernetes.io/docs/user-guide/node-selection
+[secureboot]: https://github.com/advanced-threat-research/firmware-security-training/blob/master/BIOS-UEFI-Security.2-BootkitsSecureBoot.pdf
+[bootguard]: https://github.com/advanced-threat-research/firmware-security-training/blob/master/BIOS-UEFI-Security.6-Mitigations.pdf

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/docopt/docopt-go"
 	"github.com/kubernetes-incubator/node-feature-discovery/source"
 	"github.com/kubernetes-incubator/node-feature-discovery/source/cpuid"
 	"github.com/kubernetes-incubator/node-feature-discovery/source/fake"
@@ -14,10 +15,10 @@ import (
 	"github.com/kubernetes-incubator/node-feature-discovery/source/panic_fake"
 	"github.com/kubernetes-incubator/node-feature-discovery/source/pstate"
 	"github.com/kubernetes-incubator/node-feature-discovery/source/rdt"
+	"github.com/kubernetes-incubator/node-feature-discovery/source/security"
 	k8sclient "k8s.io/client-go/kubernetes"
 	api "k8s.io/client-go/pkg/api/v1"
 	restclient "k8s.io/client-go/rest"
-	"github.com/docopt/docopt-go"
 )
 
 const (
@@ -111,7 +112,7 @@ func argsParse(argv []string) (noPublish bool, sourcesArg []string, whiteListArg
   -h --help                   Show this screen.
   --version                   Output version and exit.
   --sources=<sources>         Comma separated list of feature sources.
-                              [Default: cpuid,rdt,pstate,network]
+                              [Default: cpuid,rdt,pstate,network,security]
   --no-publish                Do not publish discovered features to the
                               cluster-local Kubernetes API server.
   --label-whitelist=<pattern> Regular expression to filter label names to
@@ -147,6 +148,7 @@ func configureParameters(sourcesArg []string, whiteListArg string) (sources []so
 		rdt.Source{},
 		pstate.Source{},
 		network.Source{},
+		security.Source{},
 		fake.Source{},
 		panic_fake.Source{},
 	}

--- a/node-feature-discovery-job.json.template
+++ b/node-feature-discovery-job.json.template
@@ -8,7 +8,8 @@
     "name": "node-feature-discovery"
   },
   "spec": {
-    "completions": COMPLETION_COUNT,
+    "completions": COMPLETION_COUNT
+,
     "parallelism": PARALLELISM_COUNT,
     "template": {
       "metadata": {
@@ -17,7 +18,7 @@
         }
       },
       "spec": {
-	"hostNetwork": true,
+        "hostNetwork": true,
         "containers": [
           {
             "env": [
@@ -39,13 +40,30 @@
               }
             ],
             "image": "quay.io/kubernetes_incubator/node-feature-discovery:v0.1.0",
+            "securityContext": {
+              "privileged": true
+            },
             "name": "node-feature-discovery",
+            "volumeMounts": [
+              {
+                "mountPath": "/sys",
+                "name": "efi-volume"
+              }
+            ],
             "ports": [
               {
                 "containerPort": 7156,
                 "hostPort": 7156
               }
             ]
+          }
+        ],
+        "volumes": [
+          {
+            "name": "efi-volume",
+            "hostPath": {
+              "path": "/sys"
+            }
           }
         ],
         "restartPolicy": "Never"

--- a/source/security/security.go
+++ b/source/security/security.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package security
+
+import (
+	"bytes"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/golang/glog"
+)
+
+const (
+	SecureBootString = "SecureBoot enabled"
+)
+
+// Source implements FeatureSource.
+type Source struct{}
+
+func (s Source) Name() string { return "security" }
+
+// Returns feature names for SecureBoot and BootGuard if suppported.
+func (s Source) Discover() ([]string, error) {
+	features := []string{}
+
+	//Discovery of SecureBoot
+	mokutilOutBytes, err := exec.Command("mokutil", "--sb-state").Output()
+	if err != nil {
+		glog.Errorf("Failed to detect support for UEFISecureBoot: %v", err)
+	} else {
+		mokutilOut := bytes.TrimSpace(mokutilOutBytes)
+		glog.Infof("The output after running mokutil --sb-state is %s\n", mokutilOut)
+		if strings.Compare(string(mokutilOut), SecureBootString) == 0 {
+			features = append(features, "UEFISecureBoot")
+		} else {
+			glog.Errorf("UEFISecureBoot not enabled on the system\n")
+		}
+	}
+
+	//Discovery of BootGuard
+	out, err := exec.Command("rdmsr", "0x13a", "-f", "0:0").Output()
+	if err != nil {
+		glog.Errorf("Error encountered while detectng support for BootGuard: %v", err)
+	} else {
+		glog.Infof("The output after running rdmsr 0x13a -f 0:0 is %s\n", out)
+		x, err := strconv.Atoi(string(out[0]))
+		if err != nil {
+			glog.Errorf("Error converting MSR value to integer: %v\n",err)
+
+		} else {
+
+			if x == 1 {
+				features = append(features, "BootGuard")
+			} else {
+				glog.Errorf("BootGuard not enabled on the system\n")
+			}
+
+		}
+	}
+
+	return features, nil
+}


### PR DESCRIPTION
- Discovery of security features (UEFI SecureBoot and BootGuard)
- Advertisement of node labels **node.alpha.kubernetes-incubator.io/nfd-security-UEFISecureBoot=true** and **node.alpha.kubernetes-incubator.io/nfd-security-BootGuard=true** corresponding to UEFI SecureBoot and BootGuard respectively