### PR TITLE
nfd-worker: fix --label-whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ nfd-master.
                                   has been enabled.
   --no-publish                    Do not publish feature labels
   --label-whitelist=<pattern>     Regular expression to filter label names to
-                                  publish to the Kubernetes API server. [Default: ]
+                                  publish to the Kubernetes API server.
+                                  NB: the label namespace is omitted i.e. the filter
+                                  is only applied to the name part after '/'.
+                                  [Default: ]
   --extra-label-ns=<list>         Comma separated list of allowed extra label namespaces
                                   [Default: ]
   --resource-labels=<list>        Comma separated list of labels to be exposed as extended resources.
@@ -129,11 +132,14 @@ nfd-worker.
                               in testing
                               [Default: ]
   --sources=<sources>         Comma separated list of feature sources.
-                              [Default: cpu,iommu,kernel,local,memory,network,pci,storage,system,usb]
+                              [Default: cpu,custom,iommu,kernel,local,memory,network,pci,storage,system,usb]
   --no-publish                Do not publish discovered features to the
                               cluster-local Kubernetes API server.
   --label-whitelist=<pattern> Regular expression to filter label names to
-                              publish to the Kubernetes API server. [Default: ]
+                              publish to the Kubernetes API server.
+                              NB: the label namespace is omitted i.e. the filter
+                              is only applied to the name part after '/'.
+                              [Default: ]
   --oneshot                   Label once and exit.
   --sleep-interval=<seconds>  Time to sleep between re-labeling. Non-positive
                               value implies no re-labeling (i.e. infinite

--- a/cmd/nfd-master/main.go
+++ b/cmd/nfd-master/main.go
@@ -85,7 +85,10 @@ func argsParse(argv []string) (master.Args, error) {
                                   has been enabled.
   --no-publish                    Do not publish feature labels
   --label-whitelist=<pattern>     Regular expression to filter label names to
-                                  publish to the Kubernetes API server. [Default: ]
+                                  publish to the Kubernetes API server.
+                                  NB: the label namespace is omitted i.e. the filter
+                                  is only applied to the name part after '/'.
+                                  [Default: ]
   --extra-label-ns=<list>         Comma separated list of allowed extra label namespaces
                                   [Default: ]
   --resource-labels=<list>        Comma separated list of labels to be exposed as extended resources.

--- a/cmd/nfd-worker/main.go
+++ b/cmd/nfd-worker/main.go
@@ -95,7 +95,10 @@ func argsParse(argv []string) (worker.Args, error) {
   --no-publish                Do not publish discovered features to the
                               cluster-local Kubernetes API server.
   --label-whitelist=<pattern> Regular expression to filter label names to
-                              publish to the Kubernetes API server. [Default: ]
+                              publish to the Kubernetes API server.
+                              NB: the label namespace is omitted i.e. the filter
+                              is only applied to the name part after '/'.
+                              [Default: ]
   --oneshot                   Label once and exit.
   --sleep-interval=<seconds>  Time to sleep between re-labeling. Non-positive
                               value implies no re-labeling (i.e. infinite


### PR DESCRIPTION
After commenting #306 I looked into the code and was not happy what I found (with my own work).

Unify handling of --label-whitelist in nfd-worker and nfd-master. That is,
in nfd-worker, apply the regexp filter on non-namespaced part of the
label name.

Brief history:
1. Originally the whitelist regexp was applied on the full namespaced
   label name (that would be e.g.
   'feature.node.kubernetes.io/cpu-cpuid.AVX' in the current nfd version)

2. Commit 81752b2d changed the behavior so that the regexp was applied
   on the non-namespaced part (that would be `cpu-cpuid.AVX`)

3. Commit 40918827 added support for custom label namespaces. With this
   change, the label whitelist handling diverged between nfd-worker and
   nfd-master. In nfd-master the whitelist regexp is always applied on
   the non-namespaced label name. However, in nfd-worker the whitelist
   handling is two-fold (and inconsistent): for labels in the standard
   nfd namespace regexp is applied on the non-namespaced part (e.g.
   `cpu-cpuid.AVX`, but, for labels in custom namespaces the regexp is
   applied on the full name (e.g. `example.com/my-feature`).

This patch changes nfd-worker to behave similarly to nfd-master. The
namespace part is now always omitted, which should be easier for the
users to comprehend.

Also, fixes a bug in the label name prefixing so that the name of the
feature source is not prefixed into labels with custom label namespace
(effectively mangling the intended namespace). For example, previously a
'example.com/feature' label from the 'custom' feature source would be
prefixed with the source name, mangling it to
'custom-example.com/feature'.