### PR TITLE
scripts/test-infra: add script for end-to-end testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,7 @@ script:
       set -e;
       echo "$IMAGE_REPO_PASSWORD" | docker login -u "$IMAGE_REPO_USER" --password-stdin quay.io;
       make push -e;
-      curl -o $HOME/bin/aws-iam-authenticator --create-dirs https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator;
-      chmod a+x $HOME/bin/aws-iam-authenticator;
-      export PATH=$PATH:$HOME/bin;
-      echo "$KUBECONFIG_AWS" > kubeconfig_aws;
-      echo "$E2E_TEST_CONFIG_DATA" > e2e-test-config;
-      make e2e-test -e KUBECONFIG=`pwd`/kubeconfig_aws E2E_TEST_CONFIG=`pwd`/e2e-test-config;
+      scripts/test-infra/test-e2e.sh;
     fi
 
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -87,3 +87,15 @@ e2e-test:
 
 push:
 	$(IMAGE_PUSH_CMD) $(IMAGE_TAG)
+
+poll-image:
+	set -e; \
+	image=$(IMAGE_REPO):$(IMAGE_TAG_NAME); \
+	base_url=`echo $(IMAGE_REPO) | sed -e s'!\([^/]*\)!\1/v2!'`; \
+	errors=`curl -fsS -X GET https://$$base_url/manifests/$(IMAGE_TAG_NAME)|jq .errors`;  \
+	if [ "$$errors" = "null" ]; then \
+	  echo Image $$image found; \
+	else \
+	  echo Image $$image not found; \
+	  exit 1; \
+	fi;

--- a/scripts/test-infra/test-e2e.sh
+++ b/scripts/test-infra/test-e2e.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+
+# Install deps
+curl -o $HOME/bin/aws-iam-authenticator --create-dirs https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator
+chmod a+x $HOME/bin/aws-iam-authenticator
+export PATH=$PATH:$HOME/bin
+
+
+# Configure environment
+if [ -z "$IMAGE_TAG_NAME" ]; then
+    export IMAGE_TAG_NAME="$_PULL_BASE_REF-g$COMMIT_SHA"
+fi
+export KUBECONFIG=`pwd`/kubeconfig
+export E2E_TEST_CONFIG=`pwd`/e2e-test-config
+
+echo "$KUBECONFIG_DATA" > "$KUBECONFIG"
+echo "$E2E_TEST_CONFIG_DATA" > "$E2E_TEST_CONFIG"
+
+
+# Wait for the image to be built and published
+i=1
+while true; do
+    if make poll-image -e; then
+        break
+    elif [ $i -ge 10 ]; then
+        "ERROR: too many tries when polling for image"
+        exit 1
+    fi
+    sleep 60
+
+    i=$(( $i + 1 ))
+done
+
+
+# Configure environment and run tests
+make e2e-test -e
+


### PR DESCRIPTION
Add a new script for running end-to-end tests. Implement a Makefile rule
for polling the container image. We need this for prow as there is no
other way for syncing the jobs (e2e postsubmit job must wait until the
image-pushing job has built and published the image). This is
implemented in the Makefile as all the image-related variables are also
defined/available there.

Also, adapt the TravisCI config to use the new script.