### PR TITLE
Change the worker conf update mechanism of templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,13 @@ templates: $(yaml_templates)
 	@# Need to prepend each line in the sample config with spaces in order to
 	@# fit correctly in the configmap spec.
 	@sed s'/^/    /' nfd-worker.conf.example > nfd-worker.conf.tmp
-	@# The quick-n-dirty sed below expects the configmap data to be at the very end of the file
-	@for f in $+; do sed -e '/nfd-worker\.conf/r nfd-worker.conf.tmp' -e '/nfd-worker\.conf/q' -i $$f; done
+	@# The sed magic below replaces the block of text between the lines with start and end markers
+	@for f in $+; do \
+	    start=NFD-WORKER-CONF-START-DO-NOT-REMOVE; \
+	    end=NFD-WORKER-CONF-END-DO-NOT-REMOVE; \
+	    sed -e "/$$start/,/$$end/{ /$$start/{ p; r nfd-worker.conf.tmp" \
+	        -e "}; /$$end/p; d }" -i $$f; \
+	done
 	@rm nfd-worker.conf.tmp
 
 mock:

--- a/nfd-daemonset-combined.yaml.template
+++ b/nfd-daemonset-combined.yaml.template
@@ -141,7 +141,7 @@ metadata:
   name: nfd-worker-conf
   namespace: node-feature-discovery
 data:
-  nfd-worker.conf: |
+  nfd-worker.conf: | ### <NFD-WORKER-CONF-START-DO-NOT-REMOVE>
     #sources:
     #  cpu:
     #    cpuid:
@@ -227,3 +227,4 @@ data:
     #            vendor: ["15b3"]
     #            device: ["1014", "1017"]
     #          loadedKMod : ["vendor_kmod1", "vendor_kmod2"]
+### <NFD-WORKER-CONF-END-DO-NOT-REMOVE>

--- a/nfd-worker-daemonset.yaml.template
+++ b/nfd-worker-daemonset.yaml.template
@@ -101,7 +101,7 @@ metadata:
   name: nfd-worker-conf
   namespace: node-feature-discovery
 data:
-  nfd-worker.conf: |
+  nfd-worker.conf: | ### <NFD-WORKER-CONF-START-DO-NOT-REMOVE>
     #sources:
     #  cpu:
     #    cpuid:
@@ -187,3 +187,4 @@ data:
     #            vendor: ["15b3"]
     #            device: ["1014", "1017"]
     #          loadedKMod : ["vendor_kmod1", "vendor_kmod2"]
+### <NFD-WORKER-CONF-END-DO-NOT-REMOVE>

--- a/nfd-worker-job.yaml.template
+++ b/nfd-worker-job.yaml.template
@@ -111,7 +111,7 @@ metadata:
   name: nfd-worker-conf
   namespace: node-feature-discovery
 data:
-  nfd-worker.conf: |
+  nfd-worker.conf: | ### <NFD-WORKER-CONF-START-DO-NOT-REMOVE>
     #sources:
     #  cpu:
     #    cpuid:
@@ -197,3 +197,4 @@ data:
     #            vendor: ["15b3"]
     #            device: ["1014", "1017"]
     #          loadedKMod : ["vendor_kmod1", "vendor_kmod2"]
+### <NFD-WORKER-CONF-END-DO-NOT-REMOVE>


### PR DESCRIPTION
Rely on markers instead which makes the update work also in the middle
of a template file. Previously it relied on the configuration data to be
at the very end of the file to be updated.