### PR TITLE
Fix daemonset deployment template

### DIFF
--- a/nfd-worker-daemonset.yaml.template
+++ b/nfd-worker-daemonset.yaml.template
@@ -32,11 +32,6 @@ spec:
               drop: ["ALL"]
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-          tolerations:
-              - key: "node-role.kubernetes.io/master"
-                operator: "Equal"
-                value: ""
-                effect: "NoSchedule"
           command:
             - "nfd-worker"
           args:


### PR DESCRIPTION
Remove incorrect tolerations that accidentally crept in with the helm
charts and break the deployment.