### PR TITLE
source/cpu: detect SST-CP

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ such as restricting discovered features with the --label-whitelist option._
 | cpuid                   | &lt;cpuid flag&gt; | CPU capability is supported
 | hardware_multithreading | <br>               | Hardware multithreading, such as Intel HTT, enabled (number of logical CPUs is greater than physical CPUs)
 | power                   | sst_bf.enabled     | Intel SST-BF ([Intel Speed Select Technology][intel-sst] - Base frequency) enabled
+|                         | sst_cp.enabled     | Intel SST-CP  ([Intel Speed Select Technology][intel-sst] - Core Power) enabled
 | [pstate][intel-pstate]  | turbo              | Set to 'true' if turbo frequencies are enabled in Intel pstate driver, set to 'false' if they have been disabled.
 | [rdt][intel-rdt]        | RDTMON             | Intel RDT Monitoring Technology
 | <br>                    | RDTCMT             | Intel Cache Monitoring (CMT)

--- a/source/cpu/cpu.go
+++ b/source/cpu/cpu.go
@@ -109,6 +109,14 @@ func (s Source) Discover() (source.Features, error) {
 		features["power.sst_bf.enabled"] = true
 	}
 
+	// Check SST-CP
+	found, err = discoverSSTCP()
+	if err != nil {
+		log.Printf("ERROR: failed to detect SST-CP: %v", err)
+	} else if found {
+		features["power.sst_cp.enabled"] = true
+	}
+
 	// Detect CPUID
 	cpuidFlags := getCpuidFlags()
 	for _, f := range cpuidFlags {

--- a/source/cpu/power_stub.go
+++ b/source/cpu/power_stub.go
@@ -21,3 +21,7 @@ package cpu
 func discoverSSTBF() (bool, error) {
 	return false, nil
 }
+
+func discoverSSTCP() (bool, error) {
+	return false, nil
+}


### PR DESCRIPTION
Detection for Intel SST-CP ( Speed Select Technology - Core Power )

Adds the following feature label:

> feature.node.kubernetes.io/cpu-power.sst_cp.enabled=true

