### PR TITLE
source/memory: detect presence of NVDIMM devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,10 @@ possible security implications.
 
 ### Memory Features
 
-| Feature name   | Description                                                                         |
-| :------------: | :---------------------------------------------------------------------------------: |
-| numa           | Multiple memory nodes i.e. NUMA architecture detected
+| Feature | Attribute | Description                                            |
+| ------- | --------- | ------------------------------------------------------ |
+| numa    | <br>      | Multiple memory nodes i.e. NUMA architecture detected
+| nv      | present   | NVDIMM device(s) are present
 
 ### Network Features
 


### PR DESCRIPTION
Add a new (binary) label indicating the presence of non-volatile DIMM devices:
```
feature.node.kubernetes.io/memory-nv.present
```

Implements #178 