### PR TITLE
Add nfd-worker-conf ConfigMap to deployment templates

### DIFF
--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -174,39 +174,19 @@ possible.
 Worker configuration file is read inside the container, and thus, Volumes and
 VolumeMounts are needed to make your configuration available for NFD. The
 preferred method is to use a ConfigMap which provides easy deployment and
-re-configurability.  For example, create a config map using the example config
-as a template:
+re-configurability.
 
-```bash
-cp nfd-worker.conf.example nfd-worker.conf
-vim nfd-worker.conf  # edit the configuration
-kubectl create configmap nfd-worker-config --from-file=nfd-worker.conf
+The provided nfd-worker deployment templates create an empty configmap and
+mount it inside the nfd-worker containers. Configuration can be edited with:
+
 ```
-
-Then, configure Volumes and VolumeMounts in the Pod spec (just the relevant
-snippets shown below):
-
-```yaml
-...
-  containers:
-      volumeMounts:
-        - name: nfd-worker-config
-          mountPath: "/etc/kubernetes/node-feature-discovery/"
-...
-  volumes:
-    - name: nfd-worker-config
-      configMap:
-        name: nfd-worker-config
-...
+kubectl -n ${NFD_NS} edit configmap nfd-worker-conf
 ```
-
-You could also use other types of volumes, of course. That is, hostPath if
-different config for different nodes would be required, for example.
 
 The (empty-by-default)
 [example config](https://github.com/kubernetes-sigs/node-feature-discovery/blob/{{ site.release }}/nfd-worker.conf.example)
-is used as a config in the NFD Docker image. Thus, this can be used as a default
-configuration in custom-built images.
+contains all available configuration options and can be used as a reference
+for creating creating a configuration.
 
 Configuration options can also be specified via the `--options` command line
 flag, in which case no mounts need to be used. The same format as in the config

--- a/nfd-daemonset-combined.yaml.template
+++ b/nfd-daemonset-combined.yaml.template
@@ -110,6 +110,9 @@ spec:
             - name: features-d
               mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
               readOnly: true
+            - name: nfd-worker-conf
+              mountPath: "/etc/kubernetes/node-feature-discovery"
+              readOnly: true
       volumes:
         - name: host-boot
           hostPath:
@@ -126,3 +129,99 @@ spec:
         - name: features-d
           hostPath:
             path: "/etc/kubernetes/node-feature-discovery/features.d/"
+        - name: nfd-worker-conf
+          configMap:
+            name: nfd-worker-conf
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nfd-worker-conf
+  namespace: node-feature-discovery
+data:
+  nfd-worker.conf: |
+    #sources:
+    #  cpu:
+    #    cpuid:
+    ##     NOTE: whitelist has priority over blacklist
+    #      attributeBlacklist:
+    #        - "BMI1"
+    #        - "BMI2"
+    #        - "CLMUL"
+    #        - "CMOV"
+    #        - "CX16"
+    #        - "ERMS"
+    #        - "F16C"
+    #        - "HTT"
+    #        - "LZCNT"
+    #        - "MMX"
+    #        - "MMXEXT"
+    #        - "NX"
+    #        - "POPCNT"
+    #        - "RDRAND"
+    #        - "RDSEED"
+    #        - "RDTSCP"
+    #        - "SGX"
+    #        - "SSE"
+    #        - "SSE2"
+    #        - "SSE3"
+    #        - "SSE4.1"
+    #        - "SSE4.2"
+    #        - "SSSE3"
+    #      attributeWhitelist:
+    #  kernel:
+    #    kconfigFile: "/path/to/kconfig"
+    #    configOpts:
+    #      - "NO_HZ"
+    #      - "X86"
+    #      - "DMI"
+    #  pci:
+    #    deviceClassWhitelist:
+    #      - "0200"
+    #      - "03"
+    #      - "12"
+    #    deviceLabelFields:
+    #      - "class"
+    #      - "vendor"
+    #      - "device"
+    #      - "subsystem_vendor"
+    #      - "subsystem_device"
+    #  usb:
+    #    deviceClassWhitelist:
+    #      - "0e"
+    #      - "ef"
+    #      - "fe"
+    #      - "ff"
+    #    deviceLabelFields:
+    #      - "class"
+    #      - "vendor"
+    #      - "device"
+    #  custom:
+    #    - name: "my.kernel.feature"
+    #      matchOn:
+    #        - loadedKMod: ["example_kmod1", "example_kmod2"]
+    #    - name: "my.pci.feature"
+    #      matchOn:
+    #        - pciId:
+    #            class: ["0200"]
+    #            vendor: ["15b3"]
+    #            device: ["1014", "1017"]
+    #        - pciId :
+    #            vendor: ["8086"]
+    #            device: ["1000", "1100"]
+    #    - name: "my.usb.feature"
+    #      matchOn:
+    #        - usbId:
+    #          class: ["ff"]
+    #          vendor: ["03e7"]
+    #          device: ["2485"]
+    #        - usbId:
+    #          class: ["fe"]
+    #          vendor: ["1a6e"]
+    #          device: ["089a"]
+    #    - name: "my.combined.feature"
+    #      matchOn:
+    #        - pciId:
+    #            vendor: ["15b3"]
+    #            device: ["1014", "1017"]
+    #          loadedKMod : ["vendor_kmod1", "vendor_kmod2"]

--- a/nfd-worker-daemonset.yaml.template
+++ b/nfd-worker-daemonset.yaml.template
@@ -57,6 +57,9 @@ spec:
             - name: features-d
               mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
               readOnly: true
+            - name: nfd-worker-conf
+              mountPath: "/etc/kubernetes/node-feature-discovery"
+              readOnly: true
 ## Enable TLS authentication (2/3)
 #            - name: nfd-ca-cert
 #              mountPath: "/etc/kubernetes/node-feature-discovery/trust"
@@ -80,6 +83,9 @@ spec:
         - name: features-d
           hostPath:
             path: "/etc/kubernetes/node-feature-discovery/features.d/"
+        - name: nfd-worker-conf
+          configMap:
+            name: nfd-worker-conf
 ## Enable TLS authentication (3/3)
 #        - name: nfd-ca-cert
 #          configMap:
@@ -87,3 +93,96 @@ spec:
 #        - name: nfd-worker-cert
 #          secret:
 #            secretName: nfd-worker-cert
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nfd-worker-conf
+  namespace: node-feature-discovery
+data:
+  nfd-worker.conf: |
+    #sources:
+    #  cpu:
+    #    cpuid:
+    ##     NOTE: whitelist has priority over blacklist
+    #      attributeBlacklist:
+    #        - "BMI1"
+    #        - "BMI2"
+    #        - "CLMUL"
+    #        - "CMOV"
+    #        - "CX16"
+    #        - "ERMS"
+    #        - "F16C"
+    #        - "HTT"
+    #        - "LZCNT"
+    #        - "MMX"
+    #        - "MMXEXT"
+    #        - "NX"
+    #        - "POPCNT"
+    #        - "RDRAND"
+    #        - "RDSEED"
+    #        - "RDTSCP"
+    #        - "SGX"
+    #        - "SSE"
+    #        - "SSE2"
+    #        - "SSE3"
+    #        - "SSE4.1"
+    #        - "SSE4.2"
+    #        - "SSSE3"
+    #      attributeWhitelist:
+    #  kernel:
+    #    kconfigFile: "/path/to/kconfig"
+    #    configOpts:
+    #      - "NO_HZ"
+    #      - "X86"
+    #      - "DMI"
+    #  pci:
+    #    deviceClassWhitelist:
+    #      - "0200"
+    #      - "03"
+    #      - "12"
+    #    deviceLabelFields:
+    #      - "class"
+    #      - "vendor"
+    #      - "device"
+    #      - "subsystem_vendor"
+    #      - "subsystem_device"
+    #  usb:
+    #    deviceClassWhitelist:
+    #      - "0e"
+    #      - "ef"
+    #      - "fe"
+    #      - "ff"
+    #    deviceLabelFields:
+    #      - "class"
+    #      - "vendor"
+    #      - "device"
+    #  custom:
+    #    - name: "my.kernel.feature"
+    #      matchOn:
+    #        - loadedKMod: ["example_kmod1", "example_kmod2"]
+    #    - name: "my.pci.feature"
+    #      matchOn:
+    #        - pciId:
+    #            class: ["0200"]
+    #            vendor: ["15b3"]
+    #            device: ["1014", "1017"]
+    #        - pciId :
+    #            vendor: ["8086"]
+    #            device: ["1000", "1100"]
+    #    - name: "my.usb.feature"
+    #      matchOn:
+    #        - usbId:
+    #          class: ["ff"]
+    #          vendor: ["03e7"]
+    #          device: ["2485"]
+    #        - usbId:
+    #          class: ["fe"]
+    #          vendor: ["1a6e"]
+    #          device: ["089a"]
+    #    - name: "my.combined.feature"
+    #      matchOn:
+    #        - pciId:
+    #            vendor: ["15b3"]
+    #            device: ["1014", "1017"]
+    #          loadedKMod : ["vendor_kmod1", "vendor_kmod2"]

--- a/nfd-worker-job.yaml.template
+++ b/nfd-worker-job.yaml.template
@@ -66,6 +66,9 @@ spec:
             - name: features-d
               mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
               readOnly: true
+            - name: nfd-worker-conf
+              mountPath: "/etc/kubernetes/node-feature-discovery"
+              readOnly: true
 ## Enable TLS authentication (2/3)
 #            - name: nfd-ca-cert
 #              mountPath: "/etc/kubernetes/node-feature-discovery/trust"
@@ -90,6 +93,9 @@ spec:
         - name: features-d
           hostPath:
             path: "/etc/kubernetes/node-feature-discovery/features.d/"
+        - name: nfd-worker-conf
+          configMap:
+            name: nfd-worker-conf
 ## Enable TLS authentication (3/3)
 #        - name: nfd-ca-cert
 #          configMap:
@@ -97,3 +103,96 @@ spec:
 #        - name: nfd-worker-cert
 #          secret:
 #            secretName: nfd-worker-cert
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nfd-worker-conf
+  namespace: node-feature-discovery
+data:
+  nfd-worker.conf: |
+    #sources:
+    #  cpu:
+    #    cpuid:
+    ##     NOTE: whitelist has priority over blacklist
+    #      attributeBlacklist:
+    #        - "BMI1"
+    #        - "BMI2"
+    #        - "CLMUL"
+    #        - "CMOV"
+    #        - "CX16"
+    #        - "ERMS"
+    #        - "F16C"
+    #        - "HTT"
+    #        - "LZCNT"
+    #        - "MMX"
+    #        - "MMXEXT"
+    #        - "NX"
+    #        - "POPCNT"
+    #        - "RDRAND"
+    #        - "RDSEED"
+    #        - "RDTSCP"
+    #        - "SGX"
+    #        - "SSE"
+    #        - "SSE2"
+    #        - "SSE3"
+    #        - "SSE4.1"
+    #        - "SSE4.2"
+    #        - "SSSE3"
+    #      attributeWhitelist:
+    #  kernel:
+    #    kconfigFile: "/path/to/kconfig"
+    #    configOpts:
+    #      - "NO_HZ"
+    #      - "X86"
+    #      - "DMI"
+    #  pci:
+    #    deviceClassWhitelist:
+    #      - "0200"
+    #      - "03"
+    #      - "12"
+    #    deviceLabelFields:
+    #      - "class"
+    #      - "vendor"
+    #      - "device"
+    #      - "subsystem_vendor"
+    #      - "subsystem_device"
+    #  usb:
+    #    deviceClassWhitelist:
+    #      - "0e"
+    #      - "ef"
+    #      - "fe"
+    #      - "ff"
+    #    deviceLabelFields:
+    #      - "class"
+    #      - "vendor"
+    #      - "device"
+    #  custom:
+    #    - name: "my.kernel.feature"
+    #      matchOn:
+    #        - loadedKMod: ["example_kmod1", "example_kmod2"]
+    #    - name: "my.pci.feature"
+    #      matchOn:
+    #        - pciId:
+    #            class: ["0200"]
+    #            vendor: ["15b3"]
+    #            device: ["1014", "1017"]
+    #        - pciId :
+    #            vendor: ["8086"]
+    #            device: ["1000", "1100"]
+    #    - name: "my.usb.feature"
+    #      matchOn:
+    #        - usbId:
+    #          class: ["ff"]
+    #          vendor: ["03e7"]
+    #          device: ["2485"]
+    #        - usbId:
+    #          class: ["fe"]
+    #          vendor: ["1a6e"]
+    #          device: ["089a"]
+    #    - name: "my.combined.feature"
+    #      matchOn:
+    #        - pciId:
+    #            vendor: ["15b3"]
+    #            device: ["1014", "1017"]
+    #          loadedKMod : ["vendor_kmod1", "vendor_kmod2"]

--- a/nfd-worker-job.yaml.template
+++ b/nfd-worker-job.yaml.template
@@ -43,6 +43,13 @@ spec:
           args:
             - "--oneshot"
             - "--server=nfd-master:8080"
+## Enable TLS authentication (1/3)
+## The example below assumes having the root certificate named ca.crt stored in
+## a ConfigMap named nfd-ca-cert, and, the TLS authentication credentials stored
+## in a TLS Secret named nfd-worker-cert
+#            - "--ca-file=/etc/kubernetes/node-feature-discovery/trust/ca.crt"
+#            - "--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
+#            - "--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
           volumeMounts:
             - name: host-boot
               mountPath: "/host-boot"
@@ -59,6 +66,13 @@ spec:
             - name: features-d
               mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
               readOnly: true
+## Enable TLS authentication (2/3)
+#            - name: nfd-ca-cert
+#              mountPath: "/etc/kubernetes/node-feature-discovery/trust"
+#              readOnly: true
+#            - name: nfd-worker-cert
+#              mountPath: "/etc/kubernetes/node-feature-discovery/certs"
+#              readOnly: true
       restartPolicy: Never
       volumes:
         - name: host-boot
@@ -76,3 +90,10 @@ spec:
         - name: features-d
           hostPath:
             path: "/etc/kubernetes/node-feature-discovery/features.d/"
+## Enable TLS authentication (3/3)
+#        - name: nfd-ca-cert
+#          configMap:
+#            name: nfd-ca-cert
+#        - name: nfd-worker-cert
+#          secret:
+#            secretName: nfd-worker-cert

--- a/scripts/test-infra/verify.sh
+++ b/scripts/test-infra/verify.sh
@@ -7,3 +7,16 @@ export PATH=$PATH:$(go env GOPATH)/bin
 # Run verify steps
 make gofmt-verify
 make ci-lint
+
+# Check that repo is clean
+if ! git diff --quiet; then
+    echo "Repository is dirty!"
+    exit 1
+fi
+
+# Check that templates are up-to-date
+make templates
+if ! git diff --quiet; then
+    echo "Deployment templates are not up-to-date. Run 'make templates' to update"
+    exit 1
+fi


### PR DESCRIPTION
Add a virtually empty ConfigMap that is mounted inside the workers.
Makes it easier to start customizing the worker deployment e.g. with just:

  `$ kubectl -n ${NFD_NS} edit configmap nfd-worker-conf`

Create a new 'templates' make target for inserting the content of
nfd-worker.conf.example into the configmap spec of the templates. Thus,
'make templates' should be run whenever the example config is update.
Update the verify.sh prow script to check that the templates are up to
date.

This patch also streamlines the documentation about configuration
management, reflecting the changes.