### PR TITLE
use cert-manager for TLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ nfd-master.yaml
 nfd-worker-daemonset.yaml
 nfd-worker-job.yaml
 nfd-prune.yaml
+nfd-cert-manager.yaml

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ yamls: $(yaml_instances)
 	     -e s',^(\s*)name: node-feature-discovery # NFD namespace,\1name: ${K8S_NAMESPACE},' \
 	     -e s',^(\s*)image:.+$$,\1image: ${IMAGE_TAG},' \
 	     -e s',^(\s*)namespace:.+$$,\1namespace: ${K8S_NAMESPACE},' \
+	     -e s',^(\s*- |\s*- nfd-master.|\s*- nfd-worker.)node-feature-discovery,\1${K8S_NAMESPACE},' \
 	     -e s',^(\s*)mountPath: "/host-,\1mountPath: "${CONTAINER_HOSTMOUNT_PREFIX},' \
 	     -e '/nfd-worker.conf:/r nfd-worker.conf.tmp' \
 	     $< > $@

--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -284,6 +284,30 @@ nfd-master args, in which case nfd-master verifies that the NodeName presented
 by nfd-worker matches the Common Name (CN) of its certificate. This means that
 each nfd-worker requires a individual node-specific TLS certificate.
 
+#### Automated TLS certificate management using cert-manager
+
+[cert-manager](https://cert-manager.io/) can be used to automate certificate
+management between nfd-master and the nfd-worker pods. The instructions below describe
+steps how to set up cert-manager's
+[CA Issuer](https://cert-manager.io/docs/configuration/ca/) to
+sign `Certificate` requests for NFD components in `node-feature-discovery` namespace.
+
+```bash
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
+$ make yamls
+$ openssl genrsa -out ca.key 2048
+$ openssl req -x509 -new -nodes -key ca.key -subj "/CN=nfd-ca" -days 10000 -out ca.crt
+$ sed s"/tls.key:.*/tls.key: $(cat ca.key|base64 -w 0)/" -i nfd-cert-manager.yaml
+$ sed s"/tls.crt:.*/tls.crt: $(cat ca.crt|base64 -w 0)/" -i nfd-cert-manager.yaml
+$ kubectl apply -f nfd-cert-manager.yaml
+```
+
+Finally, deploy `nfd-master.yaml` and `nfd-worker-daemonset.yaml` with the Secrets
+(`nfd-master-cert` and `nfd-worker-cert`) mounts enabled.
+
+**Note:** the automated setup to support `--verify-node-name` hardening cannot
+be configured currently.
+
 ## Worker configuration
 
 NFD-Worker supports dynamic configuration through a configuration file. The

--- a/nfd-cert-manager.yaml.template
+++ b/nfd-cert-manager.yaml.template
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nfd-ca-key-pair
+  namespace: node-feature-discovery
+data:
+  tls.key:
+  tls.crt:
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: nfd-ca-issuer
+  namespace: node-feature-discovery
+spec:
+  ca:
+    secretName: nfd-ca-key-pair
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: nfd-master-cert
+  namespace: node-feature-discovery
+spec:
+  secretName: nfd-master-cert
+  subject:
+    organizations:
+    - node-feature-discovery
+  commonName: nfd-master
+  dnsNames:
+  - nfd-master.node-feature-discovery.svc
+  - nfd-master.node-feature-discovery.svc.cluster.local
+  - nfd-master
+  issuerRef:
+    name: nfd-ca-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: nfd-workers-cert
+  namespace: node-feature-discovery
+spec:
+  secretName: nfd-worker-cert
+  subject:
+    organizations:
+    - node-feature-discovery
+  commonName: nfd-worker
+  dnsNames:
+  - nfd-worker.node-feature-discovery.svc.cluster.local
+  issuerRef:
+    name: nfd-ca-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/nfd-master.yaml.template
+++ b/nfd-master.yaml.template
@@ -93,27 +93,21 @@ spec:
           command:
             - "nfd-master"
 ## Enable TLS authentication
-## The example below assumes having the root certificate named ca.crt stored in
-## a ConfigMap named nfd-ca-cert, and, the TLS authentication credentials stored
-## in a TLS Secret named nfd-master-cert.
+## The example below assumes having a Secret named nfd-master-cert with
+## the TLS authentication credentials and a root certificate named ca.crt created.
+## cert-manager can be used to automate the Secret creation and updates.
 ## Additional hardening can be enabled by specifying --verify-node-name in
 ## args, in which case every nfd-worker requires a individual node-specific
 ## TLS certificate.
 #          args:
-#            - "--ca-file=/etc/kubernetes/node-feature-discovery/trust/ca.crt"
+#            - "--ca-file=/etc/kubernetes/node-feature-discovery/certs/ca.crt"
 #            - "--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
 #            - "--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
 #          volumeMounts:
-#            - name: nfd-ca-cert
-#              mountPath: "/etc/kubernetes/node-feature-discovery/trust"
-#              readOnly: true
 #            - name: nfd-master-cert
 #              mountPath: "/etc/kubernetes/node-feature-discovery/certs"
 #              readOnly: true
 #      volumes:
-#        - name: nfd-ca-cert
-#          configMap:
-#            name: nfd-ca-cert
 #        - name: nfd-master-cert
 #          secret:
 #            secretName: nfd-master-cert

--- a/nfd-worker-daemonset.yaml.template
+++ b/nfd-worker-daemonset.yaml.template
@@ -38,10 +38,10 @@ spec:
             - "--sleep-interval=60s"
             - "--server=nfd-master:8080"
 ## Enable TLS authentication (1/3)
-## The example below assumes having the root certificate named ca.crt stored in
-## a ConfigMap named nfd-ca-cert, and, the TLS authentication credentials stored
-## in a TLS Secret named nfd-worker-cert
-#            - "--ca-file=/etc/kubernetes/node-feature-discovery/trust/ca.crt"
+## The example below assumes having a Secret named nfd-worker-cert with
+## the TLS authentication credentials and a root certificate named ca.crt created.
+## cert-manager can be used to automate the Secret creation and updates.
+#            - "--ca-file=/etc/kubernetes/node-feature-discovery/certs/ca.crt"
 #            - "--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
 #            - "--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
           volumeMounts:
@@ -69,9 +69,6 @@ spec:
 #              mountPath: "/etc/kubernetes/node-feature-discovery/custom.d/extra-rules-1"
 #              readOnly: true
 ## Enable TLS authentication (2/3)
-#            - name: nfd-ca-cert
-#              mountPath: "/etc/kubernetes/node-feature-discovery/trust"
-#              readOnly: true
 #            - name: nfd-worker-cert
 #              mountPath: "/etc/kubernetes/node-feature-discovery/certs"
 #              readOnly: true
@@ -99,9 +96,6 @@ spec:
 #          configMap:
 #            name: custom-source-extra-rules
 ## Enable TLS authentication (3/3)
-#        - name: nfd-ca-cert
-#          configMap:
-#            name: nfd-ca-cert
 #        - name: nfd-worker-cert
 #          secret:
 #            secretName: nfd-worker-cert


### PR DESCRIPTION
A POC to use cert-manager to manage nfd-master and nfd-worker certs

TODO:
- [ ] use `cert-manager-csi` (looks to be in early stages still) to get per node nfd-worker certs
- [ ] how to support `--verify-mode-name`
- [ ] kustomize?

Closes: #277