### PR TITLE
cloudbuild.yaml: build using make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,10 @@ VERSION := $(shell git describe --tags --dirty --always)
 IMAGE_REGISTRY := k8s.gcr.io/nfd
 IMAGE_NAME := node-feature-discovery
 IMAGE_TAG_NAME := $(VERSION)
+IMAGE_EXTRA_TAG_NAMES :=
 IMAGE_REPO := $(IMAGE_REGISTRY)/$(IMAGE_NAME)
 IMAGE_TAG := $(IMAGE_REPO):$(IMAGE_TAG_NAME)
+IMAGE_EXTRA_TAGS := $(foreach tag,$(IMAGE_EXTRA_TAG_NAMES),$(IMAGE_REPO):$(tag))
 K8S_NAMESPACE := kube-system
 
 # We use different mount prefix for local and container builds.
@@ -47,6 +49,7 @@ image: yamls
 	$(IMAGE_BUILD_CMD) --build-arg VERSION=$(VERSION) \
 		--build-arg HOSTMOUNT_PREFIX=$(CONTAINER_HOSTMOUNT_PREFIX) \
 		-t $(IMAGE_TAG) \
+		$(foreach tag,$(IMAGE_EXTRA_TAGS),-t $(tag)) \
 		$(IMAGE_BUILD_EXTRA_OPTS) ./
 
 yamls: $(yaml_instances)
@@ -87,6 +90,7 @@ e2e-test:
 
 push:
 	$(IMAGE_PUSH_CMD) $(IMAGE_TAG)
+	for tag in $(IMAGE_EXTRA_TAGS); do $(IMAGE_PUSH_CMD) $$tag; done
 
 poll-image:
 	set -e; \

--- a/README.md
+++ b/README.md
@@ -887,6 +887,7 @@ name of the resulting container image.
 | IMAGE_REGISTRY             | Container image registry to use                                   | k8s.gcr.io/nfd
 | IMAGE_NAME                 | Container image name                                              | node-feature-discovery
 | IMAGE_TAG_NAME             | Container image tag name                                          | &lt;nfd version&gt;
+| IMAGE_EXTRA_TAG_NAMES      | Additional container image tag(s) to create when building image   | *empty*
 | IMAGE_REPO                 | Container image repository to use                                 | &lt;IMAGE_REGISTRY&gt;/&lt;IMAGE_NAME&gt;
 | IMAGE_TAG                  | Full image:tag to tag the image with                              | &lt;IMAGE_REPO&gt;/&lt;IMAGE_NAME&gt;
 | K8S_NAMESPACE              | nfd-master and nfd-worker namespace                               | kube-system

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,20 +1,10 @@
 steps:
-  - name: gcr.io/cloud-builders/docker
-    args:
-    - 'build'
-    - '--build-arg=VERSION=$_GIT_TAG'
-    - '--build-arg=HOSTMOUNT_PREFIX=/host-'
-    - '--tag=gcr.io/$PROJECT_ID/node-feature-discovery:$_GIT_TAG'
-    - '--tag=gcr.io/$PROJECT_ID/node-feature-discovery:$_PULL_BASE_REF'
-    - '--tag=gcr.io/$PROJECT_ID/node-feature-discovery:$_PULL_BASE_REF-g$COMMIT_SHA'
-    - '.'
+  - name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db
+    entrypoint: scripts/test-infra/push-image.sh
+    env:
+    - IMAGE_EXTRA_TAG_NAMES=$_PULL_BASE_REF
 substitutions:
   _GIT_TAG: '0.0.0'
   _PULL_BASE_REF: 'master'
 options:
   substitution_option: ALLOW_LOOSE
-# Pust images
-images:
-  - 'gcr.io/$PROJECT_ID/node-feature-discovery:$_GIT_TAG'
-  - 'gcr.io/$PROJECT_ID/node-feature-discovery:$_PULL_BASE_REF'
-  - 'gcr.io/$PROJECT_ID/node-feature-discovery:$_PULL_BASE_REF-g$COMMIT_SHA'

--- a/scripts/test-infra/push-image.sh
+++ b/scripts/test-infra/push-image.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+make image -e
+make push -e

--- a/scripts/test-infra/test-e2e.sh
+++ b/scripts/test-infra/test-e2e.sh
@@ -7,9 +7,6 @@ export PATH=$PATH:$HOME/bin
 
 
 # Configure environment
-if [ -z "$IMAGE_TAG_NAME" ]; then
-    export IMAGE_TAG_NAME="$_PULL_BASE_REF-g$COMMIT_SHA"
-fi
 export KUBECONFIG=`pwd`/kubeconfig
 export E2E_TEST_CONFIG=`pwd`/e2e-test-config
 


### PR DESCRIPTION
Use make for building our container image (through a new push-image.sh
script) instead of building directly with docker. This way we avoid the
container image tag naming hassle where we build and push the image on
"image-pushing" prow job and need to be able to reliably re-create the
same tag on the "testing" side for end-to-end tests. This also has the
advantage that the same mechanism (make) is used everywhere, i.e. in
image-pushing, testing and locally.
