### PR TITLE
nfd-worker: add special handling for --sources=all

### DIFF
--- a/cmd/nfd-worker/main.go
+++ b/cmd/nfd-worker/main.go
@@ -90,8 +90,9 @@ func argsParse(argv []string) (worker.Args, error) {
   --server-name-override=<name> Name (CN) expect from server certificate, useful
                               in testing
                               [Default: ]
-  --sources=<sources>         Comma separated list of feature sources.
-                              [Default: cpu,custom,iommu,kernel,local,memory,network,pci,storage,system,usb]
+  --sources=<sources>         Comma separated list of feature sources. Special
+                              value 'all' enables all feature sources.
+                              [Default: all]
   --no-publish                Do not publish discovered features to the
                               cluster-local Kubernetes API server.
   --label-whitelist=<pattern> Regular expression to filter label names to

--- a/cmd/nfd-worker/main_test.go
+++ b/cmd/nfd-worker/main_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-var allSources = []string{"cpu", "custom", "iommu", "kernel", "local", "memory", "network", "pci", "storage", "system", "usb"}
+var allSources = []string{"all"}
 
 func TestArgsParse(t *testing.T) {
 	Convey("When parsing command line arguments", t, func() {

--- a/docs/advanced/developer-guide.md
+++ b/docs/advanced/developer-guide.md
@@ -222,8 +222,6 @@ Command line flags of nfd-worker:
 ```bash
 $ docker run --rm ${NFD_CONTAINER_IMAGE} nfd-worker --help
 ...
-nfd-worker.
-
   Usage:
   nfd-worker [--no-publish] [--sources=<sources>] [--label-whitelist=<pattern>]
      [--oneshot | --sleep-interval=<seconds>] [--config=<path>]
@@ -253,8 +251,9 @@ nfd-worker.
   --server-name-override=<name> Name (CN) expect from server certificate, useful
                               in testing
                               [Default: ]
-  --sources=<sources>         Comma separated list of feature sources.
-                              [Default: cpu,custom,iommu,kernel,local,memory,network,pci,storage,system,usb]
+  --sources=<sources>         Comma separated list of feature sources. Special
+                              value 'all' enables all feature sources.
+                              [Default: all]
   --no-publish                Do not publish discovered features to the
                               cluster-local Kubernetes API server.
   --label-whitelist=<pattern> Regular expression to filter label names to
@@ -266,6 +265,7 @@ nfd-worker.
   --sleep-interval=<seconds>  Time to sleep between re-labeling. Non-positive
                               value implies no re-labeling (i.e. infinite
                               sleep). [Default: 60s]
+
 ```
 
 **NOTE** Some feature sources need certain directories and/or files from the

--- a/docs/advanced/worker-commandline-reference.md
+++ b/docs/advanced/worker-commandline-reference.md
@@ -139,9 +139,9 @@ nfd-worker --server-name-override=localhost
 ### --sources
 
 The `--sources` flag specifies a comma-separated list of enabled feature
-sources.
+sources. A special value `all` enables all feature sources.
 
-Default: cpu,custom,iommu,kernel,local,memory,network,pci,storage,system,usb
+Default: all
 
 Example:
 


### PR DESCRIPTION
A new special value 'all' is a shortcut for enabling all feature
sources. It should be the only name specified -- if any other names are
specified 'all' does not take effect, but, we only enable the listed
feature sources. E.g.
  --sources=all enables all sources, but
  --sources=all,cpu only enables the cpu source