### PR TITLE
Use pod anti-affinity in the worker Job template spec

### DIFF
--- a/label-nodes.sh
+++ b/label-nodes.sh
@@ -26,8 +26,6 @@ fi
 NumNodes=$(kubectl get nodes | grep -i ' ready ' | wc -l)
 
 # We set the .spec.completions and .spec.parallelism to the node count
-# We request a specific hostPort in the job spec to limit the number of pods
-# that run on a node to one. As a result, one pod runs on each node in parallel
 # We set the NODE_NAME environment variable to get the Kubernetes node object.
 sed -e "s/completions:.*$/completions: $NumNodes/" \
     -e "s/parallelism:.*$/parallelism: $NumNodes/" \

--- a/nfd-worker-job.yaml.template
+++ b/nfd-worker-job.yaml.template
@@ -15,6 +15,16 @@ spec:
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - node-feature-discovery
       containers:
         - env:
           - name: NODE_NAME
@@ -28,9 +38,6 @@ spec:
           args:
             - "--oneshot"
             - "--server=nfd-master:8080"
-          ports:
-            - containerPort: 7156
-              hostPort: 7156
           volumeMounts:
             - name: host-boot
               mountPath: "/host-boot"


### PR DESCRIPTION
Use pod anti-affinity to explicitly indicate that pods should be
scheduled on separate nodes. And, remove the obscure and non-obvious
ports definition whose only purpose was to reach the same effect.