### PR TITLE
Update go to 1.14.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - "1.13.12"
+  - "1.14.7"
 
 env:
   global:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build node feature discovery
-FROM golang:1.13.12 as builder
+FROM golang:1.14.7 as builder
 
 # Get (cache) deps in a separate layer
 COPY go.mod go.sum /go/node-feature-discovery/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/node-feature-discovery
 
-go 1.13
+go 1.14
 
 require (
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815


### PR DESCRIPTION
Go 1.14.2 is stable enough for us to move from 1.13 at this point
after this PR we could start thinking updating deps for K1.19
Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>