### PR TITLE
Make all mounts in deployment templates read-only

### DIFF
--- a/nfd-daemonset-combined.yaml.template
+++ b/nfd-daemonset-combined.yaml.template
@@ -98,10 +98,13 @@ spec:
               readOnly: true
             - name: host-sys
               mountPath: "/host-sys"
+              readOnly: true
             - name: source-d
               mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
+              readOnly: true
             - name: features-d
               mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
+              readOnly: true
       volumes:
         - name: host-boot
           hostPath:

--- a/nfd-worker-daemonset.yaml.template
+++ b/nfd-worker-daemonset.yaml.template
@@ -50,10 +50,13 @@ spec:
               readOnly: true
             - name: host-sys
               mountPath: "/host-sys"
+              readOnly: true
             - name: source-d
               mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
+              readOnly: true
             - name: features-d
               mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
+              readOnly: true
 ## Enable TLS authentication (2/3)
 #            - name: nfd-ca-cert
 #              mountPath: "/etc/kubernetes/node-feature-discovery/trust"

--- a/nfd-worker-job.yaml.template
+++ b/nfd-worker-job.yaml.template
@@ -52,10 +52,13 @@ spec:
               readOnly: true
             - name: host-sys
               mountPath: "/host-sys"
+              readOnly: true
             - name: source-d
               mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
+              readOnly: true
             - name: features-d
               mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
+              readOnly: true
       restartPolicy: Never
       volumes:
         - name: host-boot


### PR DESCRIPTION
NFD-Worker does not need write access.