### PR TITLE
source/cpu: support 'false' status of cpu-pstate.turbo

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ such as restricting discovered features with the --label-whitelist option._
 | cpuid                   | &lt;cpuid flag&gt; | CPU capability is supported
 | hardware_multithreading | <br>               | Hardware multithreading, such as Intel HTT, enabled (number of logical CPUs is greater than physical CPUs)
 | power                   | sst_bf.enabled     | Intel SST-BF ([Intel Speed Select Technology][intel-sst] - Base frequency) enabled
-| [pstate][intel-pstate]  | turbo              | Turbo frequencies are enabled in Intel pstate driver
+| [pstate][intel-pstate]  | turbo              | Set to 'true' if turbo frequencies are enabled in Intel pstate driver, set to 'false' if they have been disabled.
 | [rdt][intel-rdt]        | RDTMON             | Intel RDT Monitoring Technology
 | <br>                    | RDTCMT             | Intel Cache Monitoring (CMT)
 | <br>                    | RDTMBM             | Intel Memory Bandwidth Monitoring (MBM)

--- a/source/cpu/cpu.go
+++ b/source/cpu/cpu.go
@@ -116,12 +116,14 @@ func (s Source) Discover() (source.Features, error) {
 		}
 	}
 
-	// Detect turbo boost
-	turbo, err := turboEnabled()
+	// Detect pstate features
+	pstate, err := detectPstate()
 	if err != nil {
 		log.Printf("ERROR: %v", err)
-	} else if turbo {
-		features["pstate.turbo"] = true
+	} else {
+		for k, v := range pstate {
+			features["pstate."+k] = v
+		}
 	}
 
 	// Detect RDT features

--- a/source/cpu/pstate.go
+++ b/source/cpu/pstate.go
@@ -22,22 +22,23 @@ import (
 	"runtime"
 )
 
-// Discover returns feature names for p-state related features such as turbo boost.
-func turboEnabled() (bool, error) {
+// Discover p-state related features such as turbo boost.
+func detectPstate() (map[string]string, error) {
 	// On other platforms, the frequency boost mechanism is software-based.
 	// So skip pstate detection on other architectures.
 	if runtime.GOARCH != "amd64" && runtime.GOARCH != "386" {
-		return false, nil
+		return nil, nil
 	}
 
 	// Only looking for turbo boost for now...
 	bytes, err := ioutil.ReadFile("/sys/devices/system/cpu/intel_pstate/no_turbo")
 	if err != nil {
-		return false, fmt.Errorf("can't detect whether turbo boost is enabled: %s", err.Error())
+		return nil, fmt.Errorf("can't detect whether turbo boost is enabled: %s", err.Error())
 	}
+	features := map[string]string{"turbo": "false"}
 	if bytes[0] == byte('0') {
-		return true, nil
+		features["turbo"] = "true"
 	}
 
-	return false, nil
+	return features, nil
 }


### PR DESCRIPTION
Some workloads may benefit from Intel Turbo Boost technology being
disabled. This patch sets the
'feature.node.kubernetes.io/cpu-pstate.turbo' label to 'false' if we can
detect that it has been disabled. If detection fails no label is
published.