### PR TITLE
be a bit more verbose on a required KUBECONFIG env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ test:
 	$(GO_CMD) test ./cmd/... ./pkg/...
 
 e2e-test:
+	@if [ -z ${KUBECONFIG} ]; then echo "[ERR] KUBECONFIG missing, must be defined"; exit 1; fi
 	$(GO_CMD) test -v ./test/e2e/ -args -nfd.repo=$(IMAGE_REPO) -nfd.tag=$(IMAGE_TAG_NAME) -kubeconfig=$(KUBECONFIG) -nfd.e2e-config=$(E2E_TEST_CONFIG) -ginkgo.focus="\[NFD\]"
 
 push:


### PR DESCRIPTION
throw an error message before running `e2e-test` if `KUBECONFIG` is not defined 
 
Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>