### PR TITLE
version: allow undefined version

### DIFF
--- a/cmd/nfd-master/main.go
+++ b/cmd/nfd-master/main.go
@@ -35,8 +35,8 @@ const (
 
 func main() {
 	// Assert that the version is known
-	if version.Get() == "undefined" {
-		log.Fatalf("version not set! Set -ldflags \"-X sigs.k8s.io/node-feature-discovery/pkg/version.version=`git describe --tags --dirty --always`\" during build or run.")
+	if version.Undefined() {
+		log.Print("WARNING: version not set! Set -ldflags \"-X sigs.k8s.io/node-feature-discovery/pkg/version.version=`git describe --tags --dirty --always`\" during build or run.")
 	}
 
 	// Parse command-line arguments.

--- a/cmd/nfd-worker/main.go
+++ b/cmd/nfd-worker/main.go
@@ -34,8 +34,8 @@ const (
 
 func main() {
 	// Assert that the version is known
-	if version.Get() == "undefined" {
-		log.Fatalf("version not set! Set -ldflags \"-X sigs.k8s.io/node-feature-discovery/pkg/version.version=`git describe --tags --dirty --always`\" during build or run.")
+	if version.Undefined() {
+		log.Printf("WARNING: version not set! Set -ldflags \"-X sigs.k8s.io/node-feature-discovery/pkg/version.version=`git describe --tags --dirty --always`\" during build or run.")
 	}
 
 	// Parse command-line arguments.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,9 +16,17 @@ limitations under the License.
 
 package version
 
-// Must not be const, supposed to be set using ldflags at build time
-var version = "undefined"
+const undefinedVersion string = "undefined"
 
+// Must not be const, supposed to be set using ldflags at build time
+var version = undefinedVersion
+
+// Get returns the version as a string
 func Get() string {
 	return version
+}
+
+// Undefined returns if version is at it's default value
+func Undefined() bool {
+	return version == undefinedVersion
 }


### PR DESCRIPTION
Just print a warning instead of exiting with an error if no version has
been specified at build-time. This was pointless and just annoying at
development time when doing builds with go directly.