### PR TITLE
source/cpu: make cpuid configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,16 @@ such as restricting discovered features with the --label-whitelist option._
 | <br>                    | RDTL2CA            | Intel L2 Cache Allocation Technology
 | <br>                    | RDTMBA             | Intel Memory Bandwidth Allocation (MBA) Technology
 
+The (sub-)set of CPUID attributes to publish is configurable via the
+`attributeBlacklist` and `attributeWhitelist` cpuid options of the cpu source.
+If whitelist is specified, only whitelisted attributes will be published. With
+blacklist, only blacklisted attributes are filtered out. `attributeWhitelist`
+has priority over `attributeBlacklist`.  For examples and more information
+about configurability, see [Configuration Options](#configuration-options).
+By default, the following CPUID flags have been blacklisted:
+BMI1, BMI2, CLMUL, CMOV, CX16, ERMS, F16C, HTT, LZCNT, MMX, MMXEXT, NX, POPCNT,
+RDRAND, RDSEED, RDTSCP, SGX, SSE, SSE2, SSE3, SSE4.1, SSE4.2 and SSSE3.
+
 **NOTE** The cpuid features advertise *supported* CPU capabilities, that is, a
 capability might be supported but not enabled.
 
@@ -227,11 +237,6 @@ capability might be supported but not enabled.
 | AESNI     | Advanced Encryption Standard (AES) New Instructions (AES-NI)
 | AVX       | Advanced Vector Extensions (AVX)
 | AVX2      | Advanced Vector Extensions 2 (AVX2)
-| BMI1      | Bit Manipulation Instruction Set 1 (BMI)
-| BMI2      | Bit Manipulation Instruction Set 2 (BMI2)
-| SSE4.1    | Streaming SIMD Extensions 4.1 (SSE4.1)
-| SSE4.2    | Streaming SIMD Extensions 4.2 (SSE4.2)
-| SGX       | Software Guard Extensions (SGX)
 
 #### Arm64 CPUID Attribute (Partial List)
 
@@ -552,7 +557,8 @@ Configuration options specified from the command line will override those read
 from the config file.
 
 Currently, the only available configuration options are related to the
-[PCI](#pci-features) and [Kernel](#kernel-features) feature sources.
+[CPU](#cpu-features), [PCI](#pci-features) and [Kernel](#kernel-features)
+feature sources.
 
 ## Building from source
 

--- a/nfd-worker.conf.example
+++ b/nfd-worker.conf.example
@@ -1,4 +1,32 @@
 #sources:
+#  cpu:
+#    cpuid:
+##     NOTE: whitelist has priority over blacklist
+#      attributeBlacklist:
+#        - "BMI1"
+#        - "BMI2"
+#        - "CLMUL"
+#        - "CMOV"
+#        - "CX16"
+#        - "ERMS"
+#        - "F16C"
+#        - "HTT"
+#        - "LZCNT"
+#        - "MMX"
+#        - "MMXEXT"
+#        - "NX"
+#        - "POPCNT"
+#        - "RDRAND"
+#        - "RDSEED"
+#        - "RDTSCP"
+#        - "SGX"
+#        - "SSE"
+#        - "SSE2"
+#        - "SSE3"
+#        - "SSE4.1"
+#        - "SSE4.2"
+#        - "SSSE3"
+#      attributeWhitelist:
 #  kernel:
 #    kconfigFile: "/path/to/kconfig"
 #    configOpts:

--- a/pkg/nfd-worker/nfd-worker.go
+++ b/pkg/nfd-worker/nfd-worker.go
@@ -58,6 +58,7 @@ var (
 // Global config
 type NFDConfig struct {
 	Sources struct {
+		Cpu    *cpu.NFDConfig    `json:"cpu,omitempty"`
 		Kernel *kernel.NFDConfig `json:"kernel,omitempty"`
 		Pci    *pci.NFDConfig    `json:"pci,omitempty"`
 	} `json:"sources,omitempty"`
@@ -197,6 +198,7 @@ func (w *nfdWorker) Run() error {
 
 // Parse configuration options
 func configParse(filepath string, overrides string) error {
+	config.Sources.Cpu = &cpu.Config
 	config.Sources.Kernel = &kernel.Config
 	config.Sources.Pci = &pci.Config
 

--- a/source/cpu/cpuid_arm64.go
+++ b/source/cpu/cpuid_arm64.go
@@ -26,10 +26,6 @@ unsigned long gethwcap() {
 */
 import "C"
 
-import (
-	"sigs.k8s.io/node-feature-discovery/source"
-)
-
 /* all special features for arm64 should be defined here */
 const (
 	/* extension instructions */


### PR DESCRIPTION
Add 'cpuid/attributeBlacklist' and 'cpuid/attributeWhitelist' config
options for the cpu feature source. These can be used to filter the set
of cpuid capabilities that get published. The intention is to reduce
clutter in the NFD label space, getting rid of "obvious" or misleading
cpuid labels. Whitelisting has higher priority, i.e.  only whitelist
takes effect if both attributeWhitelist and attributeBlacklist are
specified.
