### PR TITLE
e2e test integration in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,28 @@
-language: minimal
+language: go
+go:
+  - "1.12"
 
 env:
   global:
     # Sanitize git branch name into a valid docker tag name
     - IMAGE_TAG_NAME=$(echo -n $TRAVIS_BRANCH | tr -c "[a-zA-Z0-9._'" "_")
+    - GO111MODULE=on
 
 services:
   - docker
 
 script:
   - make image -e
+  - if [ "$TRAVIS_BRANCH" == master -a -n "$IMAGE_REPO_USER" ]; then
+      set -e;
+      echo "$IMAGE_REPO_PASSWORD" | docker login -u "$IMAGE_REPO_USER" --password-stdin quay.io;
+      make push -e;
+      curl -o $HOME/bin/aws-iam-authenticator --create-dirs https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator;
+      chmod a+x $HOME/bin/aws-iam-authenticator;
+      export PATH=$PATH:$HOME/bin;
+      echo "$KUBECONFIG_AWS" > kubeconfig_aws;
+      make e2e-test -e KUBECONFIG=`pwd`/kubeconfig_aws;
+    fi
 
 deploy:
   - on:


### PR DESCRIPTION
Integrate end-to-end tests (#181) to Travis.

First, it reworks Makefile, adding targets for pushing images to remote registry and running e2e tests in a (remote) test cluster. Then it adds travis integration (in .travis.yml) for running e2e tests in AWS EKS.

Basically, the following environment variables need to be configured in travis in order to make it work:
* `AWS_ACCESS_KEY_ID`
* `AWS_SECRET_ACCESS_KEY`
* `AWS_REGION`
* `KUBECONFIG_AWS`
* `IMAGE_REPO`
* `IMAGE_REPO_PASSWORD`
* `IMAGE_REPO_USER`