### PR TITLE
source/network: run discovery under /host-sys

### DIFF
--- a/nfd-daemonset-combined.yaml.template
+++ b/nfd-daemonset-combined.yaml.template
@@ -56,7 +56,6 @@ spec:
         app: nfd
     spec:
       serviceAccount: nfd-master
-      hostNetwork: true
       containers:
         - env:
           - name: NODE_NAME

--- a/nfd-worker-daemonset.yaml.template
+++ b/nfd-worker-daemonset.yaml.template
@@ -14,7 +14,6 @@ spec:
       labels:
         app: nfd-worker
     spec:
-      hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - env:

--- a/nfd-worker-job.yaml.template
+++ b/nfd-worker-job.yaml.template
@@ -13,7 +13,6 @@ spec:
       labels:
         app: node-feature-discovery
     spec:
-      hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
The default deployment mounts /sys from the host under /host-sys so
let's use that. No need to use hostNetwork after that so drop it from
the worker deployment templates.