### PR TITLE
Remove inactive approvers from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,8 +4,6 @@
 
 approvers:
   - balajismaniam
-  - ConnorDoyle
-  - flyingcougar
   - marquiz
 reviewers:
   - Ethyling


### PR DESCRIPTION
Remove ConnorDoyle and flyingcougar from the OWNERS file. They haven't
been active in over a year and are not members of the Kubernetes-SIGs
org. We can easily add them back, later, if needed.