### PR TITLE
Add label for network bridges

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,10 +281,11 @@ See [configuration options](#configuration-options) for more information.
 
 ### Network Features
 
-| Feature | Attribute  | Description                                           |
-| ------- | ---------- | ----------------------------------------------------- |
-| sriov   | capable    | [Single Root Input/Output Virtualization][sriov] (SR-IOV) enabled Network Interface Card(s) present
-| <br>    | configured | SR-IOV virtual functions have been configured
+| Feature | Attribute    | Description                                           |
+| ------- | ------------ | ----------------------------------------------------- |
+| sriov   | capable      | [Single Root Input/Output Virtualization][sriov] (SR-IOV) enabled Network Interface Card(s) present
+| <br>    | configured   | SR-IOV virtual functions have been configured
+| bridge  | &lt;name&gt; | Network bridge with given &lt;name&gt; is present on node
 
 ### PCI Features
 

--- a/source/network/network.go
+++ b/source/network/network.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 
@@ -81,6 +82,11 @@ func (s Source) Discover() (source.Features, error) {
 				}
 			}
 		}
+
+		if bridgeDir, _ := os.Stat("/sys/class/net/" + netInterface.Name + "/bridge"); bridgeDir != nil {
+			features["bridge."+netInterface.Name] = true
+		}
+
 	}
 	return features, nil
 }


### PR DESCRIPTION
This patch will add labeling for linux network bridges.
If a bridge named 'br1' exists on a node, the following label
will be added:
    feature.node.kubernetes.io/network-bridge.br1: "true"

This feature is need by the kubevirt project in order to schedule
pods with custom networks.