### PR TITLE
scripts: configure docker authentication in push-image.sh

### DIFF
--- a/scripts/test-infra/push-image.sh
+++ b/scripts/test-infra/push-image.sh
@@ -6,5 +6,8 @@ if [ -n "$_GIT_TAG" ]; then
     export VERSION=${_GIT_TAG:10}
 fi
 
+# Authenticate in order to be able to push images
+gcloud auth configure-docker
+
 make image -e
 make push -e


### PR DESCRIPTION
As we're trying to push the images directly from the phase job and not
use 'images:' targets in cloudbuild.yaml.