### PR TITLE
Fix NFD master chart template

### DIFF
--- a/deployment/node-feature-discovery/templates/master.yaml
+++ b/deployment/node-feature-discovery/templates/master.yaml
@@ -45,9 +45,9 @@ spec:
           resources:
             {{- toYaml .Values.master.resources | nindent 12 }}
           args:
-            { { - if .Values.master.instance | empty | not } }
+            {{- if .Values.master.instance | empty | not }}
             - "--instance={{ .Values.master.instance }}"
-            { { - end } }
+            {{- end }}
 ## Enable TLS authentication
 ## The example below assumes having the root certificate named ca.crt stored in
 ## a ConfigMap named nfd-ca-cert, and, the TLS authentication credentials stored


### PR DESCRIPTION
Commit 88bd80d415eec5adc6af29bca9aa6509a2300307 introduces error
in template due to the bad formatting. This commit fixes it.