### PR TITLE
Fixes to label naming change

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The published node labels encode a few pieces of information:
 
 Feature label names adhere to the following pattern:
 ```
-<namespace>/nfd-<source name>-<feature name>[.<attribute name>]
+<namespace>/<source name>-<feature name>[.<attribute name>]
 ```
 The last component (i.e. `attribute-name`) is optional, and only used if a
 feature logically has sub-hierarchy, e.g. `sriov.capable` and
@@ -114,17 +114,17 @@ the only label value published for features is the string `"true"`._
 ```json
 {
   "feature.node.kubernetes.io/node-feature-discovery.version": "v0.3.0",
-  "feature.node.kubernetes.io/nfd-cpuid-<feature-name>": "true",
-  "feature.node.kubernetes.io/nfd-iommu-<feature-name>": "true",
+  "feature.node.kubernetes.io/cpuid-<feature-name>": "true",
+  "feature.node.kubernetes.io/iommu-<feature-name>": "true",
   "feature.node.kubernetes.io/kernel-config.<option-name>": "true",
-  "feature.node.kubernetes.io/nfd-kernel-version.<version component>": "<version number>",
-  "feature.node.kubernetes.io/nfd-memory-<feature-name>": "true",
-  "feature.node.kubernetes.io/nfd-network-<feature-name>": "true",
-  "feature.node.kubernetes.io/nfd-pci-<device label>.present": "true",
-  "feature.node.kubernetes.io/nfd-pstate-<feature-name>": "true",
-  "feature.node.kubernetes.io/nfd-rdt-<feature-name>": "true",
-  "feature.node.kubernetes.io/nfd-selinux-<feature-name>": "true",
-  "feature.node.kubernetes.io/nfd-storage-<feature-name>": "true",
+  "feature.node.kubernetes.io/kernel-version.<version component>": "<version number>",
+  "feature.node.kubernetes.io/memory-<feature-name>": "true",
+  "feature.node.kubernetes.io/network-<feature-name>": "true",
+  "feature.node.kubernetes.io/pci-<device label>.present": "true",
+  "feature.node.kubernetes.io/pstate-<feature-name>": "true",
+  "feature.node.kubernetes.io/rdt-<feature-name>": "true",
+  "feature.node.kubernetes.io/selinux-<feature-name>": "true",
+  "feature.node.kubernetes.io/storage-<feature-name>": "true",
   "feature.node.kubernetes.io/<hook name>-<feature name>": "<feature value>"
 }
 ```
@@ -262,7 +262,7 @@ The set of fields used in `<device label>` is configurable, valid fields being
 Defaults fields are `class` and `vendor`. An example label using the default
 label fields:
 ```
-feature.node.kubernetes.io/nfd-pci-1200_8086.present=true
+feature.node.kubernetes.io/pci-1200_8086.present=true
 ```
 
 Also  the set of PCI device classes that the feature source detects is
@@ -438,7 +438,7 @@ spec:
     - image: golang
       name: go1
   nodeSelector:
-    feature.node.kubernetes.io/nfd-pstate-turbo: 'true'
+    feature.node.kubernetes.io/pstate-turbo: 'true'
 ```
 
 For more details on targeting nodes, see [node selection][node-sel].

--- a/README.md
+++ b/README.md
@@ -93,8 +93,6 @@ The current set of feature sources are the following:
 The published node labels encode a few pieces of information:
 
 - Namespace, i.e. `feature.node.kubernetes.io`
-- The version of this discovery code that wrote the label, according to
-  `git describe --tags --dirty --always`.
 - The source for each label (e.g. `cpuid`).
 - The name of the discovered feature as it appears in the underlying
   source, (e.g. `AESNI` from cpuid).
@@ -113,7 +111,6 @@ the only label value published for features is the string `"true"`._
 
 ```json
 {
-  "feature.node.kubernetes.io/node-feature-discovery.version": "v0.3.0",
   "feature.node.kubernetes.io/cpuid-<feature-name>": "true",
   "feature.node.kubernetes.io/iommu-<feature-name>": "true",
   "feature.node.kubernetes.io/kernel-config.<option-name>": "true",

--- a/demo/helper-scripts/demo-pod-with-discovery.yaml.cloverleaf.template
+++ b/demo/helper-scripts/demo-pod-with-discovery.yaml.cloverleaf.template
@@ -11,7 +11,7 @@ metadata:
                             {
                                 "matchExpressions": [
                                     {
-                                        "key": "feature.node.kubernetes.io/nfd-pstate-turbo",
+                                        "key": "feature.node.kubernetes.io/pstate-turbo",
                                         "operator": "DoesNotExist"
                                     }
                                 ]

--- a/demo/helper-scripts/demo-pod-with-discovery.yaml.parsec.template
+++ b/demo/helper-scripts/demo-pod-with-discovery.yaml.parsec.template
@@ -10,5 +10,5 @@ spec:
         - containerPort: 3351
           hostPort: 10001
   nodeSelector:
-    feature.node.kubernetes.io/nfd-pstate-turbo: 'true'
+    feature.node.kubernetes.io/pstate-turbo: 'true'
   restartPolicy: Never


### PR DESCRIPTION
Remove 'nfd' label prefix from README and demos.

Remove references to nfd version label from README