### PR TITLE
Go 1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build node feature discovery
-FROM golang:1.14.7 as builder
+FROM golang:1.15.4 as builder
 
 # Get (cache) deps in a separate layer
 COPY go.mod go.sum /go/node-feature-discovery/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/node-feature-discovery
 
-go 1.14
+go 1.15
 
 require (
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815


### PR DESCRIPTION
Now that we are using deps from K8s 1.19 and the cert issue has been solved we are good to bump to go 1.15

this patch bumps both the Dockerfile and go.mod go version to 1.15

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>