### PR TITLE
Proposal kernel.go: Replace forbidden symbols and check format

### DIFF
--- a/source/kernel/kernel.go
+++ b/source/kernel/kernel.go
@@ -97,6 +97,11 @@ func parseVersion() (map[string]string, error) {
 	}
 
 	full := strings.TrimSpace(string(raw))
+
+	// Replace forbidden symbols
+	fullRegex := regexp.MustCompile("[^-A-Za-z0-9_.]")
+	full = fullRegex.ReplaceAllString(full, "_")
+
 	version["full"] = full
 
 	// Regexp for parsing version components


### PR DESCRIPTION
Some Kernel versions include symbols such as "+". Yocto L4T kernel is
an example of this behaviour. To fix this error the symbols are replaced
by an underscore.

Signed-off-by: Pablo Rodriguez <paroque28@gmail.com>

This is associated with issue:
https://github.com/kubernetes-sigs/node-feature-discovery/issues/308