### PR TITLE
nfd-worker: use fsnotify for watching for config file changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/protobuf v1.4.3
 	github.com/klauspost/cpuid/v2 v2.0.2
 	github.com/onsi/ginkgo v1.11.0

--- a/pkg/nfd-worker/nfd-worker.go
+++ b/pkg/nfd-worker/nfd-worker.go
@@ -286,6 +286,10 @@ func (w *nfdWorker) Run() error {
 
 		case <-configTrigger:
 			w.configure(configFilePath, w.args.Options)
+
+			// Always re-label after a re-config event. This way the new config
+			// comes into effect even if the sleep interval is long (or infinite)
+			labelTrigger = time.After(0)
 		}
 	}
 }


### PR DESCRIPTION
Add support for detecting configuration file changes via file system
notifications (fsnotify). Watches are added for the whole directory
chain (up to root directory) so that all changes (even directory
renames) affecting the given configuration file path are captured.

Previously dynamic (re-)configuration of nfd-worker was implemented by
(re-)reading the configuration file on every labeling pass. This was
simple and effective, even if a bit wasteful. However, it didn't provide
asynchronous configuration updates that will be required for e.g.
controlling the "sleep-interval" parameter dynamically which will be
implemented by later patches.
