### PR TITLE
Replace improper usage of filepath.Join with path.Join

### DIFF
--- a/pkg/apihelper/jsonpatch.go
+++ b/pkg/apihelper/jsonpatch.go
@@ -17,7 +17,7 @@ limitations under the License.
 package apihelper
 
 import (
-	"path/filepath"
+	"path"
 	"strings"
 )
 
@@ -29,6 +29,6 @@ type JsonPatch struct {
 }
 
 // NewJsonPatch returns a new JsonPatch object
-func NewJsonPatch(verb string, path string, key string, value string) JsonPatch {
-	return JsonPatch{verb, filepath.Join(path, strings.ReplaceAll(key, "/", "~1")), value}
+func NewJsonPatch(verb string, jsonpath string, key string, value string) JsonPatch {
+	return JsonPatch{verb, path.Join(jsonpath, strings.ReplaceAll(key, "/", "~1")), value}
 }

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -24,7 +24,7 @@ import (
 	"log"
 	"net"
 	"os"
-	"path/filepath"
+	"path"
 	"regexp"
 	"sort"
 	"strconv"
@@ -500,7 +500,7 @@ func addNs(src string, nsToAdd string) string {
 	if strings.Contains(src, "/") {
 		return src
 	}
-	return filepath.Join(nsToAdd, src)
+	return path.Join(nsToAdd, src)
 }
 
 // splitNs splits a name into its namespace and name parts


### PR DESCRIPTION
In JSON and kubernetes API object names we want to use slashes instead
of the OS dependent file path separator.