### PR TITLE
source/system: advertise major and minor OS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,10 +299,12 @@ for more information on NFD config.
 
 ### System Features
 
-| Feature     | Attribute  | Description                                       |
-| ----------- | ---------- | --------------------------------------------------|
-| os_release  | ID         | Operating system identifier
-| <br>        | VERSION_ID | Operating system version identifier
+| Feature     | Attribute        | Description                                 |
+| ----------- | ---------------- | --------------------------------------------|
+| os_release  | ID               | Operating system identifier
+| <br>        | VERSION_ID       | Operating system version identifier (e.g. '6.7')
+| <br>        | VERSION_ID.major | First component of the OS version id (e.g. '6')
+| <br>        | VERSION_ID.minor | Second component of the OS version id (e.g. '7')
 
 ## Getting started
 ### System requirements


### PR DESCRIPTION
Add two new attributes 'VERSION_ID.major' and 'VERSION_ID.minor' to the
os_release feature. These represent the first two components of
the OS version (version components are assumed to be separated by a
dot). E.g. if VERSION_ID would be 1.2.rc3 major and minor versions would
be 1 and 2, respectively:
  feature.node.kubernetes.io/system-os_release.VERSION_ID=1.2.rc3
  feature.node.kubernetes.io/system-os_release.VERSION_ID.major=1
  feature.node.kubernetes.io/system-os_release.VERSION_ID.minor=2

The version components must be purely numerical in order for them to be
advertised. This way they can be fully (and reliably) utilized in
nodeAffinity, including relative (Gt and Lt) operators.