### PR TITLE
vendor: update klauspost/cpuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/json-iterator/go v1.1.7 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
-	github.com/klauspost/cpuid v1.2.2-0.20191106130511-5a626f7029c9
+	github.com/klauspost/cpuid v1.2.3
 	github.com/munnerz/goautoneg v0.0.0-20190414153302-2ae31c8b6b30 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/onsi/ginkgo v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -198,6 +198,8 @@ github.com/klauspost/cpuid v1.2.0 h1:NMpwD2G9JSFOE1/TJjGSo5zG7Yb2bTe7eq1jH+irmeE
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.2.2-0.20191106130511-5a626f7029c9 h1:bBK4GTyzBQHZWkqWwl5j2Wh2GECowFzo0om/r98FCII=
 github.com/klauspost/cpuid v1.2.2-0.20191106130511-5a626f7029c9/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/klauspost/cpuid v1.2.3 h1:CCtW0xUnWGVINKvE/WWOYKdsPV6mawAtvQuSl8guwQs=
+github.com/klauspost/cpuid v1.2.3/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/source/cpu/cpu.go
+++ b/source/cpu/cpu.go
@@ -60,6 +60,7 @@ var Config = NFDConfig{
 			"RDSEED",
 			"RDTSCP",
 			"SGX",
+			"SGXLC",
 			"SSE",
 			"SSE2",
 			"SSE3",


### PR DESCRIPTION
Update cpuid from v1.2.2 to v1.2.3. Brings in SGX improvements and
CPUID leaf 7 feature detection (VBMI2, VPOPCNTDQ, GFNI, VAES,
AVX512BITALG, VPCLMULQDQ, AVX512BF16, AVX512VP2INTERSECT).

Signed-off-by: Antti Kervinen <antti.kervinen@intel.com>