### PR TITLE
Refer to kubernetes-sigs in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Node feature discovery for [Kubernetes](https://kubernetes.io)
 
-[![Build Status](https://api.travis-ci.org/kubernetes-incubator/node-feature-discovery.svg?branch=master)](https://travis-ci.com/kubernetes-incubator/node-feature-discovery)
-[![Go Report Card](https://goreportcard.com/badge/github.com/kubernetes-incubator/node-feature-discovery)](https://goreportcard.com/report/github.com/kubernetes-incubator/node-feature-discovery)
+[![Build Status](https://api.travis-ci.org/kubernetes-sigs/node-feature-discovery.svg?branch=master)](https://travis-ci.com/kubernetes-sigs/node-feature-discovery)
+[![Go Report Card](https://goreportcard.com/badge/github.com/kubernetes-sigs/node-feature-discovery)](https://goreportcard.com/report/github.com/kubernetes-sigs/node-feature-discovery)
 
 - [Overview](#overview)
 - [Command line interface](#command-line-interface)
@@ -17,15 +17,13 @@
 - [License](#license)
 - [Demo](#demo)
 
-_**NOTE:** We are gathering evidence in order to graduate from the Kubernetes incubator. If you are a user of the project, please add yourself to [this list](https://github.com/kubernetes-incubator/node-feature-discovery/wiki/Users) with as much detail as you are comfortable providing (name and email optional)._
-
 ## Overview
 
 This software enables node feature discovery for Kubernetes. It detects
 hardware features available on each node in a Kubernetes cluster, and advertises
 those features using node labels.
 
-This project uses GitHub [milestones](https://github.com/kubernetes-incubator/node-feature-discovery/milestones) for release planning.
+This project uses GitHub [milestones](https://github.com/kubernetes-sigs/node-feature-discovery/milestones) for release planning.
 
 ## Command line interface
 
@@ -68,7 +66,7 @@ node-feature-discovery.
 host mounted inside the NFD container. Thus, you need to provide Docker with the
 correct `--volume` options in order for them to work correctly when run
 stand-alone directly with `docker run`. See the
-[template spec](https://github.com/kubernetes-incubator/node-feature-discovery/blob/master/node-feature-discovery-daemonset.yaml.template)
+[template spec](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/node-feature-discovery-daemonset.yaml.template)
 for up-to-date information about the required volume mounts.
 
 ## Feature discovery
@@ -258,7 +256,7 @@ to the node to advertise hardware features.
 If you have RBAC authorization enabled (as is the default e.g. with clusters initialized with kubeadm) you need to configure the appropriate ClusterRoles, ClusterRoleBindings and a ServiceAccount in order for NFD to create node labels. The provided templates will configure these for you.
 
 When run as a daemonset, nodes are re-labeled at an interval specified using
-the `--sleep-interval` option. In the [template](https://github.com/kubernetes-incubator/node-feature-discovery/blob/master/node-feature-discovery-daemonset.yaml.template#L26) the default interval is set to 60s
+the `--sleep-interval` option. In the [template](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/node-feature-discovery-daemonset.yaml.template#L26) the default interval is set to 60s
 which is also the default when no `--sleep-interval` is specified.
 
 Feature discovery can alternatively be configured as a one-shot job. There is
@@ -307,7 +305,7 @@ You could also use other types of volumes, of course. That is, hostPath if
 different config for different nodes would be required, for example.
 
 The (empty-by-default)
-[example config](https://github.com/kubernetes-incubator/node-feature-discovery/blob/master/node-feature-discovery.conf.example)
+[example config](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/node-feature-discovery.conf.example)
 is used as a config in the NFD Docker image. Thus, this can be used as a default
 configuration in custom-built images.
 
@@ -328,7 +326,7 @@ Currently, the only available configuration options are related to the
 Download the source code.
 
 ```
-git clone https://github.com/kubernetes-incubator/node-feature-discovery
+git clone https://github.com/kubernetes-sigs/node-feature-discovery
 ```
 
 **Build the container image:**
@@ -392,13 +390,14 @@ Github issues
 
 [Design proposal](https://docs.google.com/document/d/1uulT2AjqXjc_pLtDu0Kw9WyvvXm-WAZZaSiUziKsr68/edit)
 
-## Kubernetes Incubator
+## Governance
 
-This is a [Kubernetes Incubator project](https://github.com/kubernetes/community/blob/master/incubator.md). The project was established 2016-08-29. The incubator team for the project is:
-
-- Sponsor: Dawn Chen (@dchen1107)
-- Champion: David Oppenheimer (@davidopp)
-- SIG: sig-node
+This is a [SIG-node](https://github.com/kubernetes/community/blob/master/sig-node/README.md)
+subproject, hosted under the
+[Kubernetes SIGs](https://github.com/kubernetes-sigs) organization in
+Github. The project was established in 2016 as a
+[Kubernetes Incubator](https://github.com/kubernetes/community/blob/master/incubator.md)
+project and migrated to Kubernetes SIGs in 2018.
 
 ## License
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,10 +9,10 @@ is as follows:
 - [ ] All [OWNERS](OWNERS) must LGTM the release proposal.
 - [ ] Update the [job template](node-feature-discovery-job.json.template) to use the new tagged container image
 - [ ] An OWNER runs `git tag -s $VERSION` and insert the changelog into the tag description.
-- [ ] [Build and push](https://github.com/kubernetes-incubator/node-feature-discovery#building-from-source) a container image with the same tag to [quay.io](https://quay.io/kubernetes_incubator).
+- [ ] [Build and push](https://github.com/kubernetes-sigs/node-feature-discovery#building-from-source) a container image with the same tag to [quay.io](https://quay.io/kubernetes_incubator).
 - [ ] Update the `:latest` virtual tag in quay.io to track the last stable (this) release.
 - [ ] An OWNER pushes the tag with `git push $VERSION`.
-- [ ] Write the change log into the [Github release info](https://github.com/kubernetes-incubator/node-feature-discovery/releases).
+- [ ] Write the change log into the [Github release info](https://github.com/kubernetes-sigs/node-feature-discovery/releases).
 - [ ] Add a link to the tagged release in this issue.
 - [ ] An announcement email is sent to `kubernetes-dev@googlegroups.com` with the
    subject `[ANNOUNCE] node-feature-discovery $VERSION is released`


### PR DESCRIPTION
Change links in README.md and RELEASE.md to point to the new repo
location under kubernetes-sigs. Also, remove some outdated references to
kubernetes incubator project.