### PR TITLE
scripts/update-gh-pages: redirect to "stable" documentation

### DIFF
--- a/scripts/github/update-gh-pages.sh
+++ b/scripts/github/update-gh-pages.sh
@@ -125,6 +125,10 @@ _stable=`(ls -d1 v*/ || :) | sort -n | tail -n1`
 # Detect existing versions from the gh-pages branch
 create_versions_js > versions.js
 
+cat > index.html << EOF
+<meta http-equiv="refresh" content="0; URL='stable/'"/>
+EOF
+
 if [ -z "`git status --short`" ]; then
     echo "No new content, gh-pages branch already up-to-date"
     exit 0


### PR DESCRIPTION
Update update-gh-pages.sh to manage the index.html in the root of the
main gh-pages site. Make the index page to redirect to the documentation
of the latest stable version.