### PR TITLE
pci: add sriov.capable attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,9 +289,10 @@ See [configuration options](#configuration-options) for more information.
 
 ### PCI Features
 
-| Feature              | Attribute | Description                               |
-| -------------------- | --------- | ----------------------------------------- |
-| &lt;device label&gt; | present   | PCI device is detected
+| Feature              | Attribute     | Description                               |
+| -------------------- | ------------- | ----------------------------------------- |
+| &lt;device label&gt; | present       | PCI device is detected
+| &lt;device label&gt; | sriov.capable | [Single Root Input/Output Virtualization][sriov] (SR-IOV) enabled PCI device present
 
 `<device label>` is composed of raw PCI IDs, separated by underscores.
 The set of fields used in `<device label>` is configurable, valid fields being


### PR DESCRIPTION
SR-IOV is a PCI attribute and also non-NIC PCI devices can have it. Therefore,
it is useful to label all PCI devices with that capability.

After this commit the following labels for Intel NICs are overlapping:
```
feature.node.kubernetes.io/pci-0200_8086.sriov.capable=true
feature.node.kubernetes.io/network-sriov.capable=true
```
Fixes: #286

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>