### PR TITLE
Add NFD master '--instance' flag support to Helm chart

### DIFF
--- a/deployment/node-feature-discovery/templates/master.yaml
+++ b/deployment/node-feature-discovery/templates/master.yaml
@@ -44,6 +44,10 @@ spec:
             - "nfd-master"
           resources:
             {{- toYaml .Values.master.resources | nindent 12 }}
+          args:
+            { { - if .Values.master.instance | empty | not } }
+            - "--instance={{ .Values.master.instance }}"
+            { { - end } }
 ## Enable TLS authentication
 ## The example below assumes having the root certificate named ca.crt stored in
 ## a ConfigMap named nfd-ca-cert, and, the TLS authentication credentials stored
@@ -51,7 +55,6 @@ spec:
 ## Additional hardening can be enabled by specifying --verify-node-name in
 ## args, in which case every nfd-worker requires a individual node-specific
 ## TLS certificate.
-#          args:
 #            - "--ca-file=/etc/kubernetes/node-feature-discovery/trust/ca.crt"
 #            - "--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
 #            - "--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"

--- a/deployment/node-feature-discovery/values.yaml
+++ b/deployment/node-feature-discovery/values.yaml
@@ -19,6 +19,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 master:
+  instance:
   replicaCount: 1
 
   podSecurityContext: {}

--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -171,6 +171,7 @@ We have introduced the following Chart parameters.
 ##### Master pod parameters
 
 | `master.*` | dict |  | NFD master deployment configuration |
+| `master.instance` | string |  |  Instance name. Used to separate annotation namespaces for multiple parallel deployments |
 | `master.replicaCount` | integer | 1 | Number of desired pods. This is a pointer to distinguish between explicit zero and not specified |
 | `master.podSecurityContext` | dict | {} | SecurityContext holds pod-level security attributes and common container settings |
 | `master.service.type` | string | ClusterIP | NFD master service type |


### PR DESCRIPTION
 --instance flag was introduce in the e52ec3480fc586211bbdea3c99caa47bf810c72d commit.

This patch adds ability to configure it in the Helm chard during deployment.