### PR TITLE
cloudbuild.yaml: set _GIT_TAG in env

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,6 +2,7 @@ steps:
   - name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db
     entrypoint: scripts/test-infra/push-image.sh
     env:
+    - _GIT_TAG=$_GIT_TAG
     - IMAGE_EXTRA_TAG_NAMES=$_PULL_BASE_REF
 substitutions:
   _GIT_TAG: '0.0.0'


### PR DESCRIPTION
Needed by push-image.sh.