### PR TITLE
go.mod: update klauspost/cpuid

### DIFF
--- a/docs/get-started/features.md
+++ b/docs/get-started/features.md
@@ -89,6 +89,8 @@ capability might be supported but not enabled.
 | AVX       | Advanced Vector Extensions (AVX)
 | AVX2      | Advanced Vector Extensions 2 (AVX2)
 
+See the full list in [github.com/klauspost/cpuid][klauspost-cpuid].
+
 #### Arm CPUID Attribute (Partial List)
 
 | Attribute | Description                                                      |
@@ -634,6 +636,7 @@ labels exist:
 ```
 
 <!-- Links -->
+[klauspost-cpuid]: https://github.com/klauspost/cpuid#x86-cpu-instructions
 [intel-rdt]: http://www.intel.com/content/www/us/en/architecture-and-technology/resource-director-technology.html
 [intel-pstate]: https://www.kernel.org/doc/Documentation/cpu-freq/intel-pstate.txt
 [intel-sst]: https://www.intel.com/content/www/us/en/architecture-and-technology/speed-select-technology-article.html

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,9 @@ go 1.15
 
 require (
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/protobuf v1.4.3
-	github.com/klauspost/cpuid v1.2.3
+	github.com/klauspost/cpuid v1.3.2-0.20201127150341-242d0b0aa207
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.0
 	github.com/smartystreets/assertions v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -402,8 +402,8 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
-github.com/klauspost/cpuid v1.2.3 h1:CCtW0xUnWGVINKvE/WWOYKdsPV6mawAtvQuSl8guwQs=
-github.com/klauspost/cpuid v1.2.3/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/klauspost/cpuid v1.3.2-0.20201127150341-242d0b0aa207 h1:p4Tby4HJ6itc7Bra1IzOIzYOvumFldKbHp79Y+W39d4=
+github.com/klauspost/cpuid v1.3.2-0.20201127150341-242d0b0aa207/go.mod h1:bYW4mA6ZgKPob1/Dlai2LviZJO7KGI3uoWLd42rAQw4=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=

--- a/source/internal/cpuidutils/cpuid_amd64.go
+++ b/source/internal/cpuidutils/cpuid_amd64.go
@@ -22,5 +22,5 @@ import (
 
 // Discover returns feature names for all the supported CPU features.
 func GetCpuidFlags() []string {
-	return cpuid.CPU.Features.Strings()
+	return cpuid.CPU.FeatureSet()
 }


### PR DESCRIPTION
The latest changes in klauspost/cpuid add detection for Sapphire Rapids
new instructions.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>