### PR TITLE
Update builder image to Go 1.13.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - "1.13.5"
+  - "1.13.12"
 
 env:
   global:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build node feature discovery
-FROM golang:1.13.5 as builder
+FROM golang:1.13.12 as builder
 
 # Get (cache) deps in a separate layer
 COPY go.mod go.sum /go/node-feature-discovery/


### PR DESCRIPTION
Go versions after 1.13.7 contain fix for CVE-2020-7919