### PR TITLE
Drop gcloud auth for image pushing

### DIFF
--- a/scripts/test-infra/push-image.sh
+++ b/scripts/test-infra/push-image.sh
@@ -6,8 +6,5 @@ if [ -n "$_GIT_TAG" ]; then
     export VERSION=${_GIT_TAG:10}
 fi
 
-# Authenticate in order to be able to push images
-gcloud auth configure-docker
-
 make image -e
 make push -e


### PR DESCRIPTION
gcloud auth call in push_image.sh test script is no longer needed

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>