### PR TITLE
Implement systemd service detection for 'irqbalance'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ FROM debian:stretch-slim
 
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /usr/local/lib /usr/local/lib
+COPY --from=builder /bin/systemctl /bin/systemctl
 COPY --from=builder /etc/kubernetes/node-feature-discovery /etc/kubernetes/node-feature-discovery
 RUN ldconfig
 COPY --from=builder /go/bin/node-feature-discovery /usr/bin/node-feature-discovery

--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ Kernel config file to use, and, the set of config options to be detected are
 configurable.
 See [configuration options](#configuration-options) for more information.
 
+### System Features
+
+| Feature | Attribute  | Description                                           |
+| ------- | ---------- | ----------------------------------------------------- |
+| systemd | irqbalance | Check the service of irqbalance is active or not
+
 ### Local (User-specific Features)
 
 NFD has a special feature source named *local* which is designed for running

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/node-feature-discovery/source/rdt"
 	"sigs.k8s.io/node-feature-discovery/source/selinux"
 	"sigs.k8s.io/node-feature-discovery/source/storage"
+	"sigs.k8s.io/node-feature-discovery/source/system"
 	api "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "k8s.io/client-go/kubernetes"
@@ -182,7 +183,7 @@ func argsParse(argv []string) (args Args) {
                               will override settings read from the config file.
                               [Default: ]
   --sources=<sources>         Comma separated list of feature sources.
-                              [Default: cpuid,iommu,kernel,local,memory,network,pci,pstate,rdt,selinux,storage]
+                              [Default: cpuid,iommu,kernel,local,memory,network,pci,pstate,rdt,selinux,storage,system]
   --no-publish                Do not publish discovered features to the
                               cluster-local Kubernetes API server.
   --label-whitelist=<pattern> Regular expression to filter label names to
@@ -270,6 +271,7 @@ func configureParameters(sourcesWhiteList []string, labelWhiteListStr string) (e
 		rdt.Source{},
 		selinux.Source{},
 		storage.Source{},
+		system.Source{},
 		// local needs to be the last source so that it is able to override
 		// labels from other sources
 		local.Source{},

--- a/main_test.go
+++ b/main_test.go
@@ -152,7 +152,7 @@ func TestArgsParse(t *testing.T) {
 				So(args.sleepInterval, ShouldEqual, 60*time.Second)
 				So(args.noPublish, ShouldBeTrue)
 				So(args.oneshot, ShouldBeTrue)
-				So(args.sources, ShouldResemble, []string{"cpuid", "iommu", "kernel", "local", "memory", "network", "pci", "pstate", "rdt", "selinux", "storage"})
+				So(args.sources, ShouldResemble, []string{"cpuid", "iommu", "kernel", "local", "memory", "network", "pci", "pstate", "rdt", "selinux", "storage", "system"})
 				So(len(args.labelWhiteList), ShouldEqual, 0)
 			})
 		})
@@ -174,7 +174,7 @@ func TestArgsParse(t *testing.T) {
 
 			Convey("args.labelWhiteList is set to appropriate value and args.sources is set to default value", func() {
 				So(args.noPublish, ShouldBeFalse)
-				So(args.sources, ShouldResemble, []string{"cpuid", "iommu", "kernel", "local", "memory", "network", "pci", "pstate", "rdt", "selinux", "storage"})
+				So(args.sources, ShouldResemble, []string{"cpuid", "iommu", "kernel", "local", "memory", "network", "pci", "pstate", "rdt", "selinux", "storage", "system"})
 				So(args.labelWhiteList, ShouldResemble, ".*rdt.*")
 			})
 		})

--- a/node-feature-discovery-daemonset.yaml.template
+++ b/node-feature-discovery-daemonset.yaml.template
@@ -31,6 +31,9 @@ spec:
               readOnly: true
             - name: host-sys
               mountPath: "/host-sys"
+            - name: systemd
+              mountPath: "/run/systemd"
+              readOnly: true
       volumes:
         - name: host-boot
           hostPath:
@@ -38,3 +41,5 @@ spec:
         - name: host-sys
           hostPath:
             path: "/sys"
+        - name: systemd
+            path: "/run/systemd"

--- a/node-feature-discovery-job.yaml.template
+++ b/node-feature-discovery-job.yaml.template
@@ -33,6 +33,9 @@ spec:
               readOnly: true
             - name: host-sys
               mountPath: "/host-sys"
+            - name: systemd
+              mountPath: "/run/systemd"
+              readOnly: true
       restartPolicy: Never
       volumes:
         - name: host-boot
@@ -41,3 +44,6 @@ spec:
         - name: host-sys
           hostPath:
             path: "/sys"
+        - name: systemd
+          hostPath:
+            path: "/run/systemd"

--- a/source/system/system.go
+++ b/source/system/system.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"log"
+
+	"sigs.k8s.io/node-feature-discovery/source"
+)
+
+// Source implements FeatureSource.
+type Source struct{}
+
+// Name returns an identifier string for this feature source.
+func (s Source) Name() string { return "system" }
+
+// Discover returns feature names for system configuration: irqbalance, swap, ksm, memory compaction, iommu...
+func (s Source) Discover() (source.Features, error) {
+	features := source.Features{}
+	active, err := SystemctlStatusIsActive("irqbalance")
+
+	if err != nil {
+		log.Printf("ERROR: Failed to check irqbalance: %s", err)
+	} else {
+		features["systemd.irqbalance"] = active
+	}
+
+	return features, nil
+}

--- a/source/system/systemd.go
+++ b/source/system/systemd.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"os/exec"
+	"strings"
+)
+
+func runSystemctlCmd(args []string) (string, error) {
+	output, err := exec.Command("systemctl", args...).CombinedOutput()
+	return strings.TrimRight(string(output), "\n"), err
+}
+
+func SystemctlStatusIsActive(service string) (string, error) {
+	args := []string{"is-active"}
+	args = append(args, service)
+
+	output, err := runSystemctlCmd(args)
+	if err != nil {
+		return "", err
+	}
+
+	return output, nil
+}


### PR DESCRIPTION
When we deploy DPDK related pods, we should check some reuqired
system configuration information to get best performance for DPDK application.

Such as:
enable iommu, disable irqbalance, disable hyperthreading,
disable thp...

In this patch, I enabled detection for irqbalance.
For other information, I will enable them later.

Signed-off-by: Bin Lu <bin.lu@arm.com>