### PR TITLE
source/memory: detect NVDIMM DAX mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ See [configuration options](#configuration-options) for more information.
 | ------- | --------- | ------------------------------------------------------ |
 | numa    | <br>      | Multiple memory nodes i.e. NUMA architecture detected
 | nv      | present   | NVDIMM device(s) are present
+| nv      | dax       | NVDIMM region(s) configured in DAX mode are present
 
 ### Network Features
 


### PR DESCRIPTION
Extend NVDIMM (non-volatile DIMM) discovery by adding detection of DAX
mode, i.e. detection of regions in DAX/AppDirect mode.
The new label is:
    feature.node.kubernetes.io/memory-nv.dax: true