### PR TITLE
add support for SST-BF features

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ nfd-worker.
                               in testing
                               [Default: ]
   --sources=<sources>         Comma separated list of feature sources.
-                              [Default: cpu,cpuid,iommu,kernel,local,memory,network,pci,pstate,rdt,storage,system]
+                              [Default: cpu,cpuid,iommu,kernel,local,memory,network, cpu_power, pci,pstate,rdt,storage,system]
   --no-publish                Do not publish discovered features to the
                               cluster-local Kubernetes API server.
   --label-whitelist=<pattern> Regular expression to filter label names to
@@ -160,6 +160,7 @@ The current set of feature sources are the following:
 - RDT ([Intel Resource Director Technology][intel-rdt])
 - Storage
 - System
+- CPU Power([Intel Speed Select Technology][intel-sst])
 
 ### Feature labels
 
@@ -352,6 +353,12 @@ possible security implications.
 | Feature name | Description                                                   |
 | :----------: | ------------------------------------------------------------- |
 | turbo        | Turbo frequencies are enabled in Intel pstate driver
+
+### System Features
+
+| Feature     | Attribute        | Description                                 |
+| ----------- | ---------------- | --------------------------------------------|
+| cpu_power   | sst_bf.enabled   | Speed Select Technology - Base frequency is enabled in cpu           |
 
 ### Memory Features
 
@@ -649,3 +656,4 @@ A demo on the benefits of using node feature discovery can be found in [demo](de
 [gcc-down]: https://gcc.gnu.org
 [kubectl-setup]: https://coreos.com/kubernetes/docs/latest/configure-kubectl.html
 [node-sel]: http://kubernetes.io/docs/user-guide/node-selection
+[intel-sst]:https://www.intel.co.uk/content/www/uk/en/architecture-and-technology/speed-select-technology-article.html

--- a/cmd/nfd-worker/main.go
+++ b/cmd/nfd-worker/main.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/node-feature-discovery/pkg/version"
 	"sigs.k8s.io/node-feature-discovery/source"
 	"sigs.k8s.io/node-feature-discovery/source/cpu"
+	"sigs.k8s.io/node-feature-discovery/source/cpu/cpu_power"
 	"sigs.k8s.io/node-feature-discovery/source/cpuid"
 	"sigs.k8s.io/node-feature-discovery/source/fake"
 	"sigs.k8s.io/node-feature-discovery/source/iommu"
@@ -218,7 +219,7 @@ func argsParse(argv []string) (Args, error) {
                               in testing
                               [Default: ]
   --sources=<sources>         Comma separated list of feature sources.
-                              [Default: cpu,cpuid,iommu,kernel,local,memory,network,pci,pstate,rdt,storage,system]
+                              [Default: cpu,cpuid,iommu,kernel,local,memory,network,cpu_power,pci,pstate,rdt,storage,system]
   --no-publish                Do not publish discovered features to the
                               cluster-local Kubernetes API server.
   --label-whitelist=<pattern> Regular expression to filter label names to
@@ -320,6 +321,7 @@ func configureParameters(sourcesWhiteList []string, labelWhiteListStr string) (e
 		network.Source{},
 		panic_fake.Source{},
 		pci.Source{},
+		cpu_power.Source{},
 		pstate.Source{},
 		rdt.Source{},
 		storage.Source{},

--- a/cmd/nfd-worker/main_test.go
+++ b/cmd/nfd-worker/main_test.go
@@ -86,7 +86,7 @@ func TestArgsParse(t *testing.T) {
 				So(args.sleepInterval, ShouldEqual, 60*time.Second)
 				So(args.noPublish, ShouldBeTrue)
 				So(args.oneshot, ShouldBeTrue)
-				So(args.sources, ShouldResemble, []string{"cpu", "cpuid", "iommu", "kernel", "local", "memory", "network", "pci", "pstate", "rdt", "storage", "system"})
+				So(args.sources, ShouldResemble, []string{"cpu", "cpuid", "iommu", "kernel", "local", "memory", "network", "cpu_power", "pci", "pstate", "rdt", "storage", "system"})
 				So(len(args.labelWhiteList), ShouldEqual, 0)
 				So(err, ShouldBeNil)
 			})
@@ -110,7 +110,7 @@ func TestArgsParse(t *testing.T) {
 
 			Convey("args.labelWhiteList is set to appropriate value and args.sources is set to default value", func() {
 				So(args.noPublish, ShouldBeFalse)
-				So(args.sources, ShouldResemble, []string{"cpu", "cpuid", "iommu", "kernel", "local", "memory", "network", "pci", "pstate", "rdt", "storage", "system"})
+				So(args.sources, ShouldResemble, []string{"cpu", "cpuid", "iommu", "kernel", "local", "memory", "network", "cpu_power", "pci", "pstate", "rdt", "storage", "system"})
 				So(args.labelWhiteList, ShouldResemble, ".*rdt.*")
 				So(err, ShouldBeNil)
 			})

--- a/source/cpu/cpu_power/cpupower.go
+++ b/source/cpu/cpu_power/cpupower.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpu_power
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"sigs.k8s.io/node-feature-discovery/source"
+)
+
+var (
+	cpuinfo     = "/host-proc/cpuinfo"
+	sysdevcpu   = "/host-sys/devices/system/cpu/cpu"
+	cpubasefreq = "/cpufreq/base_frequency"
+)
+
+// Source implements FeatureSource.
+type Source struct{}
+
+// Name returns an identifier string for this feature source.
+func (s Source) Name() string { return "cpu_power" }
+
+type NoBasefreqSupport struct {
+	message string
+}
+
+func (b *NoBasefreqSupport) Error() string {
+	return string(b.message)
+}
+
+func getcpuBaseFrequency() int {
+	baseFreq := DiscoverBaseFreq()
+	return int(baseFreq)
+}
+
+func getcpuCount() (int, error) {
+	files, err := ioutil.ReadDir("/host-sys/devices/system/cpu")
+	if err != nil {
+		return 0, err
+	}
+
+	re := regexp.MustCompile("cpu([0-9])")
+	var i int
+	for _, f := range files {
+		if re.MatchString(f.Name()) {
+			i++
+		}
+	}
+
+	return i, nil
+}
+
+func getBaseFrequency(cpu int) (int, error) {
+	var baseFreq int
+
+	baseFile := fmt.Sprintf("%s%d%s", sysdevcpu, cpu, cpubasefreq)
+	if _, err := os.Lstat(baseFile); err != nil {
+		return baseFreq, &NoBasefreqSupport{"no base frequency support"}
+	}
+
+	data, err := ioutil.ReadFile(baseFile)
+	if err != nil {
+		return baseFreq, fmt.Errorf("failed to read the %q err: %v", baseFile, err)
+	}
+
+	if len(data) == 0 {
+		return baseFreq, fmt.Errorf("no data in the file %q", baseFile)
+	}
+
+	rawbaseFreq := strings.TrimSpace(string(data))
+	baseFreq, err = strconv.Atoi(rawbaseFreq)
+	if err != nil {
+		return baseFreq, fmt.Errorf("failed to convert baseFreqs(byte value) of %q: %v", baseFile, err)
+	}
+
+	baseFreq = baseFreq / 1000
+	return baseFreq, nil
+}
+
+func checkpbfCores() (bool, error) {
+	var pbfenabled bool
+
+	cpucount, err := getcpuCount()
+	if err != nil {
+		return pbfenabled, err
+	}
+
+	P1 := getcpuBaseFrequency()
+
+	for cpuid := 0; cpuid < cpucount; cpuid++ {
+		base, err := getBaseFrequency(cpuid)
+		if err != nil {
+			return pbfenabled, err
+		}
+
+		if base > P1 {
+			pbfenabled = true
+			break
+		}
+	}
+
+	return pbfenabled, nil
+}
+
+// Discover returns feature names for pbf related features
+func (s Source) Discover() (source.Features, error) {
+	features := source.Features{}
+
+	pbfenabled, err := checkpbfCores()
+	if err != nil {
+		if _, ok := err.(*NoBasefreqSupport); ok {
+			features["sst_bf.enabled"] = false
+		} else {
+			return nil, fmt.Errorf("can't detect whether pbf is enabled: %s", err.Error())
+		}
+	}
+
+	if pbfenabled != false {
+		features["sst_bf.enabled"] = true
+	}
+
+	return features, nil
+}

--- a/source/cpu/cpu_power/cpupower_amd64.go
+++ b/source/cpu/cpu_power/cpupower_amd64.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpu_power
+
+type CpuidRet struct {
+	EAX, EBX, ECX, EDX uint32
+}
+
+func cpuid_low(eax, ecx uint32) CpuidRet {
+	r := CpuidRet{}
+	r.EAX, r.EBX, r.ECX, r.EDX = cpuidAsm(eax, ecx)
+	return r
+}
+
+func cpuidAsm(eax_arg, ecx_arg uint32) (eax, ebx, ecx, edx uint32)
+
+const (
+	// CPUID EAX input values
+	PROCESSOR_FREQ_INFO_ENUMERATION_LEAF = 0x16
+)
+
+func DiscoverBaseFreq() uint32 {
+	freqInfo := cpuid_low(PROCESSOR_FREQ_INFO_ENUMERATION_LEAF, 0)
+	return freqInfo.EAX
+}

--- a/source/cpu/cpu_power/cpupower_amd64.s
+++ b/source/cpu/cpu_power/cpupower_amd64.s
@@ -1,0 +1,27 @@
+// +build amd64
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+TEXT ·cpuidAsm(SB), 4, $0   // 4 = NOSPLIT
+    MOVL    eax_arg+0(FP), AX
+    MOVL    ecx_arg+4(FP), CX
+    CPUID
+    MOVL    AX, eax+8(FP)
+    MOVL    BX, ebx+12(FP)
+    MOVL    CX, ecx+16(FP)
+    MOVL    DX, edx+20(FP)
+    RET


### PR DESCRIPTION
* add discovery of SST-BF high-priority core through NFD

For more information, please refer to https://www.intel.co.uk/content/www/uk/en/architecture-and-technology/speed-select-technology-article.html

Change-Id: I4b2031ef40d206842d9f6cef188a14a0e47f1dea