### PR TITLE
source/system: do not publish empty version labels

### DIFF
--- a/source/system/system.go
+++ b/source/system/system.go
@@ -51,7 +51,9 @@ func (s Source) Discover() (source.Features, error) {
 				if key == "VERSION_ID" {
 					versionComponents := splitVersion(value)
 					for subKey, subValue := range versionComponents {
-						features[feature+"."+subKey] = subValue
+						if subValue != "" {
+							features[feature+"."+subKey] = subValue
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Do not publish non-existing version components as empty labels.

Reading the description of #297 I realised that it would probably be better to not publish the missing version components as labels with empty values.