### PR TITLE
test/e2e: interpret node names in config as regexps

### DIFF
--- a/test/e2e/e2e-test-config.exapmle.yaml
+++ b/test/e2e/e2e-test-config.exapmle.yaml
@@ -60,7 +60,8 @@ defaultFeatures:
     - "nfd.node.kubernetes.io/worker.version"
     - "nfd.node.kubernetes.io/feature-labels"
   nodes:
-    my-node-1:
+    # NOTE: keys here are interpreted as regexps
+    my-node-regexp-1:
       expectedLabelValues:
         "feature.node.kubernetes.io/cpu-cpuid.ADX": "true"
         "feature.node.kubernetes.io/cpu-cpuid.AESNI": "true"

--- a/test/e2e/node_feature_discovery.go
+++ b/test/e2e/node_feature_discovery.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"regexp"
 	"strings"
 	"time"
 
@@ -57,6 +58,7 @@ type e2eConfig struct {
 }
 
 type nodeConfig struct {
+	nameRe                   *regexp.Regexp
 	ExpectedLabelValues      map[string]string
 	ExpectedLabelKeys        lookupMap
 	ExpectedAnnotationValues map[string]string
@@ -93,6 +95,13 @@ func readConfig() {
 	ginkgo.By("Parsing end-to-end test configuration data")
 	err = yaml.Unmarshal(data, &conf)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Pre-compile node name matching regexps
+	for name, nodeConf := range conf.DefaultFeatures.Nodes {
+		nodeConf.nameRe, err = regexp.Compile(name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		conf.DefaultFeatures.Nodes[name] = nodeConf
+	}
 }
 
 // Create required RBAC configuration
@@ -519,11 +528,17 @@ var _ = framework.KubeDescribe("Node Feature Discovery", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				for _, node := range nodeList.Items {
-					if _, ok := fConf.Nodes[node.Name]; !ok {
-						e2elog.Logf("node %q missing from e2e-config, skipping...", node.Name)
+					var nodeConf *nodeConfig
+					for _, conf := range fConf.Nodes {
+						if conf.nameRe.MatchString(node.Name) {
+							e2elog.Logf("node %q matches rule %q", node.Name, conf.nameRe)
+							nodeConf = &conf
+						}
+					}
+					if nodeConf == nil {
+						e2elog.Logf("node %q has no matching rule in e2e-config, skipping...", node.Name)
 						continue
 					}
-					nodeConf := fConf.Nodes[node.Name]
 
 					// Check labels
 					e2elog.Logf("verifying labels of node %q...", node.Name)


### PR DESCRIPTION
Interpret node names in the e2e test config as regexps instead of plain
strings. This makes it a lot easier to maintain a config file where
multiple nodes share configuration.