### PR TITLE
Add support for USB device discovery

### DIFF
--- a/cmd/nfd-worker/main.go
+++ b/cmd/nfd-worker/main.go
@@ -91,7 +91,7 @@ func argsParse(argv []string) (worker.Args, error) {
                               in testing
                               [Default: ]
   --sources=<sources>         Comma separated list of feature sources.
-                              [Default: cpu,custom,iommu,kernel,local,memory,network,pci,storage,system]
+                              [Default: cpu,custom,iommu,kernel,local,memory,network,pci,storage,system,usb]
   --no-publish                Do not publish discovered features to the
                               cluster-local Kubernetes API server.
   --label-whitelist=<pattern> Regular expression to filter label names to

--- a/cmd/nfd-worker/main_test.go
+++ b/cmd/nfd-worker/main_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-var allSources = []string{"cpu", "custom", "iommu", "kernel", "local", "memory", "network", "pci", "storage", "system"}
+var allSources = []string{"cpu", "custom", "iommu", "kernel", "local", "memory", "network", "pci", "storage", "system", "usb"}
 
 func TestArgsParse(t *testing.T) {
 	Convey("When parsing command line arguments", t, func() {

--- a/nfd-worker.conf.example
+++ b/nfd-worker.conf.example
@@ -44,6 +44,16 @@
 #      - "device"
 #      - "subsystem_vendor"
 #      - "subsystem_device"
+#  usb:
+#    deviceClassWhitelist:
+#      - "0e"
+#      - "ef"
+#      - "fe"
+#      - "ff"
+#    deviceLabelFields:
+#      - "class"
+#      - "vendor"
+#      - "device"
 #  custom:
 #    - name: "my.kernel.feature"
 #      matchOn:
@@ -57,6 +67,16 @@
 #        - pciId :
 #            vendor: ["8086"]
 #            device: ["1000", "1100"]
+#    - name: "my.usb.feature"
+#      matchOn:
+#        - usbId:
+#          class: ["ff"]
+#          vendor: ["03e7"]
+#          device: ["2485"]
+#        - usbId:
+#          class: ["fe"]
+#          vendor: ["1a6e"]
+#          device: ["089a"]
 #    - name: "my.combined.feature"
 #      matchOn:
 #        - pciId:

--- a/pkg/nfd-worker/nfd-worker.go
+++ b/pkg/nfd-worker/nfd-worker.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/node-feature-discovery/source/pci"
 	"sigs.k8s.io/node-feature-discovery/source/storage"
 	"sigs.k8s.io/node-feature-discovery/source/system"
+	"sigs.k8s.io/node-feature-discovery/source/usb"
 	"sigs.k8s.io/yaml"
 )
 
@@ -62,6 +63,7 @@ type NFDConfig struct {
 		Cpu    *cpu.NFDConfig    `json:"cpu,omitempty"`
 		Kernel *kernel.NFDConfig `json:"kernel,omitempty"`
 		Pci    *pci.NFDConfig    `json:"pci,omitempty"`
+		Usb    *usb.NFDConfig    `json:"usb,omitempty"`
 		Custom *custom.NFDConfig `json:"custom,omitempty"`
 	} `json:"sources,omitempty"`
 }
@@ -236,6 +238,7 @@ func configParse(filepath string, overrides string) error {
 	config.Sources.Cpu = &cpu.Config
 	config.Sources.Kernel = &kernel.Config
 	config.Sources.Pci = &pci.Config
+	config.Sources.Usb = &usb.Config
 	config.Sources.Custom = &custom.Config
 
 	data, err := ioutil.ReadFile(filepath)
@@ -279,6 +282,7 @@ func configureParameters(sourcesWhiteList []string, labelWhiteListStr string) (e
 		pci.Source{},
 		storage.Source{},
 		system.Source{},
+		usb.Source{},
 		custom.Source{},
 		// local needs to be the last source so that it is able to override
 		// labels from other sources

--- a/source/custom/custom.go
+++ b/source/custom/custom.go
@@ -27,6 +27,7 @@ import (
 // Custom Features Configurations
 type MatchRule struct {
 	PciId      *rules.PciIdRule      `json:"pciId,omitempty""`
+	UsbId      *rules.UsbIdRule      `json:"usbId,omitempty""`
 	LoadedKMod *rules.LoadedKModRule `json:"loadedKMod,omitempty""`
 }
 
@@ -70,6 +71,16 @@ func (s Source) discoverFeature(feature CustomFeature) (bool, error) {
 		// PCI ID rule
 		if rule.PciId != nil {
 			match, err := rule.PciId.Match()
+			if err != nil {
+				return false, err
+			}
+			if !match {
+				continue
+			}
+		}
+		// USB ID rule
+		if rule.UsbId != nil {
+			match, err := rule.UsbId.Match()
 			if err != nil {
 				return false, err
 			}

--- a/source/custom/rules/usb_id_rule.go
+++ b/source/custom/rules/usb_id_rule.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"fmt"
+	usbutils "sigs.k8s.io/node-feature-discovery/source/internal"
+)
+
+// Rule that matches on the following USB device attributes: <class, vendor, device>
+// each device attribute will be a list elements(strings).
+// Match operation: OR will be performed per element and AND will be performed per attribute.
+// An empty attribute will not be included in the matching process.
+type UsbIdRuleInput struct {
+	Class  []string `json:"class,omitempty"`
+	Vendor []string `json:"vendor,omitempty"`
+	Device []string `json:"device,omitempty"`
+}
+
+type UsbIdRule struct {
+	UsbIdRuleInput
+}
+
+// Match USB devices on provided USB device attributes
+func (r *UsbIdRule) Match() (bool, error) {
+	devAttr := map[string]bool{}
+	for _, attr := range []string{"class", "vendor", "device"} {
+		devAttr[attr] = true
+	}
+	allDevs, err := usbutils.DetectUsb(devAttr)
+	if err != nil {
+		return false, fmt.Errorf("failed to detect USB devices: %s", err.Error())
+	}
+
+	for _, classDevs := range allDevs {
+		for _, dev := range classDevs {
+			// match rule on a single device
+			if r.matchDevOnRule(dev) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func (r *UsbIdRule) matchDevOnRule(dev usbutils.UsbDeviceInfo) bool {
+	if len(r.Class) == 0 && len(r.Vendor) == 0 && len(r.Device) == 0 {
+		return false
+	}
+
+	if len(r.Class) > 0 && !in(dev["class"], r.Class) {
+		return false
+	}
+
+	if len(r.Vendor) > 0 && !in(dev["vendor"], r.Vendor) {
+		return false
+	}
+
+	if len(r.Device) > 0 && !in(dev["device"], r.Device) {
+		return false
+	}
+
+	return true
+}
+

--- a/source/internal/pci_utils.go
+++ b/source/internal/pci_utils.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pciutils
+package busutils
 
 import (
 	"fmt"
@@ -31,7 +31,7 @@ var ExtraPciDevAttrs = []string{"sriov_totalvfs"}
 
 // Read a single PCI device attribute
 // A PCI attribute in this context, maps to the corresponding sysfs file
-func readSingleAttribute(devPath string, attrName string) (string, error) {
+func readSinglePciAttribute(devPath string, attrName string) (string, error) {
 	data, err := ioutil.ReadFile(path.Join(devPath, attrName))
 	if err != nil {
 		return "", fmt.Errorf("failed to read device attribute %s: %v", attrName, err)
@@ -48,11 +48,11 @@ func readSingleAttribute(devPath string, attrName string) (string, error) {
 }
 
 // Read information of one PCI device
-func readDevInfo(devPath string, deviceAttrSpec map[string]bool) (PciDeviceInfo, error) {
+func readPciDevInfo(devPath string, deviceAttrSpec map[string]bool) (PciDeviceInfo, error) {
 	info := PciDeviceInfo{}
 
 	for attr, must := range deviceAttrSpec {
-		attrVal, err := readSingleAttribute(devPath, attr)
+		attrVal, err := readSinglePciAttribute(devPath, attr)
 		if err != nil {
 			if must {
 				return info, fmt.Errorf("Failed to read device %s: %s", attr, err)
@@ -85,7 +85,7 @@ func DetectPci(deviceAttrSpec map[string]bool) (map[string][]PciDeviceInfo, erro
 
 	// Iterate over devices
 	for _, device := range devices {
-		info, err := readDevInfo(path.Join(basePath, device.Name()), deviceAttrSpec)
+		info, err := readPciDevInfo(path.Join(basePath, device.Name()), deviceAttrSpec)
 		if err != nil {
 			log.Print(err)
 			continue

--- a/source/internal/usb_utils.go
+++ b/source/internal/usb_utils.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package busutils
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+type UsbDeviceInfo map[string]string
+type UsbClassMap map[string]UsbDeviceInfo
+
+var DefaultUsbDevAttrs = []string{"class", "vendor", "device"}
+
+// The USB device sysfs files do not have terribly user friendly names, map
+// these for consistency with the PCI matcher.
+var devAttrFileMap = map[string]string{
+	"class":  "bDeviceClass",
+	"device": "idProduct",
+	"vendor": "idVendor",
+}
+
+func readSingleUsbSysfsAttribute(path string) (string, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read device attribute %s: %v", filepath.Base(path), err)
+	}
+
+	attrVal := strings.TrimSpace(string(data))
+
+	return attrVal, nil
+}
+
+// Read a single USB device attribute
+// A USB attribute in this context, maps to the corresponding sysfs file
+func readSingleUsbAttribute(devPath string, attrName string) (string, error) {
+	return readSingleUsbSysfsAttribute(path.Join(devPath, devAttrFileMap[attrName]))
+}
+
+// Read information of one USB device
+func readUsbDevInfo(devPath string, deviceAttrSpec map[string]bool) (UsbClassMap, error) {
+	classmap := UsbClassMap{}
+	info := UsbDeviceInfo{}
+
+	for attr, _ := range deviceAttrSpec {
+		attrVal, _ := readSingleUsbAttribute(devPath, attr)
+		if len(attrVal) > 0 {
+			info[attr] = attrVal
+		}
+	}
+
+	// USB devices encode their class information either at the device or the interface level. If the device class
+	// is set, return as-is.
+	if info["class"] != "00" {
+		classmap[info["class"]] = info
+	} else {
+		// Otherwise, if a 00 is presented at the device level, descend to the interface level.
+		interfaces, err := filepath.Glob(devPath + "/*/bInterfaceClass")
+		if err != nil {
+			return classmap, err
+		}
+
+		// A device may, notably, have multiple interfaces with mixed classes, so we create a unique device for each
+		// unique interface class.
+		for _, intf := range interfaces {
+			// Determine the interface class
+			attrVal, err := readSingleUsbSysfsAttribute(intf)
+			if err != nil {
+				return classmap, err
+			}
+
+			attr := UsbDeviceInfo{}
+			for k, v := range info {
+				attr[k] = v
+			}
+
+			attr["class"] = attrVal
+			classmap[attrVal] = attr
+		}
+	}
+
+	return classmap, nil
+}
+
+// List available USB devices and retrieve device attributes.
+// deviceAttrSpec is a map which specifies which attributes to retrieve.
+// a false value for a specific attribute marks the attribute as optional.
+// a true value for a specific attribute marks the attribute as mandatory.
+// "class" attribute is considered mandatory.
+// DetectUsb() will fail if the retrieval of a mandatory attribute fails.
+func DetectUsb(deviceAttrSpec map[string]bool) (map[string][]UsbDeviceInfo, error) {
+	// Unlike PCI, the USB sysfs interface includes entries not just for
+	// devices. We work around this by globbing anything that includes a
+	// valid product ID.
+	const devicePath = "/sys/bus/usb/devices/*/idProduct"
+	devInfo := make(map[string][]UsbDeviceInfo)
+
+	devices, err := filepath.Glob(devicePath)
+	if err != nil {
+		return nil, err
+	}
+
+	// "class" is a mandatory attribute, inject it to spec if needed.
+	deviceAttrSpec["class"] = true
+
+	// Iterate over devices
+	for _, device := range devices {
+		devMap, err := readUsbDevInfo(filepath.Dir(device), deviceAttrSpec)
+		if err != nil {
+			log.Print(err)
+			continue
+		}
+
+		for class, info := range devMap {
+			devInfo[class] = append(devInfo[class], info)
+		}
+	}
+
+	return devInfo, nil
+}

--- a/source/usb/usb.go
+++ b/source/usb/usb.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pci
+package usb
 
 import (
 	"fmt"
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"sigs.k8s.io/node-feature-discovery/source"
-	pciutils "sigs.k8s.io/node-feature-discovery/source/internal"
+	usbutils "sigs.k8s.io/node-feature-discovery/source/internal"
 )
 
 type NFDConfig struct {
@@ -31,15 +31,18 @@ type NFDConfig struct {
 }
 
 var Config = NFDConfig{
-	DeviceClassWhitelist: []string{"03", "0b40", "12"},
-	DeviceLabelFields:    []string{"class", "vendor"},
+	// Whitelist specific USB classes: https://www.usb.org/defined-class-codes
+	// By default these include classes where different accelerators are typically mapped:
+	// Video (0e), Miscellaneous (ef), Application Specific (fe), and Vendor Specific (ff).
+	DeviceClassWhitelist: []string{"0e", "ef", "fe", "ff"},
+	DeviceLabelFields:    []string{"class", "vendor", "device"},
 }
 
 // Implement FeatureSource interface
 type Source struct{}
 
 // Return name of the feature source
-func (s Source) Name() string { return "pci" }
+func (s Source) Name() string { return "usb" }
 
 // Discover features
 func (s Source) Discover() (source.Features, error) {
@@ -52,7 +55,7 @@ func (s Source) Discover() (source.Features, error) {
 		configLabelFields[field] = true
 	}
 
-	for _, attr := range pciutils.DefaultPciDevAttrs {
+	for _, attr := range usbutils.DefaultUsbDevAttrs {
 		if _, ok := configLabelFields[attr]; ok {
 			deviceLabelFields = append(deviceLabelFields, attr)
 			delete(configLabelFields, attr)
@@ -67,22 +70,18 @@ func (s Source) Discover() (source.Features, error) {
 	}
 	if len(deviceLabelFields) == 0 {
 		log.Printf("WARNING: no valid fields in deviceLabelFields defined, using the defaults")
-		deviceLabelFields = []string{"class", "vendor"}
+		deviceLabelFields = []string{"vendor", "device"}
 	}
 
-	// Read extraDevAttrs + configured or default labels. Attributes
-	// set to 'true' are considered must-have.
+	// Read configured or default labels. Attributes set to 'true' are considered must-have.
 	deviceAttrs := map[string]bool{}
-	for _, label := range pciutils.ExtraPciDevAttrs {
-		deviceAttrs[label] = false
-	}
 	for _, label := range deviceLabelFields {
 		deviceAttrs[label] = true
 	}
 
-	devs, err := pciutils.DetectPci(deviceAttrs)
+	devs, err := usbutils.DetectUsb(deviceAttrs)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to detect PCI devices: %s", err.Error())
+		return nil, fmt.Errorf("Failed to detect USB devices: %s", err.Error())
 	}
 
 	// Iterate over all device classes
@@ -98,10 +97,6 @@ func (s Source) Discover() (source.Features, error) {
 						}
 					}
 					features[devLabel+".present"] = true
-
-					if _, ok := dev["sriov_totalvfs"]; ok {
-						features[devLabel+".sriov.capable"] = true
-					}
 				}
 			}
 		}


### PR DESCRIPTION
This builds on the PCI support to enable the discovery of USB devices. While we allow for class-based discovery, many USB devices shift this to the interface level instead and have meaningless class values. The vendor and device IDs, therefore, are the main items of interest. This is primarily useful for the discovery of Edge-based heterogeneous accelerators that are connected via USB, such as the Coral USB Accelerator and the Intel NCS2 - our main motivation for this work.