### PR TITLE
Add nfd namespace to the daemonset-combined deployment template

### DIFF
--- a/nfd-daemonset-combined.yaml.template
+++ b/nfd-daemonset-combined.yaml.template
@@ -2,6 +2,11 @@
 # same pod.
 #
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: node-feature-discovery # NFD namespace
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: nfd-master


### PR DESCRIPTION
Without this the nfd namespace is not created and the deployment may
fail.