### PR TITLE
Update go version in Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - "1.12"
+  - "1.13.5"
 
 env:
   global:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build node feature discovery
-FROM golang:1.12 as builder
+FROM golang:1.13.5 as builder
 
 # Get (cache) deps in a separate layer
 COPY go.mod go.sum /go/node-feature-discovery/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/node-feature-discovery
 
-go 1.12
+go 1.13
 
 require (
 	github.com/docker/distribution v2.7.1+incompatible


### PR DESCRIPTION
Update go version in Docker build image to v1.13.5

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>