### PR TITLE
Makefile: set default deployment ns to node-feature-discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ IMAGE_REPO := $(IMAGE_REGISTRY)/$(IMAGE_NAME)
 IMAGE_TAG := $(IMAGE_REPO):$(IMAGE_TAG_NAME)
 IMAGE_EXTRA_TAGS := $(foreach tag,$(IMAGE_EXTRA_TAG_NAMES),$(IMAGE_REPO):$(tag))
 
-K8S_NAMESPACE ?= kube-system
+K8S_NAMESPACE ?= node-feature-discovery
 
 # We use different mount prefix for local and container builds.
 # Take CONTAINER_HOSTMOUNT_PREFIX from HOSTMOUNT_PREFIX if only the latter is specified


### PR DESCRIPTION
Change the default namespace used in deployment yamls from 'kube-system'
to 'node-feature-discovery'. Sync with what the templates have. Also,
this should be a safer and more desirable default for people just trying
out node-feature-discovery.