### PR TITLE
network: rename sriov labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,20 @@ The current set of feature sources are the following:
 
 The published node labels encode a few pieces of information:
 
-- A "namespace" (e.g. `node.alpha.kubernetes-incubator.io/nfd`).
+- A "namespace" (e.g. `node.alpha.kubernetes-incubator.io`).
 - The version of this discovery code that wrote the label, according to
   `git describe --tags --dirty --always`.
 - The source for each label (e.g. `cpuid`).
 - The name of the discovered feature as it appears in the underlying
   source, (e.g. `AESNI` from cpuid).
+
+Feature label names adhere to the following pattern:
+```
+<namespace>/nfd-<source name>-<feature name>[.<attribute name>]
+```
+The last component (i.e. `attribute-name`) is optional, and only used if a
+feature logically has sub-hierarchy, e.g. `sriov.capable` and
+`sriov.configure` from the `network` source.
 
 _Note: only features that are available on a given node are labeled, so
 the only label value published for features is the string `"true"`._
@@ -155,9 +163,10 @@ such as restricting discovered features with the --label-whitelist option._
 
 ### Network Features
 
-| Feature name   | Description                                                                         |
-| :------------: | :---------------------------------------------------------------------------------: |
-| [SRIOV][sriov] | Single Root Input/Output Virtualization (SR-IOV) enabled Network Interface Card
+| Feature | Attribute  | Description                                           |
+| ------- | ---------- | ----------------------------------------------------- |
+| sriov   | capable    | [Single Root Input/Output Virtualization][sriov] (SR-IOV) enabled Network Interface Card(s) present
+| <br>    | configured | SR-IOV virtual functions have been configured
 
 ### RDT (Intel Resource Director Technology) Features
 

--- a/source/network/network.go
+++ b/source/network/network.go
@@ -57,7 +57,7 @@ func (s Source) Discover() ([]string, error) {
 			if t > 0 {
 				glog.Infof("SR-IOV capability is detected on the network interface: %s", netInterface.Name)
 				glog.Infof("%d maximum supported number of virtual functions on network interface: %s", t, netInterface.Name)
-				features = append(features, "sriov")
+				features = append(features, "sriov.capable")
 				numVfsPath := "/sys/class/net/" + netInterface.Name + "/device/sriov_numvfs"
 				numBytes, err := ioutil.ReadFile(numVfsPath)
 				if err != nil {
@@ -72,7 +72,7 @@ func (s Source) Discover() ([]string, error) {
 				}
 				if n > 0 {
 					glog.Infof("%d virtual functions configured on network interface: %s", n, netInterface.Name)
-					features = append(features, "sriov-configured")
+					features = append(features, "sriov.configured")
 					break
 				} else if n == 0 {
 					glog.Errorf("SR-IOV not configured on network interface: %s", netInterface.Name)


### PR DESCRIPTION
Introduce a new scheme where features may have logical sub-components.
Rename sriov labels from the network source according to the new
pattern:
  sriov            -> sriov.capable
  sriov-configured -> sriov.configured

Also, document this new labeling scheme in the README.

Signed-off-by: Markus Lehtonen <markus.lehtonen@intel.com>