### PR TITLE
kernel: fix undefined symbol error

### DIFF
--- a/source/kernel/kernel.go
+++ b/source/kernel/kernel.go
@@ -180,7 +180,7 @@ func parseKconfig() (map[string]string, error) {
 			} else {
 				value := strings.Trim(m[2], `"`)
 				if len(value) > validation.LabelValueMaxLength {
-					logger.Printf("WARNING: ignoring kconfig option '%s': value exceeds max length of %d characters", m[1], validation.LabelValueMaxLength)
+					log.Printf("WARNING: ignoring kconfig option '%s': value exceeds max length of %d characters", m[1], validation.LabelValueMaxLength)
 					continue
 				}
 				kconfig[m[1]] = value


### PR DESCRIPTION
Fix a build failure that slipped through when adding support for
non-binary kconfig options in #197,