### PR TITLE
docs: polish the version menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,12 @@ CONTAINER_RUN_CMD ?= docker run
 # same site url than the "host" it binds to. Thus, all the links will be
 # broken if we'd bind to 0.0.0.0
 JEKYLL_VERSION := 3.8
-SITE_BUILD_CMD := $(CONTAINER_RUN_CMD) --rm -i -u "`id -u`:`id -g`" --volume="$$PWD/docs:/srv/jekyll" --volume="$$PWD/docs/vendor/bundle:/usr/local/bundle" --network=host jekyll/jekyll:$(JEKYLL_VERSION)
+JEKYLL_ENV ?= development
+SITE_BUILD_CMD := $(CONTAINER_RUN_CMD) --rm -i -u "`id -u`:`id -g`" \
+	-e JEKYLL_ENV=$(JEKYLL_ENV) \
+	--volume="$$PWD/docs:/srv/jekyll" \
+	--volume="$$PWD/docs/vendor/bundle:/usr/local/bundle" \
+	--network=host jekyll/jekyll:$(JEKYLL_VERSION)
 SITE_SUBDIR ?=
 JEKYLL_OPTS := -d _site/$(SITE_SUBDIR) -b /node-feature-discovery/$(SITE_SUBDIR)
 

--- a/docs/_includes/class/addons-wrap.liquid
+++ b/docs/_includes/class/addons-wrap.liquid
@@ -12,10 +12,14 @@
     </div>
     <div class="addons d-flex flex-column height-full p-2 d-none">
         {% if site.display_version_list %}
-            <div>
-                <dl>
-                    <dt id="versions">Versions:</dt>
+            <dl id="versions">
+                <dt>Versions</dt>
 
+                {% if jekyll.environment == "development" %}
+                    <dd>
+                    <a href="{{ site.baseurl }}/">{{ site.version }}</a>
+                    </dd>
+                {% else %}
                     {% comment %}
                     Drop the last component from site.baseurl which is supposed to
                     be pointing to a subdirectory of the true site baseurl.
@@ -36,8 +40,8 @@
                           dt.appendChild(dd);
                         }
                     </script>
-                </dl>
-            </div>
+                {% endif %}
+            </dl>
         {% endif %}
         {%- assign items = "github" | split: ", " -%}
         {% for item in items -%}

--- a/scripts/github/update-gh-pages.sh
+++ b/scripts/github/update-gh-pages.sh
@@ -102,6 +102,7 @@ fi
 export SITE_SUBDIR=${site_subdir:-master}
 echo "Updating site subdir: '$SITE_SUBDIR'"
 
+export JEKYLL_ENV=production
 make site-build
 
 #

--- a/scripts/test-infra/build-gh-pages.sh
+++ b/scripts/test-infra/build-gh-pages.sh
@@ -8,4 +8,4 @@ mkdir -p "$_outdir"
 chmod a+rwx "$_outdir"
 
 # Build docs
-make site-build
+JEKYLL_ENV=production make site-build


### PR DESCRIPTION
Only show the dynamic version menu in production environment where it's
available. Local (development) builds only show a stub version menu with
one item.

Also, fix the theme customization. Append version list items to the
correct element in html so that they are displayed correctly. Drop
unnecessary <div/>.