### PR TITLE
Add RDMA capable feature to PCI Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ See [configuration options](#configuration-options) for more information.
 | Feature              | Attribute | Description                               |
 | -------------------- | --------- | ----------------------------------------- |
 | &lt;device label&gt; | present   | PCI device is detected
+| rdma                 | capable   | RDMA capable PCI device(s) detected
 
 `<device label>` is composed of raw PCI IDs, separated by underscores.
 The set of fields used in `<device label>` is configurable, valid fields being

--- a/nfd-worker.conf.example
+++ b/nfd-worker.conf.example
@@ -44,3 +44,5 @@
 #      - "device"
 #      - "subsystem_vendor"
 #      - "subsystem_device"
+#    rdmaCapableDevices:
+#      - "15b3:.*"

--- a/source/pci/pci.go
+++ b/source/pci/pci.go
@@ -40,6 +40,10 @@ var Config = NFDConfig{
 
 var devLabelAttrs = []string{"class", "vendor", "device", "subsystem_vendor", "subsystem_device"}
 
+var rdmaCapablePCIVendorIds = []string{"15b3"}
+
+const rdmaFeatureCapable = "rdma.capable"
+
 // Implement FeatureSource interface
 type Source struct{}
 
@@ -99,6 +103,10 @@ func (s Source) Discover() (source.Features, error) {
 		}
 	}
 
+	if hasRdmaCapableDevice(devs) {
+		features[rdmaFeatureCapable] = true
+	}
+
 	return features, nil
 }
 
@@ -145,4 +153,26 @@ func detectPci() (map[string][]pciDeviceInfo, error) {
 	}
 
 	return devInfo, nil
+}
+
+// Check if the system has a remote DMA capable device.
+// Use PCI vendor ID for now.
+func hasRdmaCapableDevice(devs map[string][]pciDeviceInfo) bool {
+	for _, classDevs := range devs {
+		for _, dev := range classDevs {
+			if contains(rdmaCapablePCIVendorIds, dev["vendor"]) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func contains(slice []string, elem string) bool {
+	for _, e := range slice {
+		if e == elem {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This commit adds a new PCI feature : rdma.capable
If present it means that the node has RDMA capable PCI devices.

This can be used by other entities (e.g operators) to trigger loading
of RDMA modules on the node.

Currently we determine that by comparing the PCI vendor ID.
This can later be adapted to accomodate other vendors/devices.