### PR TITLE
Adds multi-architecture support to the Makefile using docker buildx (amd64, arm64, arm/v7)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ HOSTMOUNT_PREFIX := /host-
 KUBECONFIG :=
 E2E_TEST_CONFIG :=
 
+MULTIARCH_IMAGE_ARCHITECTURES := linux/amd64,linux/arm64,linux/arm/v7
+MULTIARCH_IMAGE_BUILD_CMD := docker buildx build
+
 yaml_templates := $(wildcard *.yaml.template)
 yaml_instances := $(patsubst %.yaml.template,%.yaml,$(yaml_templates))
 
@@ -27,6 +30,14 @@ all: image
 
 image: yamls
 	$(IMAGE_BUILD_CMD) --build-arg NFD_VERSION=$(VERSION) \
+		--build-arg HOSTMOUNT_PREFIX=$(HOSTMOUNT_PREFIX) \
+		-t $(IMAGE_TAG) \
+		$(IMAGE_BUILD_EXTRA_OPTS) ./
+
+push-multiarch: yamls
+	$(MULTIARCH_IMAGE_BUILD_CMD) --push \
+	    --platform $(MULTIARCH_IMAGE_ARCHITECTURES) \
+	    --build-arg NFD_VERSION=$(VERSION) \
 		--build-arg HOSTMOUNT_PREFIX=$(HOSTMOUNT_PREFIX) \
 		-t $(IMAGE_TAG) \
 		$(IMAGE_BUILD_EXTRA_OPTS) ./


### PR DESCRIPTION
This adds an additional `push-multiarch` command to the `Makefile` which builds and pushes multi-architecture images (architectures are listed in the `$MULTIARCH_IMAGE_ARCHITECTURES` variable).

I tried initially to do this as two separate steps, one build step and one push step as for single architecture builds. Alas it seems like for multi-arch builds with buildx you need to push as part of the build if you want to generate a suitable multi-architecture manifest file for a registry.

(There is the "hard way" as outlined here: https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/ which might make it possible to run as two steps, but buildx seems to be the future for multi-architecture builds)

**Note**: buildx is still an experimental feature, and needs to be enabled in docker as outlined here: [https://docs.docker.com/buildx/working-with-buildx](https://docs.docker.com/buildx/working-with-buildx/).

**Context** I'm been wanting to experiment with `node-feature-discovery` on a mixed-architecture [k3s](https://k3s.io/) home-lab cluster. It seems like a really cool solution for scheduling nodes based on the devices plugged into the USB ports of the cluster nodes. I noticed you didn't have any arm images built.

Thank you for this cool project!