### PR TITLE
Memory: detect transparent hugepages

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,9 +234,11 @@ possible security implications.
 
 ### Memory Features
 
-| Feature name   | Description                                                                         |
-| :------------: | :---------------------------------------------------------------------------------: |
-| numa           | Multiple memory nodes i.e. NUMA architecture detected
+| Feature              | Attribute  | Description                                             |
+| -------------------- | ---------- | ------------------------------------------------------- |
+| numa                 | <br>       | Multiple memory nodes i.e. NUMA architecture detected
+| transparent_hugepage | enabled    | Check Transparent hugepage is enabled or not
+| <br>                 | defrag     | Check the defrag efforts for THP is enabled or not
 
 ### Network Features
 


### PR DESCRIPTION
Memory: detect transparent hugepages

This patch adds a new feature: detect "transparent_hugepage" in memory module.
For best performance, before deploying the DPDK pods, 
we need to verify that the system's THP is disabled.
So I think, a new memory feature to detect THP is suitable.

The new node label is
feature.node.kubernetes.io/memory-transparent_hugepage.enabled
feature.node.kubernetes.io/memory-transparent_hugepage.defrag

Signed-off-by: Bin Lu <bin.lu@arm.com>