### PR TITLE
Added nodename rule to custom source

### DIFF
--- a/deployment/node-feature-discovery/values.yaml
+++ b/deployment/node-feature-discovery/values.yaml
@@ -161,6 +161,10 @@ worker:
     #            vendor: ["15b3"]
     #            device: ["1014", "1017"]
     #          loadedKMod : ["vendor_kmod1", "vendor_kmod2"]
+    #    - name: "feature.by.nodename"
+    #      value: customValue
+    #      matchOn:
+    #        - nodename: ["worker-0", "my-.*-node"]
 ### <NFD-WORKER-CONF-END-DO-NOT-REMOVE>
 
   podSecurityContext: {}

--- a/nfd-daemonset-combined.yaml.template
+++ b/nfd-daemonset-combined.yaml.template
@@ -115,6 +115,11 @@ spec:
             - name: nfd-worker-conf
               mountPath: "/etc/kubernetes/node-feature-discovery"
               readOnly: true
+## Example for more custom configs in an additional configmap (1/3)
+## Mounting into subdirectories of custom.d makes it easy to use multiple configmaps
+#            - name: custom-source-extra-rules
+#              mountPath: "/etc/kubernetes/node-feature-discovery/custom.d/extra-rules-1"
+#              readOnly: true
       volumes:
         - name: host-boot
           hostPath:
@@ -134,6 +139,10 @@ spec:
         - name: nfd-worker-conf
           configMap:
             name: nfd-worker-conf
+## Example for more custom configs in an additional configmap (2/3)
+#        - name: custom-source-extra-rules
+#          configMap:
+#            name: custom-source-extra-rules
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -232,4 +241,25 @@ data:
     #            vendor: ["15b3"]
     #            device: ["1014", "1017"]
     #          loadedKMod : ["vendor_kmod1", "vendor_kmod2"]
+    #    - name: "feature.by.nodename"
+    #      value: customValue
+    #      matchOn:
+    #        - nodename: ["worker-0", "my-.*-node"]
 ### <NFD-WORKER-CONF-END-DO-NOT-REMOVE>
+---
+## Example for more custom configs in an additional configmap (3/3)
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: custom-source-extra-rules
+#  namespace: node-feature-discovery
+#data:
+## Filename doesn't matter, and there can be multiple. They just need to be unique.
+#  custom.conf: |
+#    - name: "more.kernel.features"
+#      matchOn:
+#      - loadedKMod: ["example_kmod3"]
+#    - name: "more.features.by.nodename"
+#      value: customValue
+#      matchOn:
+#      - nodename: ["special-.*-node-.*"]

--- a/nfd-worker-daemonset.yaml.template
+++ b/nfd-worker-daemonset.yaml.template
@@ -68,6 +68,11 @@ spec:
             - name: nfd-worker-conf
               mountPath: "/etc/kubernetes/node-feature-discovery"
               readOnly: true
+## Example for more custom configs in an additional configmap (1/3)
+## Mounting into subdirectories of custom.d makes it easy to use multiple configmaps
+#            - name: custom-source-extra-rules
+#              mountPath: "/etc/kubernetes/node-feature-discovery/custom.d/extra-rules-1"
+#              readOnly: true
 ## Enable TLS authentication (2/3)
 #            - name: nfd-ca-cert
 #              mountPath: "/etc/kubernetes/node-feature-discovery/trust"
@@ -94,6 +99,10 @@ spec:
         - name: nfd-worker-conf
           configMap:
             name: nfd-worker-conf
+## Example for more custom configs in an additional configmap (2/3)
+#        - name: custom-source-extra-rules
+#          configMap:
+#            name: custom-source-extra-rules
 ## Enable TLS authentication (3/3)
 #        - name: nfd-ca-cert
 #          configMap:
@@ -199,4 +208,25 @@ data:
     #            vendor: ["15b3"]
     #            device: ["1014", "1017"]
     #          loadedKMod : ["vendor_kmod1", "vendor_kmod2"]
+    #    - name: "feature.by.nodename"
+    #      value: customValue
+    #      matchOn:
+    #        - nodename: ["worker-0", "my-.*-node"]
 ### <NFD-WORKER-CONF-END-DO-NOT-REMOVE>
+---
+## Example for more custom configs in an additional configmap (3/3)
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: custom-source-extra-rules
+#  namespace: node-feature-discovery
+#data:
+## Filename doesn't matter, and there can be multiple. They just need to be unique.
+#  custom.conf: |
+#    - name: "more.kernel.features"
+#      matchOn:
+#      - loadedKMod: ["example_kmod3"]
+#    - name: "more.features.by.nodename"
+#      value: customValue
+#      matchOn:
+#      - nodename: ["special-.*-node-.*"]

--- a/nfd-worker-job.yaml.template
+++ b/nfd-worker-job.yaml.template
@@ -72,6 +72,11 @@ spec:
             - name: nfd-worker-conf
               mountPath: "/etc/kubernetes/node-feature-discovery"
               readOnly: true
+## Example for more custom configs in an additional configmap (1/3)
+## Mounting into subdirectories of custom.d makes it easy to use multiple configmaps
+#            - name: custom-source-extra-rules
+#              mountPath: "/etc/kubernetes/node-feature-discovery/custom.d/extra-rules-1"
+#              readOnly: true
 ## Enable TLS authentication (2/3)
 #            - name: nfd-ca-cert
 #              mountPath: "/etc/kubernetes/node-feature-discovery/trust"
@@ -99,6 +104,10 @@ spec:
         - name: nfd-worker-conf
           configMap:
             name: nfd-worker-conf
+## Example for more custom configs in an additional configmap (2/3)
+#        - name: custom-source-extra-rules
+#          configMap:
+#            name: custom-source-extra-rules
 ## Enable TLS authentication (3/3)
 #        - name: nfd-ca-cert
 #          configMap:
@@ -204,4 +213,25 @@ data:
     #            vendor: ["15b3"]
     #            device: ["1014", "1017"]
     #          loadedKMod : ["vendor_kmod1", "vendor_kmod2"]
+    #    - name: "feature.by.nodename"
+    #      value: customValue
+    #      matchOn:
+    #        - nodename: ["worker-0", "my-.*-node"]
 ### <NFD-WORKER-CONF-END-DO-NOT-REMOVE>
+---
+## Example for more custom configs in an additional configmap (3/3)
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: custom-source-extra-rules
+#  namespace: node-feature-discovery
+#data:
+## Filename doesn't matter, and there can be multiple. They just need to be unique.
+#  custom.conf: |
+#    - name: "more.kernel.features"
+#      matchOn:
+#      - loadedKMod: ["example_kmod3"]
+#    - name: "more.features.by.nodename"
+#      value: customValue
+#      matchOn:
+#      - nodename: ["special-.*-node-.*"]

--- a/nfd-worker.conf.example
+++ b/nfd-worker.conf.example
@@ -88,3 +88,7 @@
 #            vendor: ["15b3"]
 #            device: ["1014", "1017"]
 #          loadedKMod : ["vendor_kmod1", "vendor_kmod2"]
+#    - name: "feature.by.nodename"
+#      value: customValue
+#      matchOn:
+#        - nodename: ["worker-0", "my-.*-node"]

--- a/source/custom/directory_features.go
+++ b/source/custom/directory_features.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package custom
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+const Directory = "/etc/kubernetes/node-feature-discovery/custom.d"
+
+// getDirectoryFeatureConfig returns features configured in the "/etc/kubernetes/node-feature-discovery/custom.d"
+// host directory and its 1st level subdirectories, which can be populated e.g. by ConfigMaps
+func getDirectoryFeatureConfig() []FeatureSpec {
+	features := readDir(Directory, true)
+	//log.Printf("DEBUG: all configmap based custom feature specs: %+v", features)
+	return features
+}
+
+func readDir(dirName string, recursive bool) []FeatureSpec {
+	features := make([]FeatureSpec, 0)
+
+	log.Printf("DEBUG: getting files in %s", dirName)
+	files, err := ioutil.ReadDir(dirName)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Printf("DEBUG: custom config directory %q does not exist", dirName)
+		} else {
+			log.Printf("ERROR: unable to access custom config directory %q, %v", dirName, err)
+		}
+		return features
+	}
+
+	for _, file := range files {
+		fileName := filepath.Join(dirName, file.Name())
+
+		if file.IsDir() {
+			if recursive {
+				//log.Printf("DEBUG: going into dir %q", fileName)
+				features = append(features, readDir(fileName, false)...)
+				//} else {
+				//	log.Printf("DEBUG: skipping dir %q", fileName)
+			}
+			continue
+		}
+		if strings.HasPrefix(file.Name(), ".") {
+			//log.Printf("DEBUG: skipping hidden file %q", fileName)
+			continue
+		}
+		//log.Printf("DEBUG: processing file %q", fileName)
+
+		bytes, err := ioutil.ReadFile(fileName)
+		if err != nil {
+			log.Printf("ERROR: could not read custom config file %q, %v", fileName, err)
+			continue
+		}
+		//log.Printf("DEBUG: custom config rules raw: %s", string(bytes))
+
+		config := &[]FeatureSpec{}
+		err = yaml.UnmarshalStrict(bytes, config)
+		if err != nil {
+			log.Printf("ERROR: could not parse custom config file %q, %v", fileName, err)
+			continue
+		}
+
+		features = append(features, *config...)
+	}
+	return features
+}

--- a/source/custom/rules/nodename_rule.go
+++ b/source/custom/rules/nodename_rule.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package rules
+
+import (
+	"log"
+	"os"
+	"regexp"
+)
+
+var (
+	nodeName = os.Getenv("NODE_NAME")
+)
+
+// Rule that matches on nodenames configured in a ConfigMap
+type NodenameRule []string
+
+// Force implementation of Rule
+var _ Rule = NodenameRule{}
+
+func (n NodenameRule) Match() (bool, error) {
+	for _, nodenamePattern := range n {
+		log.Printf("DEBUG: matchNodename %s", nodenamePattern)
+		match, err := regexp.MatchString(nodenamePattern, nodeName)
+		if err != nil {
+			log.Printf("ERROR: nodename rule: invalid nodename regexp %q: %v", nodenamePattern, err)
+			continue
+		}
+		if !match {
+			//log.Printf("DEBUG: nodename rule: No match for pattern %q with node %q", nodenamePattern, nodeName)
+			continue
+		}
+		//log.Printf("DEBUG: nodename rule: Match for pattern %q with node %q", nodenamePattern, nodeName)
+		return true, nil
+	}
+	return false, nil
+}


### PR DESCRIPTION
# What
With this PR we add a new `nodename` rule for the `custom` source for the NFD worker, which will apply features based on  nodes' hostnames.

For making more dynamic configuration by potentially multiple parties easier, `custom` source rules can also be read from the `/etc/kubernetes/node-feature-discovery/custom.d` directory now (probabaly mostly populated by mounted ConfigMaps).

Also an optional `value` field was added, which allows overruling the default `true` value for matching features if set.

# Details

## Example
Consider this config:
```
- name: "feature.by.nodename"
  # default value is true
  matchOn:
    - nodename:
      - worker-0
      - worker-1
- name: "another.features.by.nodename.regex"
  value: customValue
  matchOn:
    - nodename:
      - wor.*-0
```

The config will apply the `feature.by.nodename=true` feature to the `worker-0` and `worker-1` nodes, and the `another.features.by.nodename.regex=customValue` feature to all nodes matching the `wor.*-0` regex.

## Implementation
- the mounting of additional ConfigMaps into the NFD worker pod is a bit cumbersome, but can be automated with the NFD operator in a follow up (e.g. mount all ConfigMaps in the NFD namespace which match a certain name pattern).

# Usecase
A customer with many nodes is able to set the nodename according the node's purpose during node deployment, but not to add the needed labels for workload scheduling. The nodename is the only metadata available for determining the node's purpose.
With this new source the customer can put the desired nodename - label mapping(s) into a ConfigMap, and let NFD do the work of putting the labels on the nodes.

/cc @zvonkok @ArangoGutierrez @marquiz 
