### PR TITLE
Dockerfile: change the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,14 @@ RUN make install VERSION=$VERSION HOSTMOUNT_PREFIX=$HOSTMOUNT_PREFIX
 RUN make test
 
 
+# Use debian-base for the extra files we need
+FROM k8s.gcr.io/build-image/debian-base:v2.1.3 as extra
+
+RUN apt-get update -y && apt-get -q -yy install --no-install-recommends --no-install-suggests --fix-missing busybox-static
+
+
 # Create production image for running node feature discovery
-FROM k8s.gcr.io/build-image/debian-base:v2.1.3
+FROM gcr.io/distroless/static
 
 # Run as unprivileged user
 USER 65534:65534
@@ -30,3 +36,4 @@ ENV GRPC_GO_LOG_SEVERITY_LEVEL="INFO"
 
 COPY --from=builder /go/node-feature-discovery/nfd-worker.conf.example /etc/kubernetes/node-feature-discovery/nfd-worker.conf
 COPY --from=builder /go/bin/* /usr/bin/
+COPY --from=extra /bin/busybox /bin/sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN make test
 
 
 # Create production image for running node feature discovery
-FROM debian:buster-slim
+FROM k8s.gcr.io/build-image/debian-base:v2.1.3
 
 # Run as unprivileged user
 USER 65534:65534

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ HOSTMOUNT_PREFIX ?= /
 KUBECONFIG ?=
 E2E_TEST_CONFIG ?=
 
-LDFLAGS = -ldflags "-s -w -X sigs.k8s.io/node-feature-discovery/pkg/version.version=$(VERSION) -X sigs.k8s.io/node-feature-discovery/source.pathPrefix=$(HOSTMOUNT_PREFIX)"
+LDFLAGS = -ldflags "-s -w -extldflags -static -X sigs.k8s.io/node-feature-discovery/pkg/version.version=$(VERSION) -X sigs.k8s.io/node-feature-discovery/source.pathPrefix=$(HOSTMOUNT_PREFIX)"
 
 yaml_templates := $(wildcard *.yaml.template)
 # Let's treat values.yaml as template to sync configmap
@@ -65,10 +65,10 @@ all: image
 
 build:
 	@mkdir -p bin
-	$(GO_CMD) build -v -o bin $(LDFLAGS) ./cmd/...
+	CGO_ENABLED=0 $(GO_CMD) build -v -o bin $(LDFLAGS) ./cmd/...
 
 install:
-	$(GO_CMD) install -v $(LDFLAGS) ./cmd/...
+	CGO_ENABLED=0 $(GO_CMD) install -v $(LDFLAGS) ./cmd/...
 
 image: yamls
 	$(IMAGE_BUILD_CMD) --build-arg VERSION=$(VERSION) \

--- a/cmd/nfd-master/Dockerfile
+++ b/cmd/nfd-master/Dockerfile
@@ -22,7 +22,6 @@ RUN make install VERSION=$VERSION HOSTMOUNT_PREFIX=$HOSTMOUNT_PREFIX
 
 RUN make test
 
-
 # Create production image for nfd-master
 FROM gcr.io/distroless/static
 

--- a/cmd/nfd-master/Dockerfile
+++ b/cmd/nfd-master/Dockerfile
@@ -1,0 +1,34 @@
+# Build node feature discovery
+#
+# NOTE: we keep the builder stage of nfd-master and nfd-worker Dockerfiles in
+# sync in order to re-use docker layers
+#
+FROM golang:1.15.5-buster as builder
+
+# Get (cache) deps in a separate layer
+COPY go.mod go.sum /go/node-feature-discovery/
+
+WORKDIR /go/node-feature-discovery
+
+RUN go mod download
+
+# Do actual build
+COPY . /go/node-feature-discovery
+
+ARG VERSION
+ARG HOSTMOUNT_PREFIX
+
+RUN make install VERSION=$VERSION HOSTMOUNT_PREFIX=$HOSTMOUNT_PREFIX
+
+RUN make test
+
+
+# Create production image for nfd-master
+FROM gcr.io/distroless/static
+
+# Use more verbose logging of gRPC
+ENV GRPC_GO_LOG_SEVERITY_LEVEL="INFO"
+
+COPY --from=builder /go/bin/nfd-master /usr/bin/
+
+ENTRYPOINT ["/usr/bin/nfd-master"]

--- a/cmd/nfd-worker/Dockerfile
+++ b/cmd/nfd-worker/Dockerfile
@@ -1,4 +1,8 @@
 # Build node feature discovery
+#
+# NOTE: we keep the builder stage of nfd-master and nfd-worker Dockerfiles in
+# sync in order to re-use docker layers
+#
 FROM golang:1.15.5-buster as builder
 
 # Get (cache) deps in a separate layer
@@ -18,15 +22,8 @@ RUN make install VERSION=$VERSION HOSTMOUNT_PREFIX=$HOSTMOUNT_PREFIX
 
 RUN make test
 
-
-# Use debian-base for the extra files we need
-FROM k8s.gcr.io/build-image/debian-base:v2.1.3 as extra
-
-RUN apt-get update -y && apt-get -q -yy install --no-install-recommends --no-install-suggests --fix-missing busybox-static
-
-
-# Create production image for running node feature discovery
-FROM gcr.io/distroless/static
+# Create production image for nfd-worker
+FROM k8s.gcr.io/build-image/debian-base:v2.1.3
 
 # Run as unprivileged user
 USER 65534:65534
@@ -35,5 +32,6 @@ USER 65534:65534
 ENV GRPC_GO_LOG_SEVERITY_LEVEL="INFO"
 
 COPY --from=builder /go/node-feature-discovery/nfd-worker.conf.example /etc/kubernetes/node-feature-discovery/nfd-worker.conf
-COPY --from=builder /go/bin/* /usr/bin/
-COPY --from=extra /bin/busybox /bin/sh
+COPY --from=builder /go/bin/nfd-worker /usr/bin/
+
+ENTRYPOINT ["/usr/bin/nfd-worker"]

--- a/docs/advanced/developer-guide.md
+++ b/docs/advanced/developer-guide.md
@@ -28,7 +28,7 @@ cd node-feature-discovery
 
 ### Docker Build
 
-#### Build the container image
+#### Build the container images
 
 See [customizing the build](#customizing-the-build) below for altering the
 container image registry, for example.
@@ -37,12 +37,12 @@ container image registry, for example.
 make
 ```
 
-#### Push the container image
+#### Push the container images
 
 Optional, this example with Docker.
 
 ```bash
-docker push <IMAGE_TAG>
+make push
 ```
 
 #### Change the job spec to use your custom image (optional)

--- a/docs/get-started/features.md
+++ b/docs/get-started/features.md
@@ -534,10 +534,10 @@ The *local* feature source gets its labels by two different ways:
 - It tries to execute files found under
   `/etc/kubernetes/node-feature-discovery/source.d/` directory. The hook files
   must be executable and they are supposed to print all discovered features in
-  `stdout`, one per line. With ELF binaries static linking is recommended as
-  the selection of system libraries available in the NFD release image is very
-  limited. Other runtimes currently supported by the NFD stock image are bash
-  and perl.
+  `stdout`, one per line. Only statically linked ELF binaries and shell scripts
+  (busybox sh) are supported. If other runtimes are required the detection must
+  be run outside the NFD container and made available to NFD via `features.d`
+  directory.
 - It reads files found under
   `/etc/kubernetes/node-feature-discovery/features.d/` directory. The file
   content is expected to be similar to the hook output (described above).

--- a/nfd-daemonset-combined.yaml.template
+++ b/nfd-daemonset-combined.yaml.template
@@ -67,7 +67,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
+          image: gcr.io/k8s-staging-nfd/node-feature-discovery-master:master
           imagePullPolicy: Always
           name: nfd-master
           securityContext:
@@ -76,14 +76,12 @@ spec:
               drop: ["ALL"]
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-          command:
-            - "nfd-master"
         - env:
           - name: NODE_NAME
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
+          image: gcr.io/k8s-staging-nfd/node-feature-discovery-worker:master
           imagePullPolicy: Always
           name: nfd-worker
           securityContext:
@@ -92,8 +90,6 @@ spec:
               drop: ["ALL"]
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-          command:
-            - "nfd-worker"
           args:
             - "--sleep-interval=60s"
           volumeMounts:

--- a/nfd-master.yaml.template
+++ b/nfd-master.yaml.template
@@ -81,7 +81,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
+          image: gcr.io/k8s-staging-nfd/node-feature-discovery-master:master
           imagePullPolicy: Always
           name: nfd-master
           securityContext:
@@ -90,8 +90,6 @@ spec:
               drop: ["ALL"]
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-          command:
-            - "nfd-master"
 ## Enable TLS authentication
 ## The example below assumes having the root certificate named ca.crt stored in
 ## a ConfigMap named nfd-ca-cert, and, the TLS authentication credentials stored

--- a/nfd-prune.yaml.template
+++ b/nfd-prune.yaml.template
@@ -74,7 +74,7 @@ spec:
           effect: "NoSchedule"
       containers:
         - name: nfd-master
-          image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
+          image: gcr.io/k8s-staging-nfd/node-feature-discovery-master:master
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/nfd-worker-daemonset.yaml.template
+++ b/nfd-worker-daemonset.yaml.template
@@ -23,7 +23,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
+          image: gcr.io/k8s-staging-nfd/node-feature-discovery-worker:master
           imagePullPolicy: Always
           name: nfd-worker
           securityContext:
@@ -32,8 +32,6 @@ spec:
               drop: ["ALL"]
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-          command:
-            - "nfd-worker"
           args:
             - "--sleep-interval=60s"
             - "--server=nfd-master:8080"

--- a/nfd-worker-job.yaml.template
+++ b/nfd-worker-job.yaml.template
@@ -32,7 +32,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
+          image: gcr.io/k8s-staging-nfd/node-feature-discovery-worker:master
           imagePullPolicy: Always
           name: nfd-worker
           securityContext:
@@ -41,8 +41,6 @@ spec:
               drop: ["ALL"]
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-          command:
-            - "nfd-worker"
           args:
             - "--oneshot"
             - "--server=nfd-master:8080"

--- a/scripts/test-infra/build-image.sh
+++ b/scripts/test-infra/build-image.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-make image
+make images

--- a/scripts/test-infra/push-image.sh
+++ b/scripts/test-infra/push-image.sh
@@ -5,5 +5,5 @@
 # container image tag
 VERSION_OVERRIDE=${_GIT_TAG+VERSION=${_GIT_TAG:10}}
 
-make image $VERSION_OVERRIDE
+make images $VERSION_OVERRIDE
 make push $VERSION_OVERRIDE

--- a/scripts/test-infra/test-e2e.sh
+++ b/scripts/test-infra/test-e2e.sh
@@ -17,7 +17,7 @@ echo "$E2E_TEST_CONFIG_DATA" > "$E2E_TEST_CONFIG"
 # Wait for the image to be built and published
 i=1
 while true; do
-    if make poll-image; then
+    if make poll-images; then
         break
     elif [ $i -ge 10 ]; then
         "ERROR: too many tries when polling for image"


### PR DESCRIPTION
Dockerfile: use k8s.gcr.io/debian-base as the base for production image

Aligns the production base image with Kubernetes upstream. Slightly
reduces the size of the production container image from ca. 86MB to ca.
73MB.