### PR TITLE
test/e2e: fix e2e-config node matching

### DIFF
--- a/test/e2e/node_feature_discovery.go
+++ b/test/e2e/node_feature_discovery.go
@@ -535,6 +535,7 @@ var _ = framework.KubeDescribe("[NFD] Node Feature Discovery", func() {
 						if conf.nameRe.MatchString(node.Name) {
 							e2elog.Logf("node %q matches rule %q", node.Name, conf.nameRe)
 							nodeConf = &conf
+							break
 						}
 					}
 					if nodeConf == nil {


### PR DESCRIPTION
Pick the correct rule when multiple node rules are present.