### PR TITLE
nfd-master: implement --prune flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,20 @@ Command line flags of nfd-master:
 ```
 $ docker run --rm <NFD_CONTAINER_IMAGE> nfd-master --help
 ...
-nfd-master.
-
-  Usage:
-  nfd-master [--no-publish] [--label-whitelist=<pattern>] [--port=<port>]
+Usage:
+  nfd-master [--prune] [--no-publish] [--label-whitelist=<pattern>] [--port=<port>]
      [--ca-file=<path>] [--cert-file=<path>] [--key-file=<path>]
      [--verify-node-name] [--extra-label-ns=<list>] [--resource-labels=<list>]
+     [--kubeconfig=<path>]
   nfd-master -h | --help
   nfd-master --version
 
   Options:
   -h --help                       Show this screen.
   --version                       Output version and exit.
+  --prune                         Prune all NFD related attributes from all nodes
+                                  of the cluster and exit.
+  --kubeconfig=<path>             Kubeconfig to use [Default: ]
   --port=<port>                   Port on which to listen for connections.
                                   [Default: 8080]
   --ca-file=<path>                Root certificate for verifying connections

--- a/cmd/nfd-master/main.go
+++ b/cmd/nfd-master/main.go
@@ -63,7 +63,7 @@ func argsParse(argv []string) (master.Args, error) {
 	usage := fmt.Sprintf(`%s.
 
   Usage:
-  %s [--no-publish] [--label-whitelist=<pattern>] [--port=<port>]
+  %s [--prune] [--no-publish] [--label-whitelist=<pattern>] [--port=<port>]
      [--ca-file=<path>] [--cert-file=<path>] [--key-file=<path>]
      [--verify-node-name] [--extra-label-ns=<list>] [--resource-labels=<list>]
   %s -h | --help
@@ -72,6 +72,8 @@ func argsParse(argv []string) (master.Args, error) {
   Options:
   -h --help                       Show this screen.
   --version                       Output version and exit.
+  --prune                         Prune all NFD related attributes from all nodes
+                                  of the cluster and exit.
   --port=<port>                   Port on which to listen for connections.
                                   [Default: 8080]
   --ca-file=<path>                Root certificate for verifying connections
@@ -119,6 +121,7 @@ func argsParse(argv []string) (master.Args, error) {
 	args.VerifyNodeName = arguments["--verify-node-name"].(bool)
 	args.ExtraLabelNs = strings.Split(arguments["--extra-label-ns"].(string), ",")
 	args.ResourceLabels = strings.Split(arguments["--resource-labels"].(string), ",")
+	args.Prune = arguments["--prune"].(bool)
 
 	return args, nil
 }

--- a/cmd/nfd-master/main.go
+++ b/cmd/nfd-master/main.go
@@ -66,6 +66,7 @@ func argsParse(argv []string) (master.Args, error) {
   %s [--prune] [--no-publish] [--label-whitelist=<pattern>] [--port=<port>]
      [--ca-file=<path>] [--cert-file=<path>] [--key-file=<path>]
      [--verify-node-name] [--extra-label-ns=<list>] [--resource-labels=<list>]
+     [--kubeconfig=<path>]
   %s -h | --help
   %s --version
 
@@ -73,6 +74,8 @@ func argsParse(argv []string) (master.Args, error) {
   -h --help                       Show this screen.
   --version                       Output version and exit.
   --prune                         Prune all NFD related attributes from all nodes
+                                  of the cluster and exit.
+  --kubeconfig=<path>             Kubeconfig to use [Default: ]
                                   of the cluster and exit.
   --port=<port>                   Port on which to listen for connections.
                                   [Default: 8080]
@@ -122,6 +125,7 @@ func argsParse(argv []string) (master.Args, error) {
 	args.ExtraLabelNs = strings.Split(arguments["--extra-label-ns"].(string), ",")
 	args.ResourceLabels = strings.Split(arguments["--resource-labels"].(string), ",")
 	args.Prune = arguments["--prune"].(bool)
+	args.Kubeconfig = arguments["--kubeconfig"].(string)
 
 	return args, nil
 }

--- a/pkg/apihelper/apihelpers.go
+++ b/pkg/apihelper/apihelpers.go
@@ -29,6 +29,9 @@ type APIHelpers interface {
 	// GetNode returns the Kubernetes node on which this container is running.
 	GetNode(*k8sclient.Clientset, string) (*api.Node, error)
 
+	// GetNodes returns all the nodes in the cluster
+	GetNodes(*k8sclient.Clientset) (*api.NodeList, error)
+
 	// UpdateNode updates the node via the API server using a client.
 	UpdateNode(*k8sclient.Clientset, *api.Node) error
 

--- a/pkg/apihelper/k8shelpers.go
+++ b/pkg/apihelper/k8shelpers.go
@@ -24,18 +24,28 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	k8sclient "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Implements APIHelpers
 type K8sHelpers struct {
+	Kubeconfig string
 }
 
 func (h K8sHelpers) GetClient() (*k8sclient.Clientset, error) {
 	// Set up an in-cluster K8S client.
-	config, err := restclient.InClusterConfig()
+	var config *restclient.Config
+	var err error
+
+	if h.Kubeconfig == "" {
+		config, err = restclient.InClusterConfig()
+	} else {
+		config, err = clientcmd.BuildConfigFromFlags("", h.Kubeconfig)
+	}
 	if err != nil {
 		return nil, err
 	}
+
 	clientset, err := k8sclient.NewForConfig(config)
 	if err != nil {
 		return nil, err

--- a/pkg/apihelper/k8shelpers.go
+++ b/pkg/apihelper/k8shelpers.go
@@ -53,6 +53,10 @@ func (h K8sHelpers) GetNode(cli *k8sclient.Clientset, nodeName string) (*api.Nod
 	return node, nil
 }
 
+func (h K8sHelpers) GetNodes(cli *k8sclient.Clientset) (*api.NodeList, error) {
+	return cli.CoreV1().Nodes().List(meta_v1.ListOptions{})
+}
+
 func (h K8sHelpers) UpdateNode(c *k8sclient.Clientset, n *api.Node) error {
 	// Send the updated node to the apiserver.
 	_, err := c.CoreV1().Nodes().Update(n)

--- a/pkg/apihelper/mock_APIHelpers.go
+++ b/pkg/apihelper/mock_APIHelpers.go
@@ -62,6 +62,29 @@ func (_m *MockAPIHelpers) GetNode(_a0 *kubernetes.Clientset, _a1 string) (*v1.No
 	return r0, r1
 }
 
+// GetNodes provides a mock function with given fields: _a0
+func (_m *MockAPIHelpers) GetNodes(_a0 *kubernetes.Clientset) (*v1.NodeList, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *v1.NodeList
+	if rf, ok := ret.Get(0).(func(*kubernetes.Clientset) *v1.NodeList); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1.NodeList)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*kubernetes.Clientset) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // PatchStatus provides a mock function with given fields: _a0, _a1, _a2
 func (_m *MockAPIHelpers) PatchStatus(_a0 *kubernetes.Clientset, _a1 string, _a2 interface{}) error {
 	ret := _m.Called(_a0, _a1, _a2)

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -332,8 +332,9 @@ func (s *labelerServer) SetLabels(c context.Context, r *pb.SetLabelsRequest) (*p
 	return &pb.SetLabelsReply{}, nil
 }
 
-// advertiseFeatureLabels advertises the feature labels to a Kubernetes node
-// via the API server.
+// updateNodeFeatures ensures the Kubernetes node object is up to date,
+// creating new labels and extended resources where necessary and removing
+// outdated ones. Also updates the corresponding annotations.
 func updateNodeFeatures(helper apihelper.APIHelpers, nodeName string, labels Labels, annotations Annotations, extendedResources ExtendedResources) error {
 	cli, err := helper.GetClient()
 	if err != nil {

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -70,6 +70,7 @@ type Args struct {
 	CertFile       string
 	ExtraLabelNs   []string
 	KeyFile        string
+	Kubeconfig     string
 	LabelWhiteList *regexp.Regexp
 	NoPublish      bool
 	Port           int
@@ -124,7 +125,7 @@ func NewNfdMaster(args Args) (NfdMaster, error) {
 	}
 
 	// Initialize Kubernetes API helpers
-	nfd.apihelper = apihelper.K8sHelpers{}
+	nfd.apihelper = apihelper.K8sHelpers{Kubeconfig: args.Kubeconfig}
 
 	return nfd, nil
 }


### PR DESCRIPTION
A new sub-command like flag for cleaning up a cluster. When `--prune` is
specified nfd-master removes all NFD related labels, annotations and
extended resources from all nodes of the cluster and exits.

Also, add new `--kubeconfig` flag. Useful with `--prune` and for development purposes.