### PR TITLE
Simplify logging

### DIFF
--- a/source/kernel/kernel.go
+++ b/source/kernel/kernel.go
@@ -34,8 +34,6 @@ type NFDConfig struct {
 	ConfigOpts  []string `json:"configOpts,omitempty"`
 }
 
-var logger = log.New(os.Stderr, "", log.LstdFlags)
-
 var Config = NFDConfig{
 	KconfigFile: "",
 	ConfigOpts: []string{
@@ -57,7 +55,7 @@ func (s Source) Discover() (source.Features, error) {
 	// Read kernel version
 	version, err := parseVersion()
 	if err != nil {
-		logger.Printf("ERROR: Failed to get kernel version: %s", err)
+		log.Printf("ERROR: Failed to get kernel version: %s", err)
 	} else {
 		for key := range version {
 			features["version."+key] = version[key]
@@ -67,7 +65,7 @@ func (s Source) Discover() (source.Features, error) {
 	// Read kconfig
 	kconfig, err := parseKconfig()
 	if err != nil {
-		logger.Printf("ERROR: Failed to read kconfig: %s", err)
+		log.Printf("ERROR: Failed to read kconfig: %s", err)
 	}
 
 	// Check flags
@@ -79,7 +77,7 @@ func (s Source) Discover() (source.Features, error) {
 
 	selinux, err := SelinuxEnabled()
 	if err != nil {
-		logger.Print(err)
+		log.Print(err)
 	} else if selinux {
 		features["selinux.enabled"] = true
 	}
@@ -142,7 +140,7 @@ func parseKconfig() (map[string]bool, error) {
 	if len(Config.KconfigFile) > 0 {
 		raw, err = ioutil.ReadFile(Config.KconfigFile)
 		if err != nil {
-			logger.Printf("ERROR: Failed to read kernel config from %s: %s", Config.KconfigFile, err)
+			log.Printf("ERROR: Failed to read kernel config from %s: %s", Config.KconfigFile, err)
 		}
 	}
 
@@ -150,7 +148,7 @@ func parseKconfig() (map[string]bool, error) {
 	if raw == nil {
 		raw, err = readKconfigGzip("/proc/config.gz")
 		if err != nil {
-			logger.Printf("Failed to read /proc/config.gz: %s", err)
+			log.Printf("Failed to read /proc/config.gz: %s", err)
 		}
 	}
 

--- a/source/local/local.go
+++ b/source/local/local.go
@@ -33,7 +33,6 @@ import (
 var (
 	featureFilesDir = "/etc/kubernetes/node-feature-discovery/features.d/"
 	hookDir         = "/etc/kubernetes/node-feature-discovery/source.d/"
-	logger          = log.New(os.Stderr, "", log.LstdFlags)
 )
 
 // Implement FeatureSource interface
@@ -54,10 +53,10 @@ func (s Source) Discover() (source.Features, error) {
 
 	// Merge features from hooks and files
 	for k, v := range featuresFromHooks {
-			if old, ok := featuresFromFiles[k]; ok {
-				log.Printf("WARNING: overriding label '%s': value changed from '%s' to '%s'",
-					k, old, v)
-			}
+		if old, ok := featuresFromFiles[k]; ok {
+			log.Printf("WARNING: overriding label '%s': value changed from '%s' to '%s'",
+				k, old, v)
+		}
 		featuresFromFiles[k] = v
 	}
 

--- a/source/network/network.go
+++ b/source/network/network.go
@@ -19,8 +19,8 @@ package network
 import (
 	"bytes"
 	"fmt"
-	"github.com/golang/glog"
 	"io/ioutil"
+	"log"
 	"net"
 	"strconv"
 	"strings"
@@ -47,37 +47,37 @@ func (s Source) Discover() (source.Features, error) {
 			totalVfsPath := "/sys/class/net/" + netInterface.Name + "/device/sriov_totalvfs"
 			totalBytes, err := ioutil.ReadFile(totalVfsPath)
 			if err != nil {
-				glog.Errorf("SR-IOV not supported for network interface: %s: %v", netInterface.Name, err)
+				log.Printf("SR-IOV not supported for network interface: %s: %v", netInterface.Name, err)
 				continue
 			}
 			total := bytes.TrimSpace(totalBytes)
 			t, err := strconv.Atoi(string(total))
 			if err != nil {
-				glog.Errorf("Error in obtaining maximum supported number of virtual functions for network interface: %s: %v", netInterface.Name, err)
+				log.Printf("Error in obtaining maximum supported number of virtual functions for network interface: %s: %v", netInterface.Name, err)
 				continue
 			}
 			if t > 0 {
-				glog.Infof("SR-IOV capability is detected on the network interface: %s", netInterface.Name)
-				glog.Infof("%d maximum supported number of virtual functions on network interface: %s", t, netInterface.Name)
+				log.Printf("SR-IOV capability is detected on the network interface: %s", netInterface.Name)
+				log.Printf("%d maximum supported number of virtual functions on network interface: %s", t, netInterface.Name)
 				features["sriov.capable"] = true
 				numVfsPath := "/sys/class/net/" + netInterface.Name + "/device/sriov_numvfs"
 				numBytes, err := ioutil.ReadFile(numVfsPath)
 				if err != nil {
-					glog.Errorf("SR-IOV not configured for network interface: %s: %s", netInterface.Name, err)
+					log.Printf("SR-IOV not configured for network interface: %s: %s", netInterface.Name, err)
 					continue
 				}
 				num := bytes.TrimSpace(numBytes)
 				n, err := strconv.Atoi(string(num))
 				if err != nil {
-					glog.Errorf("Error in obtaining the configured number of virtual functions for network interface: %s: %v", netInterface.Name, err)
+					log.Printf("Error in obtaining the configured number of virtual functions for network interface: %s: %v", netInterface.Name, err)
 					continue
 				}
 				if n > 0 {
-					glog.Infof("%d virtual functions configured on network interface: %s", n, netInterface.Name)
+					log.Printf("%d virtual functions configured on network interface: %s", n, netInterface.Name)
 					features["sriov.configured"] = true
 					break
 				} else if n == 0 {
-					glog.Errorf("SR-IOV not configured on network interface: %s", netInterface.Name)
+					log.Printf("SR-IOV not configured on network interface: %s", netInterface.Name)
 				}
 			}
 		}

--- a/source/pci/pci.go
+++ b/source/pci/pci.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
 	"path"
 	"strings"
 
@@ -28,8 +27,6 @@ import (
 )
 
 type pciDeviceInfo map[string]string
-
-var logger = log.New(os.Stderr, "", log.LstdFlags)
 
 type NFDConfig struct {
 	DeviceClassWhitelist []string `json:"deviceClassWhitelist,omitempty"`


### PR DESCRIPTION
Simplify logging of feature sources. Drop glog which was used in some feature
sources as it was too complicated for the simple logging needs of
NFD.