### PR TITLE
Link to correct Github blobs, use staging images in deployment templates

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -44,3 +44,6 @@ remote_theme: rundocs/jekyll-rtd-theme@v2.0.9
 version: master
 display_version_list: true
 
+# Release is used to make external links to point to the correct blobs in the
+# Github repo
+release: master

--- a/docs/advanced/developer-guide.md
+++ b/docs/advanced/developer-guide.md
@@ -272,13 +272,13 @@ nfd-worker.
 host mounted inside the NFD container. Thus, you need to provide Docker with the
 correct `--volume` options in order for them to work correctly when run
 stand-alone directly with `docker run`. See the
-[template spec](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/nfd-worker-daemonset.yaml.template)
+[template spec](https://github.com/kubernetes-sigs/node-feature-discovery/blob/{{ site.release }}/nfd-worker-daemonset.yaml.template)
 for up-to-date information about the required volume mounts.
 
 ## Documentation
 
 All documentation resides under the
-[docs](https://github.com/kubernetes-sigs/node-feature-discovery/tree/master/docs)
+[docs](https://github.com/kubernetes-sigs/node-feature-discovery/tree/{{ site.release }}/docs)
 directory in the source tree. It is designed to be served as a html site by
 [GitHub Pages](https://pages.github.com/).
 
@@ -304,4 +304,4 @@ make site-build
 This will generate html documentation under `docs/_site/`.
 
 <!-- Links -->
-[e2e-config-sample]: https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/test/e2e/e2e-test-config.exapmle.yaml
+[e2e-config-sample]: https://github.com/kubernetes-sigs/node-feature-discovery/blob/{{ site.release }}/test/e2e/e2e-test-config.exapmle.yaml

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -25,9 +25,7 @@ This is a
 [SIG-node](https://github.com/kubernetes/community/blob/master/sig-node/README.md)
 subproject, hosted under the
 [Kubernetes SIGs](https://github.com/kubernetes-sigs) organization in Github.
-The project was established in 2016 as a
-[Kubernetes Incubator](https://github.com/kubernetes/community/blob/master/incubator.md)
-project and migrated to Kubernetes SIGs in 2018.
+The project was established in 2016 and was migrated to Kubernetes SIGs in 2018.
 
 ## License
 

--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -60,8 +60,8 @@ EOF
 The template specs provided in the repo can be used directly:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/nfd-master.yaml.template
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/nfd-worker-daemonset.yaml.template
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-master.yaml.template
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-worker-daemonset.yaml.template
 ```
 
 This will required RBAC rules and deploy nfd-master (as a deployment) and
@@ -75,7 +75,7 @@ manually.
 You can also run nfd-master and nfd-worker inside the same pod
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/nfd-daemonset-combined.yaml.template
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-daemonset-combined.yaml.template
 ```
 
 This creates a DaemonSet runs both nfd-worker and nfd-master in the same Pod.
@@ -89,7 +89,7 @@ The Job template may be used to achieve this:
 
 ```bash
 NUM_NODES=$(kubectl get no -o jsonpath='{.items[*].metadata.name}' | wc -w)
-curl -fs https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/nfd-worker-job.yaml.template | \
+curl -fs https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-worker-job.yaml.template | \
     sed s"/NUM_NODES/$NUM_NODES/" | \
     kubectl apply -f -
 ```
@@ -138,7 +138,7 @@ Worker connects to the nfd-master service to advertise hardware features.
 
 When run as a daemonset, nodes are re-labeled at an interval specified using
 the `--sleep-interval` option. In the
-[template](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/nfd-worker-daemonset.yaml.template#L26)
+[template](https://github.com/kubernetes-sigs/node-feature-discovery/blob/{{ site.release }}/nfd-worker-daemonset.yaml.template#L26)
 the default interval is set to 60s which is also the default when no
 `--sleep-interval` is specified. Also, the configuration file is re-read on
 each iteration providing a simple mechanism of run-time reconfiguration.
@@ -204,7 +204,7 @@ You could also use other types of volumes, of course. That is, hostPath if
 different config for different nodes would be required, for example.
 
 The (empty-by-default)
-[example config](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/nfd-worker.conf.example)
+[example config](https://github.com/kubernetes-sigs/node-feature-discovery/blob/{{ site.release }}/nfd-worker.conf.example)
 is used as a config in the NFD Docker image. Thus, this can be used as a default
 configuration in custom-built images.
 
@@ -280,7 +280,7 @@ NFD-Master has a special `--prune` command line flag for removing all
 nfd-related node labels, annotations and extended resources from the cluster.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/nfd-prune.yaml.template
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-prune.yaml.template
 kubectl -n node-feature-discovery wait job.batch/nfd-prune --for=condition=complete && \
     kubectl -n node-feature-discovery delete job/nfd-prune
 ```

--- a/docs/get-started/examples-and-demos.md
+++ b/docs/get-started/examples-and-demos.md
@@ -27,4 +27,4 @@ This page contains usage examples and demos.
 
 A demo on the benefits of using node feature discovery can be found in the
 source code repository under
-[demo/](https://github.com/kubernetes-sigs/node-feature-discovery/tree/master/demo).
+[demo/](https://github.com/kubernetes-sigs/node-feature-discovery/tree/{{ site.release }}/demo).

--- a/docs/get-started/features.md
+++ b/docs/get-started/features.md
@@ -525,7 +525,7 @@ Pods outside NFD, e.g. in Kubernetes device plugins. It is possible to mount
 the `source.d` and/or `features.d` directories common with the NFD Pod and
 deploy the custom hooks/features there. NFD will periodically scan the
 directories and run any hooks and read any feature files it finds. The
-[example nfd-worker deployment template](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/nfd-worker-daemonset.yaml.template#L69)
+[example nfd-worker deployment template](https://github.com/kubernetes-sigs/node-feature-discovery/blob/{{ site.release }}/nfd-worker-daemonset.yaml.template#L69)
 contains `hostPath` mounts for `sources.d` and `features.d` directories. By
 using the same mounts in the secondary Pod (e.g. device plugin) you have
 created a shared area for delivering hooks and feature files to NFD.

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -20,11 +20,11 @@ Continue to:
 ## Quick-start -- the short-short version
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/nfd-master.yaml.template
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-master.yaml.template
   namespace/node-feature-discovery created
 ...
 
-$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/nfd-worker-daemonset.yaml.template
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-worker-daemonset.yaml.template
   daemonset.apps/nfd-worker created
 
 $ kubectl -n node-feature-discovery get all

--- a/docs/get-started/quick-start.md
+++ b/docs/get-started/quick-start.md
@@ -13,13 +13,13 @@ Minimal steps to deploy latest released version of NFD in your cluster.
 Deploy nfd-master -- creates a new namespace, service and required RBAC rules
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/nfd-master.yaml.template
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-master.yaml.template
 ```
 
 Deploy nfd-worker as a daemonset
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/nfd-worker-daemonset.yaml.template
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-worker-daemonset.yaml.template
 ```
 
 ## Verify

--- a/nfd-daemonset-combined.yaml.template
+++ b/nfd-daemonset-combined.yaml.template
@@ -62,7 +62,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: k8s.gcr.io/nfd/node-feature-discovery:v0.6.0
+          image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
           name: nfd-master
           securityContext:
             allowPrivilegeEscalation: false
@@ -77,7 +77,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: k8s.gcr.io/nfd/node-feature-discovery:v0.6.0
+          image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
           name: nfd-worker
           securityContext:
             allowPrivilegeEscalation: false

--- a/nfd-master.yaml.template
+++ b/nfd-master.yaml.template
@@ -79,7 +79,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: k8s.gcr.io/nfd/node-feature-discovery:v0.6.0
+          image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
           name: nfd-master
           securityContext:
             allowPrivilegeEscalation: false

--- a/nfd-worker-daemonset.yaml.template
+++ b/nfd-worker-daemonset.yaml.template
@@ -21,7 +21,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: k8s.gcr.io/nfd/node-feature-discovery:v0.6.0
+          image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
           name: nfd-worker
           securityContext:
             allowPrivilegeEscalation: false

--- a/nfd-worker-job.yaml.template
+++ b/nfd-worker-job.yaml.template
@@ -30,7 +30,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: k8s.gcr.io/nfd/node-feature-discovery:v0.6.0
+          image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
           name: nfd-worker
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Support versioned links to gihub blobs in the documentation. Make the links point to the blob from the release corresponding the documentation.

Change deployment templates to point to staging image. Latest changes on the templates make them unusable with v0.6.0 release. Going forward, we should keep it this way - templates in the master branch should use staging image corresponding the template.