### PR TITLE
Move selinux detection to kernel feature source

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ node-feature-discovery.
                               will override settings read from the config file.
                               [Default: ]
   --sources=<sources>         Comma separated list of feature sources.
-                              [Default: cpu,cpuid,iommu,kernel,local,memory,network,pci,pstate,rdt,selinux,storage,system]
+                              [Default: cpu,cpuid,iommu,kernel,local,memory,network,pci,pstate,rdt,storage,system]
   --no-publish                Do not publish discovered features to the
                               cluster-local Kubernetes API server.
   --label-whitelist=<pattern> Regular expression to filter label names to
@@ -84,7 +84,6 @@ The current set of feature sources are the following:
 - Network
 - Pstate ([Intel P-State driver][intel-pstate])
 - RDT ([Intel Resource Director Technology][intel-rdt])
-- Selinux
 - Storage
 - System
 
@@ -114,14 +113,12 @@ the only label value published for features is the string `"true"`._
   "feature.node.kubernetes.io/cpu-<feature-name>": "true",
   "feature.node.kubernetes.io/cpuid-<feature-name>": "true",
   "feature.node.kubernetes.io/iommu-<feature-name>": "true",
-  "feature.node.kubernetes.io/kernel-config.<option-name>": "true",
-  "feature.node.kubernetes.io/kernel-version.<version component>": "<version number>",
+  "feature.node.kubernetes.io/kernel-<feature name>": "<feature value>",
   "feature.node.kubernetes.io/memory-<feature-name>": "true",
   "feature.node.kubernetes.io/network-<feature-name>": "true",
   "feature.node.kubernetes.io/pci-<device label>.present": "true",
   "feature.node.kubernetes.io/pstate-<feature-name>": "true",
   "feature.node.kubernetes.io/rdt-<feature-name>": "true",
-  "feature.node.kubernetes.io/selinux-<feature-name>": "true",
   "feature.node.kubernetes.io/storage-<feature-name>": "true",
   "feature.node.kubernetes.io/system-<feature name>": "<feature value>",
   "feature.node.kubernetes.io/<hook name>-<feature name>": "<feature value>"
@@ -185,6 +182,7 @@ not enabled) as reported by the `cpuid` instruction.
 | Feature | Attribute           | Description                                  |
 | ------- | ------------------- | -------------------------------------------- |
 | config  | &lt;option name&gt; | Kernel config option is enabled (set 'y' or 'm').<br> Default options are `NO_HZ`, `NO_HZ_IDLE`, `NO_HZ_FULL` and `PREEMPT`
+| selinux | enabled             | Selinux is enabled on the node
 | version | full                | Full kernel version as reported by `/proc/sys/kernel/osrelease` (e.g. '4.5.6-7-g123abcde')
 | <br>    | major               | First component of the kernel version (e.g. '4')
 | <br>    | minor               | Second component of the kernel version (e.g. '5')
@@ -292,12 +290,6 @@ for more information on NFD config.
 | RDTL3CA        | Intel L3 Cache Allocation Technology
 | RDTL2CA        | Intel L2 Cache Allocation Technology
 | RDTMBA         | Intel Memory Bandwidth Allocation (MBA) Technology
-
-### Selinux Features
-
-| Feature name       | Description                                                                         |
-| :--------------:   | :---------------------------------------------------------------------------------: |
-| selinux            | selinux is enabled on the node
 
 ### Storage Features
 

--- a/main.go
+++ b/main.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/node-feature-discovery/source/pci"
 	"sigs.k8s.io/node-feature-discovery/source/pstate"
 	"sigs.k8s.io/node-feature-discovery/source/rdt"
-	"sigs.k8s.io/node-feature-discovery/source/selinux"
 	"sigs.k8s.io/node-feature-discovery/source/storage"
 	"sigs.k8s.io/node-feature-discovery/source/system"
 )
@@ -184,7 +183,7 @@ func argsParse(argv []string) (args Args) {
                               will override settings read from the config file.
                               [Default: ]
   --sources=<sources>         Comma separated list of feature sources.
-                              [Default: cpu,cpuid,iommu,kernel,local,memory,network,pci,pstate,rdt,selinux,storage,system]
+                              [Default: cpu,cpuid,iommu,kernel,local,memory,network,pci,pstate,rdt,storage,system]
   --no-publish                Do not publish discovered features to the
                               cluster-local Kubernetes API server.
   --label-whitelist=<pattern> Regular expression to filter label names to
@@ -271,7 +270,6 @@ func configureParameters(sourcesWhiteList []string, labelWhiteListStr string) (e
 		pci.Source{},
 		pstate.Source{},
 		rdt.Source{},
-		selinux.Source{},
 		storage.Source{},
 		system.Source{},
 		// local needs to be the last source so that it is able to override

--- a/main_test.go
+++ b/main_test.go
@@ -152,7 +152,7 @@ func TestArgsParse(t *testing.T) {
 				So(args.sleepInterval, ShouldEqual, 60*time.Second)
 				So(args.noPublish, ShouldBeTrue)
 				So(args.oneshot, ShouldBeTrue)
-				So(args.sources, ShouldResemble, []string{"cpu", "cpuid", "iommu", "kernel", "local", "memory", "network", "pci", "pstate", "rdt", "selinux", "storage", "system"})
+				So(args.sources, ShouldResemble, []string{"cpu", "cpuid", "iommu", "kernel", "local", "memory", "network", "pci", "pstate", "rdt", "storage", "system"})
 				So(len(args.labelWhiteList), ShouldEqual, 0)
 			})
 		})
@@ -174,7 +174,7 @@ func TestArgsParse(t *testing.T) {
 
 			Convey("args.labelWhiteList is set to appropriate value and args.sources is set to default value", func() {
 				So(args.noPublish, ShouldBeFalse)
-				So(args.sources, ShouldResemble, []string{"cpu", "cpuid", "iommu", "kernel", "local", "memory", "network", "pci", "pstate", "rdt", "selinux", "storage", "system"})
+				So(args.sources, ShouldResemble, []string{"cpu", "cpuid", "iommu", "kernel", "local", "memory", "network", "pci", "pstate", "rdt", "storage", "system"})
 				So(args.labelWhiteList, ShouldResemble, ".*rdt.*")
 			})
 		})

--- a/source/kernel/kernel.go
+++ b/source/kernel/kernel.go
@@ -77,6 +77,13 @@ func (s Source) Discover() (source.Features, error) {
 		}
 	}
 
+	selinux, err := SelinuxEnabled()
+	if err != nil {
+		logger.Print(err)
+	} else if selinux {
+		features["selinux.enabled"] = true
+	}
+
 	return features, nil
 }
 

--- a/source/kernel/selinux.go
+++ b/source/kernel/selinux.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2017-2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,28 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package selinux
+package kernel
 
 import (
 	"fmt"
 	"io/ioutil"
-
-	"sigs.k8s.io/node-feature-discovery/source"
 )
 
-type Source struct{}
-
-func (s Source) Name() string { return "selinux" }
-
-func (s Source) Discover() (source.Features, error) {
-	features := source.Features{}
+// Detect if selinux has been enabled in the kernel
+func SelinuxEnabled() (bool, error) {
 	status, err := ioutil.ReadFile("/host-sys/fs/selinux/enforce")
 	if err != nil {
-		return nil, fmt.Errorf("Failed to detect the status of selinux, please check if the system supports selinux and make sure /sys on the host is mounted into the container: %s", err.Error())
+		return false, fmt.Errorf("Failed to detect the status of selinux, please check if the system supports selinux and make sure /sys on the host is mounted into the container: %s", err.Error())
 	}
 	if status[0] == byte('1') {
 		// selinux is enabled.
-		features["enabled"] = true
+		return true, nil
 	}
-	return features, nil
+	return false, nil
 }


### PR DESCRIPTION
Remove the 'selinux' feature source and move the functionality under the
'kernel' feature source. The selinux feature label is changed to
  feature.node.kubernetes.io/selinux.enabled

The selinux feature source was rather narrow in scope, and, the sole
feature it advertised naturally falls under the kernel feature source.