### PR TITLE
scripts/update-gh-pages: only update docs if version has been released

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,6 +14,8 @@ jobs:
 
     - name: Check out repo
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Fetch gh-pages branch
       run: git fetch --no-tags --prune --depth=1 origin refs/heads/gh-pages:refs/heads/gh-pages

--- a/scripts/github/update-gh-pages.sh
+++ b/scripts/github/update-gh-pages.sh
@@ -100,6 +100,20 @@ fi
 # Default to 'master' if no subdir was given and we couldn't parse
 # it
 site_subdir=${site_subdir:-master}
+
+# Check if this ref is for a released version
+if [ "$site_subdir" != "master" ]; then
+    _base_tag=`git describe --abbrev=0 || :`
+    case "$_base_tag" in
+        $site_subdir*)
+            ;;
+        *)
+            echo "Not a released version. Parsed release branch is $site_subdir but based on tag $_base_tag. Stopping here."
+            exit 0
+            ;;
+    esac
+fi
+
 echo "Updating site subdir: '$site_subdir'"
 
 export SITE_DESTDIR="_site/$site_subdir"


### PR DESCRIPTION
Only update documentation if the version has been released (i.e. a git
tag corresponding the version we're updating exists) or it is for the
master branch. Prevents us from pointing users to documentation of an
unreleased version.

Also updates github workflow to fetch full commit history (including
tags) so that git describe works correctly.