### PR TITLE
docs: make the list of available versions dynamic

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -40,9 +40,7 @@ remote_theme: rundocs/jekyll-rtd-theme@v2.0.9
 #   - vendor/gems/
 #   - vendor/ruby/
 
-# Document versioning. Current 'version' should be listed under
-# 'versions' as we use it in constructing the baseurl for other
-# versions.
+# Document versioning
 version: master
-versions:
-  - master
+display_version_list: true
+

--- a/docs/_includes/class/addons-wrap.liquid
+++ b/docs/_includes/class/addons-wrap.liquid
@@ -1,30 +1,30 @@
 <div class="addons-wrap d-flex flex-column overflow-y-auto">
     <div class="branch">
         <dl>
-            <dt>Versions:</dt>
+            {% if site.display_version_list %}
+                <dt id="versions">Versions:</dt>
 
-            {% comment %}
-            The following ugly construction is solely for the
-            purpose of dropping the "version" suffix from the
-            baseurl. The reason for doing this is that github-pages
-            gem forces us on --safe mode (i.e. disables custom
-            plugins) so we're not able to write a simple ruby
-            plugin doing delete_suffix()
-            {% endcomment %}
-            {% assign version_len = site.version | size %}
-            {% assign baseurl_len = site.baseurl | size %}
-            {% assign idx = baseurl_len | minus: version_len %}
-            {% assign suffix = site.baseurl | slice: idx, version_len %}
-            {% if suffix == site.version %}
-                {% assign idx = idx | minus: 1 %}
-                {% assign baseurl = site.baseurl | slice: 0, idx %}
-            {% else %}
-                {% assign baseurl = site.baseurl %}
+                {% comment %}
+                Drop the last component from site.baseurl which is supposed to
+                be pointing to a subdirectory of the true site baseurl.
+                {% endcomment %}
+                {% assign spliturl = site.baseurl | split: "/" %}
+                {% assign last = spliturl.size | minus: 1 %}
+                {% assign baseurl = spliturl | slice: 0, last | join: "/" %}
+
+                <script src="{{ baseurl }}/versions.js"></script>
+                <script>
+                    var dt = document.getElementById('versions');
+                    var items = getVersionListItems();
+                    for (var i=0; i < items.length; i++) {
+                      var dd = document.createElement('dd');
+                      var a = dd.appendChild(document.createElement('a'));
+                      a.appendChild(document.createTextNode(items[i].name));
+                      a.href = items[i].url;
+                      dt.appendChild(dd);
+                    }
+                </script>
             {% endif %}
-
-            {% for version in site.versions %}
-                <dd><a href="{{ baseurl }}/{{ version }}/">{{ version }}</a></dd>
-            {% endfor %}
         </dl>
     </div>
     <div class="status d-flex flex-justify-between p-2">

--- a/scripts/github/update-gh-pages.sh
+++ b/scripts/github/update-gh-pages.sh
@@ -103,6 +103,9 @@ fi
 # Switch to work in the gh-pages worktree
 cd "$build_dir"
 
+_stable=`(ls -d1 v*/ || :) | sort -n | tail -n1`
+[ -n "$_stable" ] && ln -sfT "$_stable" stable
+
 if [ -z "`git status --short`" ]; then
     echo "No new content, gh-pages branch already up-to-date"
     exit 0

--- a/scripts/github/update-gh-pages.sh
+++ b/scripts/github/update-gh-pages.sh
@@ -14,6 +14,19 @@ Options:
 EOF
 }
 
+# Helper function for detecting available versions from the current directory
+create_versions_js() {
+    local _baseurl="/node-feature-discovery"
+
+    echo -e "function getVersionListItems() {\n  return ["
+    # 'stable' is a symlink pointing to the latest version
+    [ -f stable ] && echo "    { name: 'stable', url: '$_baseurl/stable' },"
+    for f in `ls -d */  | tr -d /` ; do
+        echo "    { name: '$f', url: '$_baseurl/$f' },"
+    done
+    echo -e "  ];\n}"
+}
+
 #
 # Argument parsing
 #
@@ -105,6 +118,9 @@ cd "$build_dir"
 
 _stable=`(ls -d1 v*/ || :) | sort -n | tail -n1`
 [ -n "$_stable" ] && ln -sfT "$_stable" stable
+
+# Detect existing versions from the gh-pages branch
+create_versions_js > versions.js
 
 if [ -z "`git status --short`" ]; then
     echo "No new content, gh-pages branch already up-to-date"


### PR DESCRIPTION
Make the list of available versions dynamic. The items displayed is now
generated with javascript. The parent directory of the site is supposed
to contain versions.js providing getVersionListItems() that returns the
available versions.

The update-gh-pages.sh script is modified to update/create versions.js
on every invocation. It simply lists all directories in the root
directory and adds them to the version list.