### PR TITLE
Makefile: drop docker build-args for https(s) proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,4 @@ all: image
 # QUAY_REGISTRY_USER=<my-username> make docker -e.
 image:
 	$(IMAGE_BUILD_CMD) --build-arg NFD_VERSION=$(VERSION) \
-		--build-arg http_proxy=$(http_proxy) \
-		--build-arg HTTP_PROXY=$(HTTP_PROXY) \
-		--build-arg https_proxy=$(https_proxy) \
-		--build-arg HTTPS_PROXY=$(HTTPS_PROXY) \
-		--build-arg no_proxy=$(no_proxy) \
-		--build-arg NO_PROXY=$(NO_PROXY) \
 		-t $(QUAY_DOMAIN_NAME)/$(QUAY_REGISTRY_USER)/$(DOCKER_IMAGE_NAME):$(VERSION) ./


### PR DESCRIPTION
Docker v17.07 and later supports configuring proxy servers via the
docker client configuration (https://docs.docker.com/network/proxy/).

This is better than using --build-args for passing the proxy settings to
the build environment. Previously, we could end up with empty variables
values which could cause the build to fail. E.g. if you had
http_proxy=<myproxy> defined but HTTP_PROXY unset in the host
environment, you ended up with http_proxy=<myproxy> and HTTP_PROXY=""
(i.e. empty value) inside the build which caused problems in some cases.
In addition, this makes builds via make and directly with docker more
similar.