### PR TITLE
Add namespace and RBAC rules to nfd-prune.yaml.template

### DIFF
--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -262,7 +262,7 @@ nfd-related node labels, annotations and extended resources from the cluster.
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-prune.yaml.template
 kubectl -n node-feature-discovery wait job.batch/nfd-prune --for=condition=complete && \
-    kubectl -n node-feature-discovery delete job/nfd-prune
+    kubectl delete -f kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-prune.yaml.template
 ```
 
 **NOTE:** You must run prune before removing the RBAC rules (serviceaccount,

--- a/nfd-prune.yaml.template
+++ b/nfd-prune.yaml.template
@@ -1,3 +1,46 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: node-feature-discovery # NFD namespace
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfd-master
+  namespace: node-feature-discovery
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nfd-master
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+# when using command line flag --resource-labels to create extended resources
+# you will need to uncomment "- nodes/status"
+# - nodes/status
+  verbs:
+  - get
+  - patch
+  - update
+  # List only needed for --prune
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nfd-master
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nfd-master
+subjects:
+- kind: ServiceAccount
+  name: nfd-master
+  namespace: node-feature-discovery
+---
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
Makes it possible to run prune on its own. Reflect this change in the
documentation.