### PR TITLE
scripts: hand-construct a reproducible version

### DIFF
--- a/scripts/test-infra/push-image.sh
+++ b/scripts/test-infra/push-image.sh
@@ -1,4 +1,10 @@
 #!/bin/bash -e
 
+# Strip 'vYYYYMMDD-' from the variable in order to get a reproducible
+# version and container image tag
+if [ -n "$_GIT_TAG" ]; then
+    export VERSION=${_GIT_TAG:10}
+fi
+
 make image -e
 make push -e


### PR DESCRIPTION
We don't have a full git repo in the gcb builds so our version/tag magic
inside the makefile does not work. Thus, get version information from
the build information - fortunately we can do that by simply stripping
the date prefix from the _GIT_TAG variable.