### PR TITLE
Mount source.d and features.d in template YAMLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,11 @@ supposed to print all discovered features in `stdout`, one per line.
 directory. The file content is expected to be similar to the hook output (described above).
 
 These directories must be available inside the Docker image so Volumes and
-VolumeMounts must be used if standard NFD images are used.
+VolumeMounts must be used if standard NFD images are used. The given template
+files mount by default the `source.d` and the `features.d` directories
+respectively from `/etc/kubernetes/node-feature-discovery/source.d/` and
+`/etc/kubernetes/node-feature-discovery/features.d/` from the host. You should
+update them to match your needs.
 
 In both cases, the labels can be binary or non binary, using either `<name>` or
 `<name>=<value>` format.

--- a/nfd-daemonset-combined.yaml.template
+++ b/nfd-daemonset-combined.yaml.template
@@ -81,6 +81,10 @@ spec:
               readOnly: true
             - name: host-sys
               mountPath: "/host-sys"
+            - name: source-d
+              mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
+            - name: features-d
+              mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
       volumes:
         - name: host-boot
           hostPath:
@@ -91,3 +95,9 @@ spec:
         - name: host-sys
           hostPath:
             path: "/sys"
+        - name: source-d
+          hostPath:
+            path: "/etc/kubernetes/node-feature-discovery/source.d/"
+        - name: features-d
+          hostPath:
+            path: "/etc/kubernetes/node-feature-discovery/features.d/"

--- a/nfd-worker-daemonset.yaml.template
+++ b/nfd-worker-daemonset.yaml.template
@@ -44,6 +44,10 @@ spec:
               readOnly: true
             - name: host-sys
               mountPath: "/host-sys"
+            - name: source-d
+              mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
+            - name: features-d
+              mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
 ## Enable TLS authentication (2/3)
 #            - name: nfd-ca-cert
 #              mountPath: "/etc/kubernetes/node-feature-discovery/trust"
@@ -61,6 +65,12 @@ spec:
         - name: host-sys
           hostPath:
             path: "/sys"
+        - name: source-d
+          hostPath:
+            path: "/etc/kubernetes/node-feature-discovery/source.d/"
+        - name: features-d
+          hostPath:
+            path: "/etc/kubernetes/node-feature-discovery/features.d/"
 ## Enable TLS authentication (3/3)
 #        - name: nfd-ca-cert
 #          configMap:

--- a/nfd-worker-job.yaml.template
+++ b/nfd-worker-job.yaml.template
@@ -39,6 +39,10 @@ spec:
               readOnly: true
             - name: host-sys
               mountPath: "/host-sys"
+            - name: source-d
+              mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
+            - name: features-d
+              mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
       restartPolicy: Never
       volumes:
         - name: host-boot
@@ -50,3 +54,9 @@ spec:
         - name: host-sys
           hostPath:
             path: "/sys"
+        - name: source-d
+          hostPath:
+            path: "/etc/kubernetes/node-feature-discovery/source.d/"
+        - name: features-d
+          hostPath:
+            path: "/etc/kubernetes/node-feature-discovery/features.d/"


### PR DESCRIPTION
As the `local` source is enabled by default, we should mount the directories in the given YAML files

Signed-off-by: Jordan Jacobelli <jjacobelli@nvidia.com>