### PR TITLE
Fix auto-generation of nfd-prune.yaml

### DIFF
--- a/nfd-prune.yaml.template
+++ b/nfd-prune.yaml.template
@@ -28,8 +28,8 @@ spec:
           value: ""
           effect: "NoSchedule"
       containers:
-        - image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
-          name: nfd-master
+        - name: nfd-master
+          image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Change the template so that our sed magic updates the container image
name correctly.