### PR TITLE
Change release image repo to k8s.gcr.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ IMAGE_PUSH_CMD := docker push
 
 VERSION := $(shell git describe --tags --dirty --always)
 
-IMAGE_REGISTRY := quay.io/kubernetes_incubator
+IMAGE_REGISTRY := k8s.gcr.io/nfd
 IMAGE_NAME := node-feature-discovery
 IMAGE_TAG_NAME := $(VERSION)
 IMAGE_REPO := $(IMAGE_REGISTRY)/$(IMAGE_NAME)

--- a/README.md
+++ b/README.md
@@ -869,9 +869,9 @@ docker push <IMAGE_TAG>
 **Change the job spec to use your custom image (optional):**
 
 To use your published image from the step above instead of the
-`quay.io/kubernetes_incubator/node-feature-discovery` image, edit `image`
+`k8s.gcr.io/nfd/node-feature-discovery` image, edit `image`
 attribute in the spec template(s) to the new location
-(`<quay-domain-name>/<registry-user>/<image-name>[:<version>]`).
+(`<registry-name>/<image-name>[:<version>]`).
 
 ### Customizing the Build
 There are several Makefile variables that control the build process and the
@@ -882,7 +882,7 @@ name of the resulting container image.
 | IMAGE_BUILD_CMD        | Command to build the image                   | docker build
 | IMAGE_BUILD_EXTRA_OPTS | Extra options to pass to build command       | *empty*
 | IMAGE_PUSH_CMD         | Command to push the image to remote registry | docker push
-| IMAGE_REGISTRY         | Container image registry to use              | quay.io/kubernetes_incubator
+| IMAGE_REGISTRY         | Container image registry to use              | k8s.gcr.io/nfd
 | IMAGE_NAME             | Container image name                         | node-feature-discovery
 | IMAGE_TAG_NAME         | Container image tag name                     | &lt;nfd version&gt;
 | IMAGE_REPO             | Container image repository to use            | &lt;IMAGE_REGISTRY&gt;/&lt;IMAGE_NAME&gt;

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,14 +6,15 @@ is as follows:
 1. An issue is filed to propose a new release with a changelog since the last
    release. Copy the following checklist into the issue text:
 
-- [ ] All [OWNERS](OWNERS) must LGTM the release proposal.
-- [ ] Update the [daemonset template](node-feature-discovery-daemonset.yaml.template) and the [job template](node-feature-discovery-job.yaml.template) to use the new tagged container image
+- [ ] All [OWNERS](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/OWNERS) must LGTM the release proposal.
+- [ ] Update the deployment templates ([master](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/nfd-master.yaml.template), [worker-daemonset](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/nfd-worker-daemonset.yaml.template), [worker-job](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/nfd-worker-job.yaml.template) and [combined](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/nfd-daemonset-combined.yaml.template))to use the new tagged container image
 - [ ] An OWNER runs `git tag -s $VERSION` and insert the changelog into the tag description.
-- [ ] [Build and push](https://github.com/kubernetes-sigs/node-feature-discovery#building-from-source) a container image with the same tag to [quay.io](https://quay.io/kubernetes_incubator).
-- [ ] Update the `:latest` virtual tag in quay.io to track the last stable (this) release.
-- [ ] An OWNER pushes the tag with `git push $VERSION`.
+- [ ] An OWNER pushes the tag with `git push $VERSION` (this will also build and push a release container image to quay.io).
+- [ ] An OWNER pulls the newly tagged image from quay.io, tags it with `gcr.io/k8s-staging-nfd/node-feature-discovery:$VERSION` and pushes it to `gcr.io/k8s-staging-nfd`
+- [ ] Create a PR against [k8s.io](https://github.com/kubernetes/k8s.io), updading `k8s.gcr.io/images/k8s-staging-nfd/images.yaml` to promote the release image into production.
+- [ ] Wait for the PR to be merged and verify that the image (`k8s.gcr.io/nfd/node-feature-discovery:$VERSION`) is available.
 - [ ] Write the change log into the [Github release info](https://github.com/kubernetes-sigs/node-feature-discovery/releases).
 - [ ] Add a link to the tagged release in this issue.
 - [ ] An announcement email is sent to `kubernetes-dev@googlegroups.com` with the
-   subject `[ANNOUNCE] node-feature-discovery $VERSION is released`
+   subject `[ANNOUNCE] node-feature-discovery $VERSION is released`. Add a link to the release announcement here.
 - [ ] Close this issue.

--- a/nfd-daemonset-combined.yaml.template
+++ b/nfd-daemonset-combined.yaml.template
@@ -62,7 +62,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: quay.io/kubernetes_incubator/node-feature-discovery:v0.6.0
+          image: k8s.gcr.io/nfd/node-feature-discovery:v0.6.0
           name: nfd-master
           command:
             - "nfd-master"
@@ -71,7 +71,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: quay.io/kubernetes_incubator/node-feature-discovery:v0.6.0
+          image: k8s.gcr.io/nfd/node-feature-discovery:v0.6.0
           name: nfd-worker
           command:
             - "nfd-worker"

--- a/nfd-master.yaml.template
+++ b/nfd-master.yaml.template
@@ -77,7 +77,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: quay.io/kubernetes_incubator/node-feature-discovery:v0.6.0
+          image: k8s.gcr.io/nfd/node-feature-discovery:v0.6.0
           name: nfd-master
           command:
             - "nfd-master"

--- a/nfd-worker-daemonset.yaml.template
+++ b/nfd-worker-daemonset.yaml.template
@@ -21,7 +21,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: quay.io/kubernetes_incubator/node-feature-discovery:v0.6.0
+          image: k8s.gcr.io/nfd/node-feature-discovery:v0.6.0
           name: nfd-worker
           command:
             - "nfd-worker"

--- a/nfd-worker-job.yaml.template
+++ b/nfd-worker-job.yaml.template
@@ -30,7 +30,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: quay.io/kubernetes_incubator/node-feature-discovery:v0.6.0
+          image: k8s.gcr.io/nfd/node-feature-discovery:v0.6.0
           name: nfd-worker
           command:
             - "nfd-worker"


### PR DESCRIPTION
Change the documentation and deployment spec templates to refer to the new image repository `k8s.gcr.io/nfd`.

CI is still dependent on `quay.io`