### PR TITLE
nfd-master: patch node object instead of rewriting it

### DIFF
--- a/cmd/nfd-master/main.go
+++ b/cmd/nfd-master/main.go
@@ -122,7 +122,10 @@ func argsParse(argv []string) (master.Args, error) {
 		return args, fmt.Errorf("error parsing whitelist regex (%s): %s", arguments["--label-whitelist"], err)
 	}
 	args.VerifyNodeName = arguments["--verify-node-name"].(bool)
-	args.ExtraLabelNs = strings.Split(arguments["--extra-label-ns"].(string), ",")
+	args.ExtraLabelNs = map[string]struct{}{}
+	for _, n := range strings.Split(arguments["--extra-label-ns"].(string), ",") {
+		args.ExtraLabelNs[n] = struct{}{}
+	}
 	args.ResourceLabels = strings.Split(arguments["--resource-labels"].(string), ",")
 	args.Prune = arguments["--prune"].(bool)
 	args.Kubeconfig = arguments["--kubeconfig"].(string)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/klauspost/cpuid v1.2.3
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.0
+	github.com/smartystreets/assertions v1.2.0
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/stretchr/testify v1.4.0
 	github.com/vektra/errors v0.0.0-20140903201135-c64d83aba85a

--- a/go.sum
+++ b/go.sum
@@ -572,6 +572,8 @@ github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/assertions v1.2.0 h1:42S6lae5dvLc7BrLu/0ugRtcFVjoJNMC/N3yZFZkDFs=
+github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4 h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=

--- a/pkg/apihelper/apihelpers.go
+++ b/pkg/apihelper/apihelpers.go
@@ -35,6 +35,9 @@ type APIHelpers interface {
 	// UpdateNode updates the node via the API server using a client.
 	UpdateNode(*k8sclient.Clientset, *api.Node) error
 
-	// PatchStatus updates the node status via the API server using a client.
-	PatchStatus(*k8sclient.Clientset, string, interface{}) error
+	// PatchNode updates the node object via the API server using a client.
+	PatchNode(*k8sclient.Clientset, string, []JsonPatch) error
+
+	// PatchNodeStatus updates the node status via the API server using a client.
+	PatchNodeStatus(*k8sclient.Clientset, string, []JsonPatch) error
 }

--- a/pkg/apihelper/jsonpatch.go
+++ b/pkg/apihelper/jsonpatch.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apihelper
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// JsonPatch is a json marshaling helper used for patching API objects
+type JsonPatch struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value string `json:"value,omitempty"`
+}
+
+// NewJsonPatch returns a new JsonPatch object
+func NewJsonPatch(verb string, path string, key string, value string) JsonPatch {
+	return JsonPatch{verb, filepath.Join(path, strings.ReplaceAll(key, "/", "~1")), value}
+}

--- a/pkg/apihelper/k8shelpers.go
+++ b/pkg/apihelper/k8shelpers.go
@@ -78,12 +78,25 @@ func (h K8sHelpers) UpdateNode(c *k8sclient.Clientset, n *api.Node) error {
 	return nil
 }
 
-func (h K8sHelpers) PatchStatus(c *k8sclient.Clientset, nodeName string, marshalable interface{}) error {
-	// Send the updated node to the apiserver.
-	patch, err := json.Marshal(marshalable)
-	if err == nil {
-		_, err = c.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.JSONPatchType, patch, meta_v1.PatchOptions{}, "status")
+func (h K8sHelpers) PatchNode(c *k8sclient.Clientset, nodeName string, patches []JsonPatch) error {
+	if len(patches) > 0 {
+		data, err := json.Marshal(patches)
+		if err == nil {
+			_, err = c.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.JSONPatchType, data, meta_v1.PatchOptions{})
+		}
+		return err
 	}
+	return nil
+}
 
-	return err
+func (h K8sHelpers) PatchNodeStatus(c *k8sclient.Clientset, nodeName string, patches []JsonPatch) error {
+	if len(patches) > 0 {
+		data, err := json.Marshal(patches)
+		if err == nil {
+			_, err = c.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.JSONPatchType, data, meta_v1.PatchOptions{}, "status")
+		}
+		return err
+	}
+	return nil
+
 }

--- a/pkg/apihelper/mock_APIHelpers.go
+++ b/pkg/apihelper/mock_APIHelpers.go
@@ -85,12 +85,26 @@ func (_m *MockAPIHelpers) GetNodes(_a0 *kubernetes.Clientset) (*v1.NodeList, err
 	return r0, r1
 }
 
-// PatchStatus provides a mock function with given fields: _a0, _a1, _a2
-func (_m *MockAPIHelpers) PatchStatus(_a0 *kubernetes.Clientset, _a1 string, _a2 interface{}) error {
+// PatchNode provides a mock function with given fields: _a0, _a1, _a2
+func (_m *MockAPIHelpers) PatchNode(_a0 *kubernetes.Clientset, _a1 string, _a2 []JsonPatch) error {
 	ret := _m.Called(_a0, _a1, _a2)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*kubernetes.Clientset, string, interface{}) error); ok {
+	if rf, ok := ret.Get(0).(func(*kubernetes.Clientset, string, []JsonPatch) error); ok {
+		r0 = rf(_a0, _a1, _a2)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// PatchNodeStatus provides a mock function with given fields: _a0, _a1, _a2
+func (_m *MockAPIHelpers) PatchNodeStatus(_a0 *kubernetes.Clientset, _a1 string, _a2 []JsonPatch) error {
+	ret := _m.Called(_a0, _a1, _a2)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*kubernetes.Clientset, string, []JsonPatch) error); ok {
 		r0 = rf(_a0, _a1, _a2)
 	} else {
 		r0 = ret.Error(0)

--- a/pkg/nfd-master/nfd-master-internal_test.go
+++ b/pkg/nfd-master/nfd-master-internal_test.go
@@ -72,8 +72,6 @@ func TestUpdateNodeFeatures(t *testing.T) {
 		}
 		sort.Strings(fakeExtResourceNames)
 
-		fakeAnnotations[AnnotationNs+"/feature-labels"] = strings.Join(fakeFeatureLabelNames, ",")
-
 		mockAPIHelper := new(apihelper.MockAPIHelpers)
 		mockClient := &k8sclient.Clientset{}
 		// Mock node with old features
@@ -84,11 +82,14 @@ func TestUpdateNodeFeatures(t *testing.T) {
 		Convey("When I successfully update the node with feature labels", func() {
 			metadataPatches := []apihelper.JsonPatch{
 				apihelper.NewJsonPatch("replace", "/metadata/annotations", AnnotationNs+"/feature-labels", strings.Join(fakeFeatureLabelNames, ",")),
-				apihelper.NewJsonPatch("add", "/metadata/annotations", "my-annotation", "my-val"),
+				apihelper.NewJsonPatch("add", "/metadata/annotations", AnnotationNs+"/extended-resources", strings.Join(fakeExtResourceNames, ",")),
 				apihelper.NewJsonPatch("remove", "/metadata/labels", LabelNs+"/old-feature", ""),
 			}
 			for k, v := range fakeFeatureLabels {
 				metadataPatches = append(metadataPatches, apihelper.NewJsonPatch("add", "/metadata/labels", k, v))
+			}
+			for k, v := range fakeAnnotations {
+				expectedPatches = append(expectedPatches, apihelper.NewJsonPatch("add", "/metadata/annotations", k, v))
 			}
 
 			mockAPIHelper.On("GetClient").Return(mockClient, nil)

--- a/pkg/nfd-master/nfd-master-internal_test.go
+++ b/pkg/nfd-master/nfd-master-internal_test.go
@@ -189,14 +189,14 @@ func TestAddingExtResources(t *testing.T) {
 		Convey("When there are no matching labels", func() {
 			mockNode := newMockNode()
 			mockResourceLabels := ExtendedResources{}
-			resourceOps := getExtendedResourceOps(mockNode, mockResourceLabels)
+			resourceOps := createExtendedResourcePatches(mockNode, mockResourceLabels)
 			So(len(resourceOps), ShouldEqual, 0)
 		})
 
 		Convey("When there are matching labels", func() {
 			mockNode := newMockNode()
 			mockResourceLabels := ExtendedResources{LabelNs + "/feature-1": "1", LabelNs + "feature-2": "2"}
-			resourceOps := getExtendedResourceOps(mockNode, mockResourceLabels)
+			resourceOps := createExtendedResourcePatches(mockNode, mockResourceLabels)
 			So(len(resourceOps), ShouldBeGreaterThan, 0)
 		})
 
@@ -204,7 +204,7 @@ func TestAddingExtResources(t *testing.T) {
 			mockNode := newMockNode()
 			mockNode.Status.Capacity[api.ResourceName(LabelNs+"/feature-1")] = *resource.NewQuantity(1, resource.BinarySI)
 			mockResourceLabels := ExtendedResources{LabelNs + "/feature-1": "1"}
-			resourceOps := getExtendedResourceOps(mockNode, mockResourceLabels)
+			resourceOps := createExtendedResourcePatches(mockNode, mockResourceLabels)
 			So(len(resourceOps), ShouldEqual, 0)
 		})
 
@@ -212,7 +212,7 @@ func TestAddingExtResources(t *testing.T) {
 			mockNode := newMockNode()
 			mockNode.Status.Capacity[api.ResourceName(LabelNs+"/feature-1")] = *resource.NewQuantity(2, resource.BinarySI)
 			mockResourceLabels := ExtendedResources{LabelNs + "/feature-1": "1"}
-			resourceOps := getExtendedResourceOps(mockNode, mockResourceLabels)
+			resourceOps := createExtendedResourcePatches(mockNode, mockResourceLabels)
 			So(len(resourceOps), ShouldBeGreaterThan, 0)
 		})
 	})
@@ -226,7 +226,7 @@ func TestRemovingExtResources(t *testing.T) {
 			mockNode.Annotations[AnnotationNs+"/extended-resources"] = "feature-1,feature-2"
 			mockNode.Status.Capacity[api.ResourceName(LabelNs+"/feature-1")] = *resource.NewQuantity(1, resource.BinarySI)
 			mockNode.Status.Capacity[api.ResourceName(LabelNs+"/feature-2")] = *resource.NewQuantity(2, resource.BinarySI)
-			resourceOps := getExtendedResourceOps(mockNode, mockResourceLabels)
+			resourceOps := createExtendedResourcePatches(mockNode, mockResourceLabels)
 			So(len(resourceOps), ShouldEqual, 0)
 		})
 		Convey("When the related label is gone", func() {
@@ -235,7 +235,7 @@ func TestRemovingExtResources(t *testing.T) {
 			mockNode.Annotations[AnnotationNs+"/extended-resources"] = "feature-4,feature-2"
 			mockNode.Status.Capacity[api.ResourceName(LabelNs+"/feature-4")] = *resource.NewQuantity(4, resource.BinarySI)
 			mockNode.Status.Capacity[api.ResourceName(LabelNs+"/feature-2")] = *resource.NewQuantity(2, resource.BinarySI)
-			resourceOps := getExtendedResourceOps(mockNode, mockResourceLabels)
+			resourceOps := createExtendedResourcePatches(mockNode, mockResourceLabels)
 			So(len(resourceOps), ShouldBeGreaterThan, 0)
 		})
 		Convey("When the extended resource is no longer wanted", func() {
@@ -244,7 +244,7 @@ func TestRemovingExtResources(t *testing.T) {
 			mockNode.Status.Capacity[api.ResourceName(LabelNs+"/feature-2")] = *resource.NewQuantity(2, resource.BinarySI)
 			mockResourceLabels := ExtendedResources{LabelNs + "/feature-2": "2"}
 			mockNode.Annotations[AnnotationNs+"/extended-resources"] = "feature-1,feature-2"
-			resourceOps := getExtendedResourceOps(mockNode, mockResourceLabels)
+			resourceOps := createExtendedResourcePatches(mockNode, mockResourceLabels)
 			So(len(resourceOps), ShouldBeGreaterThan, 0)
 		})
 	})

--- a/test/e2e/node_feature_discovery.go
+++ b/test/e2e/node_feature_discovery.go
@@ -458,9 +458,9 @@ var _ = framework.KubeDescribe("[NFD] Node Feature Discovery", func() {
 			ginkgo.It("it should decorate the node with the fake feature labels", func() {
 
 				fakeFeatureLabels := map[string]string{
-					master.LabelNs + "fake-fakefeature1": "true",
-					master.LabelNs + "fake-fakefeature2": "true",
-					master.LabelNs + "fake-fakefeature3": "true",
+					master.LabelNs + "/fake-fakefeature1": "true",
+					master.LabelNs + "/fake-fakefeature2": "true",
+					master.LabelNs + "/fake-fakefeature3": "true",
 				}
 
 				// Remove pre-existing stale annotations and labels


### PR DESCRIPTION
When updating node labels and annotations use JSON patches instead of
doing a read-modify-write on the whole node object. Patching is already
being used in managing extended resources so some of the existing code
was re-usable. This should mitigate the problem of node update failures caused by
race conditions (a change in the node object between our read and write)
resulting e.g. in errors/restarts in nfd worker pods.

This patchset also slightly improves the unit tests.

Addresses #122