### PR TITLE
Fix up Makefile variable initialization and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,14 @@ IMAGE_PUSH_CMD ?= docker push
 VERSION := $(shell git describe --tags --dirty --always)
 
 IMAGE_REGISTRY ?= k8s.gcr.io/nfd
-IMAGE_NAME ?= node-feature-discovery
 IMAGE_TAG_NAME ?= $(VERSION)
 IMAGE_EXTRA_TAG_NAMES ?=
+
+IMAGE_NAME := node-feature-discovery
 IMAGE_REPO := $(IMAGE_REGISTRY)/$(IMAGE_NAME)
 IMAGE_TAG := $(IMAGE_REPO):$(IMAGE_TAG_NAME)
 IMAGE_EXTRA_TAGS := $(foreach tag,$(IMAGE_EXTRA_TAG_NAMES),$(IMAGE_REPO):$(tag))
+
 K8S_NAMESPACE ?= kube-system
 
 # We use different mount prefix for local and container builds.
@@ -28,8 +30,8 @@ else
 endif
 HOSTMOUNT_PREFIX ?= /
 
-KUBECONFIG :=
-E2E_TEST_CONFIG :=
+KUBECONFIG ?=
+E2E_TEST_CONFIG ?=
 
 LDFLAGS = -ldflags "-s -w -X sigs.k8s.io/node-feature-discovery/pkg/version.version=$(VERSION) -X sigs.k8s.io/node-feature-discovery/source.pathPrefix=$(HOSTMOUNT_PREFIX)"
 

--- a/README.md
+++ b/README.md
@@ -898,17 +898,13 @@ name of the resulting container image.
 
 | Variable                   | Description                                                       | Default value
 | -------------------------- | ----------------------------------------------------------------- | ----------- |
-| HOSTMOUNT_PREFIX           | Prefix of system directories for feature discovery (local builds) | /
-| CONTAINER_HOSTMOUNT_PREFIX | Prefix of system directories for feature discovery (container builds) | &lt;HOSTMOUNT_PREFIX&gt; (*if specified*) /host- (*otherwise*)
+| HOSTMOUNT_PREFIX           | Prefix of system directories for feature discovery (local builds) | / (*local builds*) /host- (*container builds*)
 | IMAGE_BUILD_CMD            | Command to build the image                                        | docker build
 | IMAGE_BUILD_EXTRA_OPTS     | Extra options to pass to build command                            | *empty*
 | IMAGE_PUSH_CMD             | Command to push the image to remote registry                      | docker push
 | IMAGE_REGISTRY             | Container image registry to use                                   | k8s.gcr.io/nfd
-| IMAGE_NAME                 | Container image name                                              | node-feature-discovery
 | IMAGE_TAG_NAME             | Container image tag name                                          | &lt;nfd version&gt;
 | IMAGE_EXTRA_TAG_NAMES      | Additional container image tag(s) to create when building image   | *empty*
-| IMAGE_REPO                 | Container image repository to use                                 | &lt;IMAGE_REGISTRY&gt;/&lt;IMAGE_NAME&gt;
-| IMAGE_TAG                  | Full image:tag to tag the image with                              | &lt;IMAGE_REPO&gt;/&lt;IMAGE_NAME&gt;
 | K8S_NAMESPACE              | nfd-master and nfd-worker namespace                               | kube-system
 | KUBECONFIG                 | Kubeconfig for running e2e-tests                                  | *empty*
 | E2E_TEST_CONFIG            | Parameterization file of e2e-tests (see [example](test/e2e/e2e-test-config.exapmle.yaml)) | *empty*


### PR DESCRIPTION
An attempt to organize the Makefile variables a bit further. The idea is
to only document variables that are really intended for build
customization and initialize all these variables in the Makefile with
'=?' so that they can be specified in the environment (and not just with
variable overrides). Thus, this patch drops some variables from the
README and change the initialization of some variables in the Makefile
so that the two files would be in sync.