### PR TITLE
cloudbuild.yaml: set correct container image registry

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,6 +2,7 @@ steps:
   - name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20200824-5d057db
     entrypoint: scripts/test-infra/push-image.sh
     env:
+    - IMAGE_REGISTRY=gcr.io/$PROJECT_ID
     - _GIT_TAG=$_GIT_TAG
     - IMAGE_EXTRA_TAG_NAMES=$_PULL_BASE_REF
 substitutions:


### PR DESCRIPTION
Use the staging image repository for tagging/pushing images. We aren't
able to (and wouldn't want to) push directly to the production
repository that is the default in the Makefile.