### PR TITLE
travis: add deploy step to automatically push docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ services:
     - docker
 
 script:
-    - docker build -t quay.io/kubernetes_incubator/node-feature-discovery .
+    - make image

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,19 @@
 language: minimal
 
+env:
+    global:
+        # Sanitize git branch name into a valid docker tag name
+        - IMAGE_TAG_NAME=$(echo -n $TRAVIS_BRANCH | tr -c "[a-zA-Z0-9._'" "_")
+
 services:
     - docker
 
 script:
-    - make image
+    - make image -e
+
+deploy:
+    on:
+        branch: master
+        condition: -n "$IMAGE_REPO_USER"
+    provider: script
+    script: echo "$IMAGE_REPO_PASSWORD" | docker login -u "$IMAGE_REPO_USER" --password-stdin quay.io && make push -e

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 .FORCE:
 
 IMAGE_BUILD_CMD := docker build
+IMAGE_BUILD_EXTRA_OPTS :=
 IMAGE_PUSH_CMD := docker push
 
 VERSION := $(shell git describe --tags --dirty --always)
@@ -20,7 +21,8 @@ all: image
 
 image: yamls
 	$(IMAGE_BUILD_CMD) --build-arg NFD_VERSION=$(VERSION) \
-		-t $(IMAGE_TAG) ./
+		-t $(IMAGE_TAG) \
+		$(IMAGE_BUILD_EXTRA_OPTS) ./
 
 yamls: $(yaml_instances)
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 .FORCE:
 
 IMAGE_BUILD_CMD := docker build
+IMAGE_PUSH_CMD := docker push
 
 VERSION := $(shell git describe --tags --dirty --always)
 
@@ -39,3 +40,6 @@ mock:
 
 test:
 	go test ./cmd/... ./pkg/...
+
+push:
+	$(IMAGE_PUSH_CMD) $(IMAGE_TAG)

--- a/README.md
+++ b/README.md
@@ -611,15 +611,16 @@ attribute in the spec template(s) to the new location
 There are several Makefile variables that control the build process and the
 name of the resulting container image.
 
-| Variable        | Description                          | Default value
-| --------------  | ------------------------------------ | ------------------- |
-| IMAGE_BUILD_CMD | Command to build the image           | docker build
-| IMAGE_REGISTRY  | Container image registry to use      | quay.io/kubernetes_incubator
-| IMAGE_NAME      | Container image name                 | node-feature-discovery
-| IMAGE_TAG_NAME  | Container image tag name             | &lt;nfd version&gt;
-| IMAGE_REPO      | Container image repository to use    | &lt;IMAGE_REGISTRY&gt;/&lt;IMAGE_NAME&gt;
-| IMAGE_TAG       | Full image:tag to tag the image with | &lt;IMAGE_REPO&gt;/&lt;IMAGE_NAME&gt;
-| K8S_NAMESPACE   | nfd-master and nfd-worker namespace  | kube-system
+| Variable        | Description                                  | Default value
+| --------------  | -------------------------------------------- | ----------- |
+| IMAGE_BUILD_CMD | Command to build the image                   | docker build
+| IMAGE_PUSH_CMD  | Command to push the image to remote registry | docker push
+| IMAGE_REGISTRY  | Container image registry to use              | quay.io/kubernetes_incubator
+| IMAGE_NAME      | Container image name                         | node-feature-discovery
+| IMAGE_TAG_NAME  | Container image tag name                     | &lt;nfd version&gt;
+| IMAGE_REPO      | Container image repository to use            | &lt;IMAGE_REGISTRY&gt;/&lt;IMAGE_NAME&gt;
+| IMAGE_TAG       | Full image:tag to tag the image with         | &lt;IMAGE_REPO&gt;/&lt;IMAGE_NAME&gt;
+| K8S_NAMESPACE   | nfd-master and nfd-worker namespace          | kube-system
 
 For example, to use a custom registry:
 ```

--- a/README.md
+++ b/README.md
@@ -611,16 +611,17 @@ attribute in the spec template(s) to the new location
 There are several Makefile variables that control the build process and the
 name of the resulting container image.
 
-| Variable        | Description                                  | Default value
-| --------------  | -------------------------------------------- | ----------- |
-| IMAGE_BUILD_CMD | Command to build the image                   | docker build
-| IMAGE_PUSH_CMD  | Command to push the image to remote registry | docker push
-| IMAGE_REGISTRY  | Container image registry to use              | quay.io/kubernetes_incubator
-| IMAGE_NAME      | Container image name                         | node-feature-discovery
-| IMAGE_TAG_NAME  | Container image tag name                     | &lt;nfd version&gt;
-| IMAGE_REPO      | Container image repository to use            | &lt;IMAGE_REGISTRY&gt;/&lt;IMAGE_NAME&gt;
-| IMAGE_TAG       | Full image:tag to tag the image with         | &lt;IMAGE_REPO&gt;/&lt;IMAGE_NAME&gt;
-| K8S_NAMESPACE   | nfd-master and nfd-worker namespace          | kube-system
+| Variable               | Description                                  | Default value
+| ---------------------- | -------------------------------------------- | ----------- |
+| IMAGE_BUILD_CMD        | Command to build the image                   | docker build
+| IMAGE_BUILD_EXTRA_OPTS | Extra options to pass to build command       | *empty*
+| IMAGE_PUSH_CMD         | Command to push the image to remote registry | docker push
+| IMAGE_REGISTRY         | Container image registry to use              | quay.io/kubernetes_incubator
+| IMAGE_NAME             | Container image name                         | node-feature-discovery
+| IMAGE_TAG_NAME         | Container image tag name                     | &lt;nfd version&gt;
+| IMAGE_REPO             | Container image repository to use            | &lt;IMAGE_REGISTRY&gt;/&lt;IMAGE_NAME&gt;
+| IMAGE_TAG              | Full image:tag to tag the image with         | &lt;IMAGE_REPO&gt;/&lt;IMAGE_NAME&gt;
+| K8S_NAMESPACE          | nfd-master and nfd-worker namespace          | kube-system
 
 For example, to use a custom registry:
 ```


### PR DESCRIPTION
Configure .travis.yml to automatically push builds on the master branch
to the container image registry (quay.io by default). This will automatically
make the latest "experimental" version of NFD, built from the tip of the
master branch, available in the upstream container image repository.

IMAGE_REPO_USER and IMAGE_REPO_PASSWORD environment variables must be defined in
the travis repositorys settings in order for the deployment step to be
triggered.