### PR TITLE
release-0.6: fix broken refs in documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,9 @@ SITE_BUILD_CMD := $(CONTAINER_RUN_CMD) --rm -i -u "`id -u`:`id -g`" \
 	--volume="$$PWD/docs:/srv/jekyll" \
 	--volume="$$PWD/docs/vendor/bundle:/usr/local/bundle" \
 	--network=host jekyll/jekyll:$(JEKYLL_VERSION)
-SITE_SUBDIR ?=
-JEKYLL_OPTS := -d _site/$(SITE_SUBDIR) -b /node-feature-discovery/$(SITE_SUBDIR)
+SITE_BASEURL ?=
+SITE_DESTDIR ?= _site
+JEKYLL_OPTS := -d '$(SITE_DESTDIR)' $(if $(SITE_BASEURL),-b '$(SITE_BASEURL)',)
 
 VERSION := $(shell git describe --tags --dirty --always)
 
@@ -127,4 +128,4 @@ site-build:
 
 site-serve:
 	@mkdir -p docs/vendor/bundle
-	$(SITE_BUILD_CMD) sh -c "bundle install && jekyll serve $(JEKYLL_OPTS) -H 127.0.0.1 -b ''"
+	$(SITE_BUILD_CMD) sh -c "bundle install && jekyll serve $(JEKYLL_OPTS) -H 127.0.0.1"

--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -234,7 +234,7 @@ nfd-worker.
 host mounted inside the NFD container. Thus, you need to provide Docker with the
 correct `--volume` options in order for them to work correctly when run
 stand-alone directly with `docker run`. See the
-[template spec](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/nfd-worker-daemonset.yaml.template)
+[template spec](https://github.com/kubernetes-sigs/node-feature-discovery/blob/release-0.6/nfd-worker-daemonset.yaml.template)
 for up-to-date information about the required volume mounts.
 
 ## Documentation

--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -66,7 +66,7 @@ name of the resulting container image.
 | IMAGE_EXTRA_TAG_NAMES      | Additional container image tag(s) to create when building image   | *empty*
 | K8S_NAMESPACE              | nfd-master and nfd-worker namespace                               | kube-system
 | KUBECONFIG                 | Kubeconfig for running e2e-tests                                  | *empty*
-| E2E_TEST_CONFIG            | Parameterization file of e2e-tests (see [example](test/e2e/e2e-test-config.exapmle.yaml)) | *empty*
+| E2E_TEST_CONFIG            | Parameterization file of e2e-tests (see [example][e2e-config-sample]) | *empty*
 
 For example, to use a custom registry:
 
@@ -239,9 +239,10 @@ for up-to-date information about the required volume mounts.
 
 ## Documentation
 
-All documentation resides under the [docs](/docs) directory in the source tree.
-It is designed to be served as a html site by [GitHub
-Pages](https://pages.github.com/).
+All documentation resides under the
+[docs](https://github.com/kubernetes-sigs/node-feature-discovery/tree/release-0.6/docs)
+directory in the source tree. It is designed to be served as a html site by
+[GitHub Pages](https://pages.github.com/).
 
 Building the documentation is containerized in order to fix the build
 environment. The recommended way for developing documentation is to run:
@@ -264,3 +265,5 @@ make site-build
 
 This will generate html documentation under `docs/_site/`.
 
+<!-- Links -->
+[e2e-config-sample]: https://github.com/kubernetes-sigs/node-feature-discovery/blob/release-0.6/test/e2e/e2e-test-config.exapmle.yaml

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -22,10 +22,8 @@ You can reach us via the following channels:
 
 This is a [SIG-node](https://github.com/kubernetes/community/blob/master/sig-node/README.md)
 subproject, hosted under the
-[Kubernetes SIGs](https://github.com/kubernetes-sigs) organization in
-Github. The project was established in 2016 as a
-[Kubernetes Incubator](https://github.com/kubernetes/community/blob/master/incubator.md)
-project and migrated to Kubernetes SIGs in 2018.
+[Kubernetes SIGs](https://github.com/kubernetes-sigs) organization in Github.
+The project was established in 2016 and was migrated to Kubernetes SIGs in 2018.
 
 ## License
 

--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -75,7 +75,7 @@ NFD-Worker connects to the nfd-master service to advertise hardware features.
 
 When run as a daemonset, nodes are re-labeled at an interval specified using
 the `--sleep-interval` option. In the
-[template](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/nfd-worker-daemonset.yaml.template#L26)
+[template](https://github.com/kubernetes-sigs/node-feature-discovery/blob/release-0.6/nfd-worker-daemonset.yaml.template#L26)
 the default interval is set to 60s which is also the default when no
 `--sleep-interval` is specified. Also, the configuration file is re-read on
 each iteration providing a simple mechanism of run-time reconfiguration.
@@ -135,7 +135,7 @@ each nfd-worker requires a individual node-specific TLS certificate.
 ### Deployment Templates
 
 For a stable version with ready-built images see the
-[latest released version](https://github.com/kubernetes-sigs/node-feature-discovery/tree/v0.6.0) ([release notes](https://github.com/kubernetes-sigs/node-feature-discovery/releases/latest)).
+[latest release](https://github.com/kubernetes-sigs/node-feature-discovery/releases/latest).
 
 ### Build Your Own
 
@@ -184,7 +184,7 @@ You could also use other types of volumes, of course. That is, hostPath if
 different config for different nodes would be required, for example.
 
 The (empty-by-default)
-[example config](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/nfd-worker.conf.example)
+[example config](https://github.com/kubernetes-sigs/node-feature-discovery/blob/release-0.6/nfd-worker.conf.example)
 is used as a config in the NFD Docker image. Thus, this can be used as a default
 configuration in custom-built images.
 

--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -199,11 +199,6 @@ file must be used, i.e. JSON (or YAML). For example:
 Configuration options specified from the command line will override those read
 from the config file.
 
-Currently, the only available configuration options are related to the
-[CPU](#cpu-features), [PCI](#pci-features) and [Kernel](#kernel-features)
-feature sources.
-
-
 ## Using Node Labels
 
 Nodes with specific features can be targeted using the `nodeSelector` field. The
@@ -224,7 +219,8 @@ spec:
     feature.node.kubernetes.io/cpu-pstate.turbo: 'true'
 ```
 
-For more details on targeting nodes, see [node selection][node-sel].
+For more details on targeting nodes, see
+[node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
 
 <!-- Links -->
 [docker-down]: https://docs.docker.com/install

--- a/docs/get-started/examples-and-demos.md
+++ b/docs/get-started/examples-and-demos.md
@@ -27,4 +27,4 @@ This page contains usage examples and demos.
 
 A demo on the benefits of using node feature discovery can be found in the
 source code repository under
-[demo/](https://github.com/kubernetes-sigs/node-feature-discovery/tree/master/demo).
+[demo/](https://github.com/kubernetes-sigs/node-feature-discovery/tree/release-0.6/demo).

--- a/docs/get-started/features.md
+++ b/docs/get-started/features.md
@@ -67,7 +67,7 @@ The (sub-)set of CPUID attributes to publish is configurable via the
 If whitelist is specified, only whitelisted attributes will be published. With
 blacklist, only blacklisted attributes are filtered out. `attributeWhitelist`
 has priority over `attributeBlacklist`.  For examples and more information
-about configurability, see [Configuration Options](#configuration-options).
+about configurability, see [configuration](deployment-and-usage#configuration).
 By default, the following CPUID flags have been blacklisted:
 BMI1, BMI2, CLMUL, CMOV, CX16, ERMS, F16C, HTT, LZCNT, MMX, MMXEXT, NX, POPCNT,
 RDRAND, RDSEED, RDTSCP, SGX, SSE, SSE2, SSE3, SSE4.1, SSE4.2 and SSSE3.
@@ -316,7 +316,8 @@ labels by defining them in the `nfd-worker` configuration file.
 
 Kernel config file to use, and, the set of config options to be detected are
 configurable.
-See [configuration options](#configuration-options) for more information.
+See [configuration](deployment-and-usage#configuration) for
+more information.
 
 ### Memory Features
 
@@ -370,8 +371,8 @@ label fields:
 feature.node.kubernetes.io/usb-fe_1a6e_089a.present=true
 ```
 
-See [configuration options](#configuration-options)
-for more information on NFD config.
+See [configuration](deployment-and-usage#configuration) for more
+information on NFD config.
 
 ### Storage Features
 

--- a/docs/get-started/features.md
+++ b/docs/get-started/features.md
@@ -446,7 +446,7 @@ Pods outside NFD, e.g. in Kubernetes device plugins. It is possible to mount
 the `source.d` and/or `features.d` directories common with the NFD Pod and
 deploy the custom hooks/features there. NFD will periodically scan the
 directories and run any hooks and read any feature files it finds. The
-[example nfd-worker deployment template](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/nfd-worker-daemonset.yaml.template#L69)
+[example nfd-worker deployment template](https://github.com/kubernetes-sigs/node-feature-discovery/blob/release-0.6/nfd-worker-daemonset.yaml.template#L69)
 contains `hostPath` mounts for `sources.d` and `features.d` directories. By
 using the same mounts in the secondary Pod (e.g. device plugin) you have
 created a shared area for delivering hooks and feature files to NFD.

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -20,11 +20,11 @@ Continue to:
 ## Quick-start -- the short-short version
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/nfd-master.yaml.template
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/release-0.6/nfd-master.yaml.template
   namespace/node-feature-discovery created
 ...
 
-$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/nfd-worker-daemonset.yaml.template
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/release-0.6/nfd-worker-daemonset.yaml.template
   daemonset.apps/nfd-worker created
 
 $ kubectl -n node-feature-discovery get all

--- a/docs/get-started/quick-start.md
+++ b/docs/get-started/quick-start.md
@@ -13,13 +13,13 @@ Minimal steps to deploy latest released version of NFD in your cluster.
 Deploy nfd-master -- creates a new namespace, service and required RBAC rules
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/v0.6.0/nfd-master.yaml.template
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/release-0.6/nfd-master.yaml.template
 ```
 
 Deploy nfd-worker as a daemonset
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/v0.6.0/nfd-worker-daemonset.yaml.template
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/release-0.6/nfd-worker-daemonset.yaml.template
 ```
 
 ## Verify

--- a/scripts/github/update-gh-pages.sh
+++ b/scripts/github/update-gh-pages.sh
@@ -99,9 +99,11 @@ fi
 
 # Default to 'master' if no subdir was given and we couldn't parse
 # it
-export SITE_SUBDIR=${site_subdir:-master}
-echo "Updating site subdir: '$SITE_SUBDIR'"
+site_subdir=${site_subdir:-master}
+echo "Updating site subdir: '$site_subdir'"
 
+export SITE_DESTDIR="_site/$site_subdir"
+export SITE_BASEURL="/node-feature-discovery/$site_subdir"
 export JEKYLL_ENV=production
 make site-build
 


### PR DESCRIPTION
- fix broken refs in docs/
- make Github refs point to `release-0.6` branch:
  Point to the tip of the release branch instead of master (or `v0.6.0` tag).
- fixup site baseurl setting (cherry-pick from master):
  Change build configuration related to site baseurl and Jekyll output directory a bit. Making it more coherent e.g. by removing the need to override baseurl for 'site-serve' makefile target.
