### PR TITLE
Change feature label namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The current set of feature sources are the following:
 
 The published node labels encode a few pieces of information:
 
-- A "namespace" (e.g. `node.alpha.kubernetes-incubator.io`).
+- Namespace, i.e. `feature.node.kubernetes.io`
 - The version of this discovery code that wrote the label, according to
   `git describe --tags --dirty --always`.
 - The source for each label (e.g. `cpuid`).
@@ -112,17 +112,17 @@ the only label value published for features is the string `"true"`._
 
 ```json
 {
-  "node.alpha.kubernetes-incubator.io/node-feature-discovery.version": "v0.3.0",
-  "node.alpha.kubernetes-incubator.io/nfd-cpuid-<feature-name>": "true",
-  "node.alpha.kubernetes-incubator.io/nfd-iommu-<feature-name>": "true",
-  "node.alpha.kubernetes-incubator.io/nfd-kernel-version.<version component>": "<version number>",
-  "node.alpha.kubernetes-incubator.io/nfd-memory-<feature-name>": "true",
-  "node.alpha.kubernetes-incubator.io/nfd-network-<feature-name>": "true",
-  "node.alpha.kubernetes-incubator.io/nfd-pci-<device label>.present": "true",
-  "node.alpha.kubernetes-incubator.io/nfd-pstate-<feature-name>": "true",
-  "node.alpha.kubernetes-incubator.io/nfd-rdt-<feature-name>": "true",
-  "node.alpha.kubernetes-incubator.io/nfd-selinux-<feature-name>": "true",
-  "node.alpha.kubernetes-incubator.io/nfd-storage-<feature-name>": "true"
+  "feature.node.kubernetes.io/node-feature-discovery.version": "v0.3.0",
+  "feature.node.kubernetes.io/nfd-cpuid-<feature-name>": "true",
+  "feature.node.kubernetes.io/nfd-iommu-<feature-name>": "true",
+  "feature.node.kubernetes.io/nfd-kernel-version.<version component>": "<version number>",
+  "feature.node.kubernetes.io/nfd-memory-<feature-name>": "true",
+  "feature.node.kubernetes.io/nfd-network-<feature-name>": "true",
+  "feature.node.kubernetes.io/nfd-pci-<device label>.present": "true",
+  "feature.node.kubernetes.io/nfd-pstate-<feature-name>": "true",
+  "feature.node.kubernetes.io/nfd-rdt-<feature-name>": "true",
+  "feature.node.kubernetes.io/nfd-selinux-<feature-name>": "true",
+  "feature.node.kubernetes.io/nfd-storage-<feature-name>": "true"
 }
 ```
 
@@ -201,7 +201,7 @@ The set of fields used in `<device label>` is configurable, valid fields being
 Defaults fields are `class` and `vendor`. An example label using the default
 label fields:
 ```
-node.alpha.kubernetes-incubator.io/nfd-pci-1200_8086.present=true
+feature.node.kubernetes.io/nfd-pci-1200_8086.present=true
 ```
 
 Also  the set of PCI device classes that the feature source detects is
@@ -377,7 +377,7 @@ spec:
     - image: golang
       name: go1
   nodeSelector:
-    node.alpha.kubernetes-incubator.io/nfd-pstate-turbo: 'true'
+    feature.node.kubernetes.io/nfd-pstate-turbo: 'true'
 ```
 
 For more details on targeting nodes, see [node selection][node-sel].

--- a/demo/helper-scripts/demo-pod-with-discovery.yaml.cloverleaf.template
+++ b/demo/helper-scripts/demo-pod-with-discovery.yaml.cloverleaf.template
@@ -11,7 +11,7 @@ metadata:
                             {
                                 "matchExpressions": [
                                     {
-                                        "key": "node.alpha.kubernetes-incubator.io/nfd-pstate-turbo",
+                                        "key": "feature.node.kubernetes.io/nfd-pstate-turbo",
                                         "operator": "DoesNotExist"
                                     }
                                 ]

--- a/demo/helper-scripts/demo-pod-with-discovery.yaml.parsec.template
+++ b/demo/helper-scripts/demo-pod-with-discovery.yaml.parsec.template
@@ -10,5 +10,5 @@ spec:
         - containerPort: 3351
           hostPort: 10001
   nodeSelector:
-    node.alpha.kubernetes-incubator.io/nfd-pstate-turbo: 'true'
+    feature.node.kubernetes.io/nfd-pstate-turbo: 'true'
   restartPolicy: Never

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ const (
 	ProgramName = "node-feature-discovery"
 
 	// Namespace is the prefix for all published labels.
-	Namespace = "node.alpha.kubernetes-incubator.io"
+	Namespace = "feature.node.kubernetes.io"
 
 	// NodeNameEnv is the environment variable that contains this node's name.
 	NodeNameEnv = "NODE_NAME"

--- a/main.go
+++ b/main.go
@@ -365,6 +365,10 @@ func advertiseFeatureLabels(helper APIHelpers, labels Labels, annotations Annota
 
 	// Remove labels with our prefix
 	helper.RemoveLabels(node, labelPrefix)
+	// Also, remove all labels with the old prefix, and the old version label
+	helper.RemoveLabels(node, "node.alpha.kubernetes-incubator.io/nfd")
+	helper.RemoveLabels(node, "node.alpha.kubernetes-incubator.io/node-feature-discovery")
+
 	// Add labels to the node object.
 	helper.AddLabels(node, labels)
 

--- a/main.go
+++ b/main.go
@@ -46,8 +46,7 @@ const (
 )
 
 var (
-	version     = "" // Must not be const, set using ldflags at build time
-	labelPrefix = labelNs + "nfd-"
+	version = "" // Must not be const, set using ldflags at build time
 )
 
 // package loggers
@@ -443,13 +442,13 @@ func (h k8sHelpers) RemoveLabelsWithPrefix(n *api.Node, search string) {
 // RemoveLabels removes given NFD labels
 func (h k8sHelpers) RemoveLabels(n *api.Node, labelNames []string) {
 	for _, l := range labelNames {
-		delete(n.Labels, labelPrefix+l)
+		delete(n.Labels, labelNs+l)
 	}
 }
 
 func (h k8sHelpers) AddLabels(n *api.Node, labels Labels) {
 	for k, v := range labels {
-		n.Labels[labelPrefix+k] = v
+		n.Labels[labelNs+k] = v
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ const (
 
 var (
 	version     = "" // Must not be const, set using ldflags at build time
-	labelPrefix = labelNs + "nfd"
+	labelPrefix = labelNs + "nfd-"
 )
 
 // package loggers
@@ -83,7 +83,7 @@ type APIHelpers interface {
 	// subsequently be updated via the API server using the client library.
 	RemoveLabels(*api.Node, string)
 
-	// AddLabels modifies the supplied node's labels collection.
+	// AddLabels adds new NFD labels to the node object.
 	// In order to publish the labels, the node must be subsequently updated via the
 	// API server using the client library.
 	AddLabels(*api.Node, Labels)
@@ -342,7 +342,7 @@ func getFeatureLabels(source source.FeatureSource) (labels Labels, err error) {
 		return nil, err
 	}
 	for k := range features {
-		labels[fmt.Sprintf("%s-%s-%s", labelPrefix, source.Name(), k)] = fmt.Sprintf("%v", features[k])
+		labels[fmt.Sprintf("%s-%s", source.Name(), k)] = fmt.Sprintf("%v", features[k])
 	}
 	return labels, nil
 }
@@ -428,7 +428,7 @@ func (h k8sHelpers) RemoveLabels(n *api.Node, search string) {
 
 func (h k8sHelpers) AddLabels(n *api.Node, labels Labels) {
 	for k, v := range labels {
-		n.Labels[k] = v
+		n.Labels[labelPrefix+k] = v
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -28,7 +28,7 @@ func TestDiscoveryWithMockSources(t *testing.T) {
 		fakeAnnotations := Annotations{"version": version}
 		for _, f := range fakeFeatureNames {
 			fakeFeatures[f] = true
-			fakeFeatureLabels[fmt.Sprintf("%s-testSource-%s", labelPrefix, f)] = "true"
+			fakeFeatureLabels[fmt.Sprintf("testSource-%s", f)] = "true"
 		}
 		fakeFeatureSource := source.FeatureSource(mockFeatureSource)
 
@@ -289,9 +289,9 @@ func TestCreateFeatureLabels(t *testing.T) {
 
 			Convey("Proper fake labels are returned", func() {
 				So(len(labels), ShouldEqual, 3)
-				So(labels, ShouldContainKey, labelPrefix+"-fake-fakefeature1")
-				So(labels, ShouldContainKey, labelPrefix+"-fake-fakefeature2")
-				So(labels, ShouldContainKey, labelPrefix+"-fake-fakefeature3")
+				So(labels, ShouldContainKey, "fake-fakefeature1")
+				So(labels, ShouldContainKey, "fake-fakefeature2")
+				So(labels, ShouldContainKey, "fake-fakefeature3")
 			})
 		})
 		Convey("When fake feature source is configured with a whitelist that doesn't match", func() {
@@ -303,9 +303,9 @@ func TestCreateFeatureLabels(t *testing.T) {
 
 			Convey("fake labels are not returned", func() {
 				So(len(labels), ShouldEqual, 0)
-				So(labels, ShouldNotContainKey, labelPrefix+"-fake-fakefeature1")
-				So(labels, ShouldNotContainKey, labelPrefix+"-fake-fakefeature2")
-				So(labels, ShouldNotContainKey, labelPrefix+"-fake-fakefeature3")
+				So(labels, ShouldNotContainKey, "fake-fakefeature1")
+				So(labels, ShouldNotContainKey, "fake-fakefeature2")
+				So(labels, ShouldNotContainKey, "fake-fakefeature3")
 			})
 		})
 	})
@@ -330,10 +330,10 @@ func TestAddLabels(t *testing.T) {
 		})
 
 		Convey("They should be added to the node.Labels", func() {
-			test1 := labelPrefix + ".test1"
+			test1 := "test1"
 			labels[test1] = "true"
 			helper.AddLabels(n, labels)
-			So(n.Labels, ShouldContainKey, test1)
+			So(n.Labels, ShouldContainKey, labelPrefix+test1)
 		})
 	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -73,7 +73,7 @@ func TestDiscoveryWithMockSources(t *testing.T) {
 			mockAPIHelper.On("GetClient").Return(mockClient, nil)
 			mockAPIHelper.On("GetNode", mockClient).Return(mockNode, nil).Once()
 			mockAPIHelper.On("AddLabels", mockNode, fakeFeatureLabels).Return().Once()
-			mockAPIHelper.On("RemoveLabelsWithPrefix", mockNode, labelPrefix).Return().Once()
+			mockAPIHelper.On("RemoveLabelsWithPrefix", mockNode, labelNs).Return().Once()
 			mockAPIHelper.On("RemoveLabelsWithPrefix", mockNode, "node.alpha.kubernetes-incubator.io/nfd").Return().Once()
 			mockAPIHelper.On("RemoveLabelsWithPrefix", mockNode, "node.alpha.kubernetes-incubator.io/node-feature-discovery").Return().Once()
 			mockAPIHelper.On("AddAnnotations", mockNode, fakeAnnotations).Return().Once()
@@ -122,7 +122,7 @@ func TestDiscoveryWithMockSources(t *testing.T) {
 			expectedError := errors.New("fake error")
 			mockAPIHelper.On("GetClient").Return(mockClient, nil)
 			mockAPIHelper.On("GetNode", mockClient).Return(mockNode, nil).Once()
-			mockAPIHelper.On("RemoveLabelsWithPrefix", mockNode, labelPrefix).Return().Once()
+			mockAPIHelper.On("RemoveLabelsWithPrefix", mockNode, labelNs).Return().Once()
 			mockAPIHelper.On("RemoveLabelsWithPrefix", mockNode, "node.alpha.kubernetes-incubator.io/nfd").Return().Once()
 			mockAPIHelper.On("RemoveLabelsWithPrefix", mockNode, "node.alpha.kubernetes-incubator.io/node-feature-discovery").Return().Once()
 			mockAPIHelper.On("AddLabels", mockNode, fakeFeatureLabels).Return().Once()
@@ -339,7 +339,7 @@ func TestAddLabels(t *testing.T) {
 			test1 := "test1"
 			labels[test1] = "true"
 			helper.AddLabels(n, labels)
-			So(n.Labels, ShouldContainKey, labelPrefix+test1)
+			So(n.Labels, ShouldContainKey, labelNs+test1)
 		})
 	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -68,6 +68,8 @@ func TestDiscoveryWithMockSources(t *testing.T) {
 			mockAPIHelper.On("GetNode", mockClient).Return(mockNode, nil).Once()
 			mockAPIHelper.On("AddLabels", mockNode, fakeFeatureLabels).Return().Once()
 			mockAPIHelper.On("RemoveLabels", mockNode, labelPrefix).Return().Once()
+			mockAPIHelper.On("RemoveLabels", mockNode, "node.alpha.kubernetes-incubator.io/nfd").Return().Once()
+			mockAPIHelper.On("RemoveLabels", mockNode, "node.alpha.kubernetes-incubator.io/node-feature-discovery").Return().Once()
 			mockAPIHelper.On("AddAnnotations", mockNode, fakeAnnotations).Return().Once()
 			mockAPIHelper.On("UpdateNode", mockClient, mockNode).Return(nil).Once()
 			noPublish := false
@@ -115,6 +117,8 @@ func TestDiscoveryWithMockSources(t *testing.T) {
 			mockAPIHelper.On("GetClient").Return(mockClient, nil)
 			mockAPIHelper.On("GetNode", mockClient).Return(mockNode, nil).Once()
 			mockAPIHelper.On("RemoveLabels", mockNode, labelPrefix).Return().Once()
+			mockAPIHelper.On("RemoveLabels", mockNode, "node.alpha.kubernetes-incubator.io/nfd").Return().Once()
+			mockAPIHelper.On("RemoveLabels", mockNode, "node.alpha.kubernetes-incubator.io/node-feature-discovery").Return().Once()
 			mockAPIHelper.On("AddLabels", mockNode, fakeFeatureLabels).Return().Once()
 			mockAPIHelper.On("AddAnnotations", mockNode, fakeAnnotations).Return().Once()
 			mockAPIHelper.On("UpdateNode", mockClient, mockNode).Return(expectedError).Once()

--- a/mockapihelpers.go
+++ b/mockapihelpers.go
@@ -58,9 +58,15 @@ func (_m *MockAPIHelpers) GetNode(_a0 *k8sclient.Clientset) (*api.Node, error) {
 	return r0, r1
 }
 
-// RemoveLabels provides a mock function with *api.Node and main.Labels as the input arguments and
+// RemoveLabelsWithPrefix provides a mock function with *api.Node and main.Labels as the input arguments and
 // no return value
-func (_m *MockAPIHelpers) RemoveLabels(_a0 *api.Node, _a1 string) {
+func (_m *MockAPIHelpers) RemoveLabelsWithPrefix(_a0 *api.Node, _a1 string) {
+	_m.Called(_a0, _a1)
+}
+
+// RemoveLabels provides a mock function with *api.Node and []strings as the input arguments and
+// no return value
+func (_m *MockAPIHelpers) RemoveLabels(_a0 *api.Node, _a1 []string) {
 	_m.Called(_a0, _a1)
 }
 

--- a/mockapihelpers.go
+++ b/mockapihelpers.go
@@ -70,6 +70,12 @@ func (_m *MockAPIHelpers) AddLabels(_a0 *api.Node, _a1 Labels) {
 	_m.Called(_a0, _a1)
 }
 
+// AddAnnotations provides a mock function with *api.Node and main.Annotations as the input arguments and
+// no return value
+func (_m *MockAPIHelpers) AddAnnotations(_a0 *api.Node, _a1 Annotations) {
+	_m.Called(_a0, _a1)
+}
+
 // UpdateNode provides a mock function with *k8sclient.Clientset and *api.Node as the input arguments and
 // error as the return value
 func (_m *MockAPIHelpers) UpdateNode(_a0 *k8sclient.Clientset, _a1 *api.Node) error {


### PR DESCRIPTION
This PR incorporates multiple changes to how NFD manages and advertises node features:
* label namespace is changed to `feature.node.kubernetes.io`
* `nfd` prefix is dropped from the feature label names
* NFD version label (`node.alpha.kubernetes-incubator.io/node-feature-discovery.version`) is dropped and replaced with an annotation
* NFD-specific annotations are added (namespace `nfd.node.kubernetes.io`):
  * `nfd.node.kubernetes.io/version` for advertising NFD version
  * `nfd.node.kubernetes.io/feature-labels` for advertising for keeping track of feature labels managed by NFD

After this change the naming scheme for all feature labels is:
```
feature.node.kubernetes.io/<source name>-<feature name>
```
