### PR TITLE
Fix APIHelpers

### DIFF
--- a/pkg/apihelper/apihelpers.go
+++ b/pkg/apihelper/apihelpers.go
@@ -29,9 +29,9 @@ type APIHelpers interface {
 	// GetNode returns the Kubernetes node on which this container is running.
 	GetNode(*k8sclient.Clientset, string) (*api.Node, error)
 
-	// RemoveLabelsWithPrefix removes labels from the supplied node that contain the
-	// search string provided. In order to publish the changes, the node must
-	// subsequently be updated via the API server using the client library.
+	// RemoveLabelsWithPrefix deletes all labels with specified prefix from a
+	// Node object In order to publish the changes, the node must subsequently
+	// be updated via the API server using the client library.
 	RemoveLabelsWithPrefix(*api.Node, string)
 
 	// RemoveLabels removes NFD labels from a node object

--- a/pkg/apihelper/k8shelpers.go
+++ b/pkg/apihelper/k8shelpers.go
@@ -54,11 +54,10 @@ func (h K8sHelpers) GetNode(cli *k8sclient.Clientset, nodeName string) (*api.Nod
 	return node, nil
 }
 
-// RemoveLabelsWithPrefix searches through all labels on Node n and removes
-// any where the key contain the search string.
+// RemoveLabelsWithPrefix deletes all labels with given prefix
 func (h K8sHelpers) RemoveLabelsWithPrefix(n *api.Node, search string) {
 	for k := range n.Labels {
-		if strings.Contains(k, search) {
+		if strings.HasPrefix(k, search) {
 			delete(n.Labels, k)
 		}
 	}

--- a/pkg/apihelper/k8shelpers_test.go
+++ b/pkg/apihelper/k8shelpers_test.go
@@ -59,9 +59,9 @@ func TestRemoveLabelsWithPrefix(t *testing.T) {
 		n := &api.Node{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Labels: map[string]string{
-					"single":     "123",
-					"multiple_A": "a",
-					"multiple_B": "b",
+					"single-label": "123",
+					"multiple_A":   "a",
+					"multiple_B":   "b",
 				},
 			},
 		}
@@ -80,8 +80,8 @@ func TestRemoveLabelsWithPrefix(t *testing.T) {
 		})
 
 		Convey("a search string with no matches should not alter labels", func() {
-			helper.RemoveLabelsWithPrefix(n, "unique")
-			So(n.Labels, ShouldContainKey, "single")
+			helper.RemoveLabelsWithPrefix(n, "i")
+			So(n.Labels, ShouldContainKey, "single-label")
 			So(n.Labels, ShouldContainKey, "multiple_A")
 			So(n.Labels, ShouldContainKey, "multiple_B")
 			So(len(n.Labels), ShouldEqual, 3)


### PR DESCRIPTION
Change RemoveLabelsWithPrefix() to do what its name suggests.
Previously, it did not test (only) for prefix, but it accepted any
substring match.