### PR TITLE
nfd-worker: try connecting to nfd-master for 60s

### DIFF
--- a/pkg/nfd-worker/nfd-worker.go
+++ b/pkg/nfd-worker/nfd-worker.go
@@ -136,7 +136,7 @@ func (w *nfdWorker) Run() error {
 	}
 
 	// Connect to NFD server
-	dialOpts := []grpc.DialOption{}
+	dialOpts := []grpc.DialOption{grpc.WithBlock(), grpc.WithTimeout(60 * time.Second)}
 	if w.args.CaFile != "" || w.args.CertFile != "" || w.args.KeyFile != "" {
 		// Load client cert for client authentication
 		cert, err := tls.LoadX509KeyPair(w.args.CertFile, w.args.KeyFile)


### PR DESCRIPTION
Instead of erroring out right away, try to connect to nfd-master for 60
seconds until giving up.