### PR TITLE
nfd-worker: switch to klog

### DIFF
--- a/cmd/nfd-worker/main.go
+++ b/cmd/nfd-worker/main.go
@@ -19,8 +19,9 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
+
+	"k8s.io/klog/v2"
 
 	worker "sigs.k8s.io/node-feature-discovery/pkg/nfd-worker"
 	"sigs.k8s.io/node-feature-discovery/pkg/utils"
@@ -46,17 +47,17 @@ func main() {
 
 	// Assert that the version is known
 	if version.Undefined() {
-		log.Printf("WARNING: version not set! Set -ldflags \"-X sigs.k8s.io/node-feature-discovery/pkg/version.version=`git describe --tags --dirty --always`\" during build or run.")
+		klog.Warningf("version not set! Set -ldflags \"-X sigs.k8s.io/node-feature-discovery/pkg/version.version=`git describe --tags --dirty --always`\" during build or run.")
 	}
 
 	// Get new NfdWorker instance
 	instance, err := worker.NewNfdWorker(args)
 	if err != nil {
-		log.Fatalf("Failed to initialize NfdWorker instance: %v", err)
+		klog.Fatalf("Failed to initialize NfdWorker instance: %v", err)
 	}
 
 	if err = instance.Run(); err != nil {
-		log.Fatalf("ERROR: %v", err)
+		klog.Fatal(err)
 	}
 }
 
@@ -76,13 +77,13 @@ func parseArgs(flags *flag.FlagSet, osArgs ...string) *worker.Args {
 		case "no-publish":
 			args.Overrides.NoPublish = overrides.NoPublish
 		case "label-whitelist":
-			log.Printf("WARNING: --label-whitelist is deprecated, use 'core.labelWhiteList' option in the config file, instead")
+			klog.Warningf("--label-whitelist is deprecated, use 'core.labelWhiteList' option in the config file, instead")
 			args.Overrides.LabelWhiteList = overrides.LabelWhiteList
 		case "sleep-interval":
-			log.Printf("WARNING: --sleep-interval is deprecated, use 'core.sleepInterval' option in the config file, instead")
+			klog.Warningf("--sleep-interval is deprecated, use 'core.sleepInterval' option in the config file, instead")
 			args.Overrides.SleepInterval = overrides.SleepInterval
 		case "sources":
-			log.Printf("WARNING: --sources is deprecated, use 'core.sources' option in the config file, instead")
+			klog.Warningf("--sources is deprecated, use 'core.sources' option in the config file, instead")
 			args.Overrides.Sources = overrides.Sources
 		}
 	})

--- a/cmd/nfd-worker/main_test.go
+++ b/cmd/nfd-worker/main_test.go
@@ -59,3 +59,19 @@ func TestParseArgs(t *testing.T) {
 		})
 	})
 }
+
+func TestKlogConfigOptName(t *testing.T) {
+	Convey("When converting names of klog command line flags", t, func() {
+		tcs := map[string]string{
+			"":                    "",
+			"a":                   "a",
+			"an_arg":              "anArg",
+			"arg_with_many_parts": "argWithManyParts",
+		}
+		Convey("resulting config option names should be as expected", func() {
+			for input, expected := range tcs {
+				So(klogConfigOptName(input), ShouldEqual, expected)
+			}
+		})
+	})
+}

--- a/deployment/node-feature-discovery/values.yaml
+++ b/deployment/node-feature-discovery/values.yaml
@@ -77,6 +77,21 @@ worker:
     #  noPublish: false
     #  sleepInterval: 60s
     #  sources: [all]
+    #  klog:
+    #    addDirHeader: false
+    #    alsologtostderr: false
+    #    logBacktraceAt:
+    #    logtostderr: true
+    #    skipHeaders: false
+    #    stderrthreshold: 2
+    #    v: 0
+    #    vmodule:
+    ##   NOTE: the following options are not dynamically run-time configurable
+    ##         and require a nfd-worker restart to take effect after being changed
+    #    logDir:
+    #    logFile:
+    #    logFileMaxSize: 1800
+    #    skipLogHeaders: false
     #sources:
     #  cpu:
     #    cpuid:

--- a/docs/advanced/worker-commandline-reference.md
+++ b/docs/advanced/worker-commandline-reference.md
@@ -232,6 +232,10 @@ configuration file, instead.
 The following logging-related flags are inherited from the
 [klog](https://pkg.go.dev/k8s.io/klog/v2) package.
 
+Note: The logger setup can also be specified via the `core.klog` configuration
+file options. However, the command line flags take precedence over any
+corresponding config file options specified.
+
 #### -add_dir_header
 
 If true, adds the file directory to the header of the log messages.

--- a/docs/advanced/worker-commandline-reference.md
+++ b/docs/advanced/worker-commandline-reference.md
@@ -227,3 +227,80 @@ nfd-worker -sleep-interval=1h
 **DEPRECATED**: you should use the `core.sleepInterval` option in the
 configuration file, instead.
 
+### Logging
+
+The following logging-related flags are inherited from the
+[klog](https://pkg.go.dev/k8s.io/klog/v2) package.
+
+#### -add_dir_header
+
+If true, adds the file directory to the header of the log messages.
+
+Default: false
+
+#### -alsologtostderr
+
+Log to standard error as well as files.
+
+Default: false
+
+#### -log_backtrace_at
+
+When logging hits line file:N, emit a stack trace.
+
+Default: *empty*
+
+#### -log_dir
+
+If non-empty, write log files in this directory.
+
+Default: *empty*
+
+#### -log_file
+
+If non-empty, use this log file.
+
+Default: *empty*
+
+#### -log_file_max_size
+
+Defines the maximum size a log file can grow to. Unit is megabytes. If the
+value is 0, the maximum file size is unlimited.
+
+Default: 1800
+
+#### -logtostderr
+
+Log to standard error instead of files
+
+Default: true
+
+#### -skip_headers
+
+If true, avoid header prefixes in the log messages.
+
+Default: false
+
+#### -skip_log_headers
+
+If true, avoid headers when opening log files.
+
+Default: false
+
+#### -stderrthreshold
+
+Logs at or above this threshold go to stderr.
+
+Default: 2
+
+#### -v
+
+Number for the log level verbosity.
+
+Default: 0
+
+#### -vmodule
+
+Comma-separated list of `pattern=N` settings for file-filtered logging.
+
+Default: *empty*

--- a/docs/advanced/worker-configuration-reference.md
+++ b/docs/advanced/worker-configuration-reference.md
@@ -104,6 +104,109 @@ core:
   noPublish: true
 ```
 
+### core.klog
+
+The following options specify the logger configuration. Most of which can be
+dynamically adjusted at run-time.
+
+Note: The logger options can also be specified via command line flags which
+take precedence over any corresponding config file options.
+
+#### core.klog.addDirHeader
+
+If true, adds the file directory to the header of the log messages.
+
+Default: false
+
+Run-time configurable: yes
+
+#### core.klog.alsologtostderr
+
+Log to standard error as well as files.
+
+Default: false
+
+Run-time configurable: yes
+
+#### core.klog.logBacktraceAt
+
+When logging hits line file:N, emit a stack trace.
+
+Default: *empty*
+
+Run-time configurable: yes
+
+#### core.klog.logDir
+
+If non-empty, write log files in this directory.
+
+Default: *empty*
+
+Run-time configurable: no
+
+#### core.klog.logFile
+
+If non-empty, use this log file.
+
+Default: *empty*
+
+Run-time configurable: no
+
+#### core.klog.logFileMaxSize
+
+Defines the maximum size a log file can grow to. Unit is megabytes. If the
+value is 0, the maximum file size is unlimited.
+
+Default: 1800
+
+Run-time configurable: no
+
+#### core.klog.logtostderr
+
+Log to standard error instead of files
+
+Default: true
+
+Run-time configurable: yes
+
+#### core.klog.skipHeaders
+
+If true, avoid header prefixes in the log messages.
+
+Default: false
+
+Run-time configurable: yes
+
+#### core.klog.skipLogHeaders
+
+If true, avoid headers when opening log files.
+
+Default: false
+
+Run-time configurable: no
+
+#### core.klog.stderrthreshold
+
+Logs at or above this threshold go to stderr (default 2)
+
+Run-time configurable: yes
+
+#### core.klog.v
+
+Number for the log level verbosity.
+
+Default: 0
+
+Run-time configurable: yes
+
+#### core.klog.vmodule
+
+Comma-separated list of `pattern=N` settings for file-filtered logging.
+
+Default: *empty*
+
+Run-time configurable: yes
+
 ## sources
 
 The `sources` section contains feature source specific configuration parameters.

--- a/nfd-daemonset-combined.yaml.template
+++ b/nfd-daemonset-combined.yaml.template
@@ -156,6 +156,21 @@ data:
     #  noPublish: false
     #  sleepInterval: 60s
     #  sources: [all]
+    #  klog:
+    #    addDirHeader: false
+    #    alsologtostderr: false
+    #    logBacktraceAt:
+    #    logtostderr: true
+    #    skipHeaders: false
+    #    stderrthreshold: 2
+    #    v: 0
+    #    vmodule:
+    ##   NOTE: the following options are not dynamically run-time configurable
+    ##         and require a nfd-worker restart to take effect after being changed
+    #    logDir:
+    #    logFile:
+    #    logFileMaxSize: 1800
+    #    skipLogHeaders: false
     #sources:
     #  cpu:
     #    cpuid:

--- a/nfd-worker-daemonset.yaml.template
+++ b/nfd-worker-daemonset.yaml.template
@@ -118,6 +118,21 @@ data:
     #  noPublish: false
     #  sleepInterval: 60s
     #  sources: [all]
+    #  klog:
+    #    addDirHeader: false
+    #    alsologtostderr: false
+    #    logBacktraceAt:
+    #    logtostderr: true
+    #    skipHeaders: false
+    #    stderrthreshold: 2
+    #    v: 0
+    #    vmodule:
+    ##   NOTE: the following options are not dynamically run-time configurable
+    ##         and require a nfd-worker restart to take effect after being changed
+    #    logDir:
+    #    logFile:
+    #    logFileMaxSize: 1800
+    #    skipLogHeaders: false
     #sources:
     #  cpu:
     #    cpuid:

--- a/nfd-worker-job.yaml.template
+++ b/nfd-worker-job.yaml.template
@@ -128,6 +128,21 @@ data:
     #  noPublish: false
     #  sleepInterval: 60s
     #  sources: [all]
+    #  klog:
+    #    addDirHeader: false
+    #    alsologtostderr: false
+    #    logBacktraceAt:
+    #    logtostderr: true
+    #    skipHeaders: false
+    #    stderrthreshold: 2
+    #    v: 0
+    #    vmodule:
+    ##   NOTE: the following options are not dynamically run-time configurable
+    ##         and require a nfd-worker restart to take effect after being changed
+    #    logDir:
+    #    logFile:
+    #    logFileMaxSize: 1800
+    #    skipLogHeaders: false
     #sources:
     #  cpu:
     #    cpuid:

--- a/nfd-worker.conf.example
+++ b/nfd-worker.conf.example
@@ -3,6 +3,21 @@
 #  noPublish: false
 #  sleepInterval: 60s
 #  sources: [all]
+#  klog:
+#    addDirHeader: false
+#    alsologtostderr: false
+#    logBacktraceAt:
+#    logtostderr: true
+#    skipHeaders: false
+#    stderrthreshold: 2
+#    v: 0
+#    vmodule:
+##   NOTE: the following options are not dynamically run-time configurable
+##         and require a nfd-worker restart to take effect after being changed
+#    logDir:
+#    logFile:
+#    logFileMaxSize: 1800
+#    skipLogHeaders: false
 #sources:
 #  cpu:
 #    cpuid:

--- a/source/cpu/cpu.go
+++ b/source/cpu/cpu.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,7 +18,8 @@ package cpu
 
 import (
 	"io/ioutil"
-	"log"
+
+	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/node-feature-discovery/source"
 	"sigs.k8s.io/node-feature-discovery/source/internal/cpuidutils"
@@ -96,7 +97,7 @@ func (s *Source) SetConfig(conf source.Config) {
 		s.config = v
 		s.initCpuidFilter()
 	default:
-		log.Printf("PANIC: invalid config type: %T", conf)
+		klog.Fatalf("invalid config type: %T", conf)
 	}
 }
 
@@ -106,7 +107,7 @@ func (s *Source) Discover() (source.Features, error) {
 	// Check if hyper-threading seems to be enabled
 	found, err := haveThreadSiblings()
 	if err != nil {
-		log.Printf("ERROR: failed to detect hyper-threading: %v", err)
+		klog.Errorf("failed to detect hyper-threading: %v", err)
 	} else if found {
 		features["hardware_multithreading"] = true
 	}
@@ -114,7 +115,7 @@ func (s *Source) Discover() (source.Features, error) {
 	// Check SST-BF
 	found, err = discoverSSTBF()
 	if err != nil {
-		log.Printf("ERROR: failed to detect SST-BF: %v", err)
+		klog.Errorf("failed to detect SST-BF: %v", err)
 	} else if found {
 		features["power.sst_bf.enabled"] = true
 	}
@@ -130,7 +131,7 @@ func (s *Source) Discover() (source.Features, error) {
 	// Detect pstate features
 	pstate, err := detectPstate()
 	if err != nil {
-		log.Printf("ERROR: %v", err)
+		klog.Error(err)
 	} else {
 		for k, v := range pstate {
 			features["pstate."+k] = v

--- a/source/custom/custom.go
+++ b/source/custom/custom.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2020-2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@ limitations under the License.
 package custom
 
 import (
-	"log"
 	"reflect"
+
+	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/node-feature-discovery/source"
 	"sigs.k8s.io/node-feature-discovery/source/custom/rules"
@@ -67,7 +68,7 @@ func (s *Source) SetConfig(conf source.Config) {
 	case *config:
 		s.config = v
 	default:
-		log.Printf("PANIC: invalid config type: %T", conf)
+		klog.Fatalf("invalid config type: %T", conf)
 	}
 }
 
@@ -76,12 +77,12 @@ func (s Source) Discover() (source.Features, error) {
 	features := source.Features{}
 	allFeatureConfig := append(getStaticFeatureConfig(), *s.config...)
 	allFeatureConfig = append(allFeatureConfig, getDirectoryFeatureConfig()...)
-	log.Printf("INFO: Custom features: %+v", allFeatureConfig)
+	klog.V(1).Infof("Custom features: %+v", allFeatureConfig)
 	// Iterate over features
 	for _, customFeature := range allFeatureConfig {
 		featureExist, err := s.discoverFeature(customFeature)
 		if err != nil {
-			log.Printf("ERROR: failed to discover feature: %q: %s", customFeature.Name, err.Error())
+			klog.Errorf("failed to discover feature: %q: %s", customFeature.Name, err.Error())
 			continue
 		}
 		if featureExist {

--- a/source/custom/rules/nodename_rule.go
+++ b/source/custom/rules/nodename_rule.go
@@ -16,9 +16,10 @@ limitations under the License.
 package rules
 
 import (
-	"log"
 	"os"
 	"regexp"
+
+	"k8s.io/klog/v2"
 )
 
 var (
@@ -33,17 +34,17 @@ var _ Rule = NodenameRule{}
 
 func (n NodenameRule) Match() (bool, error) {
 	for _, nodenamePattern := range n {
-		log.Printf("DEBUG: matchNodename %s", nodenamePattern)
+		klog.V(1).Infof("matchNodename %s", nodenamePattern)
 		match, err := regexp.MatchString(nodenamePattern, nodeName)
 		if err != nil {
-			log.Printf("ERROR: nodename rule: invalid nodename regexp %q: %v", nodenamePattern, err)
+			klog.Errorf("nodename rule: invalid nodename regexp %q: %v", nodenamePattern, err)
 			continue
 		}
 		if !match {
-			//log.Printf("DEBUG: nodename rule: No match for pattern %q with node %q", nodenamePattern, nodeName)
+			klog.V(2).Infof("nodename rule: No match for pattern %q with node %q", nodenamePattern, nodeName)
 			continue
 		}
-		//log.Printf("DEBUG: nodename rule: Match for pattern %q with node %q", nodenamePattern, nodeName)
+		klog.V(2).Infof("nodename rule: Match for pattern %q with node %q", nodenamePattern, nodeName)
 		return true, nil
 	}
 	return false, nil

--- a/source/internal/kernelutils/kernel_kconfig.go
+++ b/source/internal/kernelutils/kernel_kconfig.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018-2020 The Kubernetes Authors.
+Copyright 2018-2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,11 +21,12 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"k8s.io/klog/v2"
 
 	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/node-feature-discovery/source"
@@ -109,7 +110,7 @@ func ParseKconfig(configPath string) (map[string]string, error) {
 			} else {
 				value := strings.Trim(m[2], `"`)
 				if len(value) > validation.LabelValueMaxLength {
-					log.Printf("WARNING: ignoring kconfig option '%s': value exceeds max length of %d characters", m[1], validation.LabelValueMaxLength)
+					klog.Warningf("ignoring kconfig option '%s': value exceeds max length of %d characters", m[1], validation.LabelValueMaxLength)
 					continue
 				}
 				kconfig[m[1]] = value

--- a/source/internal/pci_utils.go
+++ b/source/internal/pci_utils.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2020-2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,9 +19,10 @@ package busutils
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"path"
 	"strings"
+
+	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/node-feature-discovery/source"
 )
@@ -88,7 +89,7 @@ func DetectPci(deviceAttrSpec map[string]bool) (map[string][]PciDeviceInfo, erro
 	for _, device := range devices {
 		info, err := readPciDevInfo(path.Join(sysfsBasePath, device.Name()), deviceAttrSpec)
 		if err != nil {
-			log.Print(err)
+			klog.Error(err)
 			continue
 		}
 		class := info["class"]

--- a/source/internal/usb_utils.go
+++ b/source/internal/usb_utils.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2020-2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,10 +19,11 @@ package busutils
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"path"
 	"path/filepath"
 	"strings"
+
+	"k8s.io/klog/v2"
 )
 
 type UsbDeviceInfo map[string]string
@@ -125,7 +126,7 @@ func DetectUsb(deviceAttrSpec map[string]bool) (map[string][]UsbDeviceInfo, erro
 	for _, device := range devices {
 		devMap, err := readUsbDevInfo(filepath.Dir(device), deviceAttrSpec)
 		if err != nil {
-			log.Print(err)
+			klog.Error(err)
 			continue
 		}
 

--- a/source/kernel/kernel.go
+++ b/source/kernel/kernel.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,9 +17,10 @@ limitations under the License.
 package kernel
 
 import (
-	"log"
 	"regexp"
 	"strings"
+
+	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/node-feature-discovery/source"
 	"sigs.k8s.io/node-feature-discovery/source/internal/kernelutils"
@@ -63,7 +64,7 @@ func (s *Source) SetConfig(conf source.Config) {
 	case *Config:
 		s.config = v
 	default:
-		log.Printf("PANIC: invalid config type: %T", conf)
+		klog.Fatalf("invalid config type: %T", conf)
 	}
 }
 
@@ -73,7 +74,7 @@ func (s *Source) Discover() (source.Features, error) {
 	// Read kernel version
 	version, err := parseVersion()
 	if err != nil {
-		log.Printf("ERROR: Failed to get kernel version: %s", err)
+		klog.Errorf("Failed to get kernel version: %s", err)
 	} else {
 		for key := range version {
 			features["version."+key] = version[key]
@@ -83,7 +84,7 @@ func (s *Source) Discover() (source.Features, error) {
 	// Read kconfig
 	kconfig, err := kernelutils.ParseKconfig(s.config.KconfigFile)
 	if err != nil {
-		log.Printf("ERROR: Failed to read kconfig: %s", err)
+		klog.Errorf("Failed to read kconfig: %s", err)
 	}
 
 	// Check flags
@@ -95,7 +96,7 @@ func (s *Source) Discover() (source.Features, error) {
 
 	selinux, err := SelinuxEnabled()
 	if err != nil {
-		log.Print(err)
+		klog.Warning(err)
 	} else if selinux {
 		features["selinux.enabled"] = true
 	}

--- a/source/memory/memory.go
+++ b/source/memory/memory.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,9 +18,10 @@ package memory
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
 	"strings"
+
+	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/node-feature-discovery/source"
 )
@@ -47,7 +48,7 @@ func (s Source) Discover() (source.Features, error) {
 	// Detect NUMA
 	numa, err := isNuma()
 	if err != nil {
-		log.Printf("ERROR: failed to detect NUMA topology: %s", err)
+		klog.Errorf("failed to detect NUMA topology: %s", err)
 	} else if numa {
 		features["numa"] = true
 	}
@@ -55,7 +56,7 @@ func (s Source) Discover() (source.Features, error) {
 	// Detect NVDIMM
 	nv, err := detectNvdimm()
 	if err != nil {
-		log.Printf("ERROR: NVDIMM detection failed: %s", err)
+		klog.Errorf("NVDIMM detection failed: %s", err)
 	} else {
 		for k, v := range nv {
 			features["nv."+k] = v
@@ -110,7 +111,7 @@ func detectNvdimm() (map[string]bool, error) {
 			}
 		}
 	} else {
-		log.Printf("WARNING: failed to detect NVDIMM configuration: %s", err)
+		klog.Warningf("failed to detect NVDIMM configuration: %s", err)
 	}
 
 	return features, nil

--- a/source/pci/pci.go
+++ b/source/pci/pci.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@ package pci
 
 import (
 	"fmt"
-	"log"
 	"strings"
+
+	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/node-feature-discovery/source"
 	pciutils "sigs.k8s.io/node-feature-discovery/source/internal"
@@ -58,7 +59,7 @@ func (s *Source) SetConfig(conf source.Config) {
 	case *Config:
 		s.config = v
 	default:
-		log.Printf("PANIC: invalid config type: %T", conf)
+		klog.Fatalf("invalid config type: %T", conf)
 	}
 }
 
@@ -84,10 +85,10 @@ func (s Source) Discover() (source.Features, error) {
 		for key := range configLabelFields {
 			keys = append(keys, key)
 		}
-		log.Printf("WARNING: invalid fields '%v' in deviceLabelFields, ignoring...", keys)
+		klog.Warningf("invalid fields '%v' in deviceLabelFields, ignoring...", keys)
 	}
 	if len(deviceLabelFields) == 0 {
-		log.Printf("WARNING: no valid fields in deviceLabelFields defined, using the defaults")
+		klog.Warningf("no valid fields in deviceLabelFields defined, using the defaults")
 		deviceLabelFields = []string{"class", "vendor"}
 	}
 

--- a/source/system/system.go
+++ b/source/system/system.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,10 +18,11 @@ package system
 
 import (
 	"bufio"
-	"log"
 	"os"
 	"regexp"
 	"strings"
+
+	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/node-feature-discovery/source"
 )
@@ -50,7 +51,7 @@ func (s Source) Discover() (source.Features, error) {
 
 	release, err := parseOSRelease()
 	if err != nil {
-		log.Printf("ERROR: failed to get os-release: %s", err)
+		klog.Errorf("failed to get os-release: %s", err)
 	} else {
 		for _, key := range osReleaseFields {
 			if value, exists := release[key]; exists {

--- a/source/usb/usb.go
+++ b/source/usb/usb.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2020-2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@ package usb
 
 import (
 	"fmt"
-	"log"
 	"strings"
+
+	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/node-feature-discovery/source"
 	usbutils "sigs.k8s.io/node-feature-discovery/source/internal"
@@ -61,7 +62,7 @@ func (s *Source) SetConfig(conf source.Config) {
 	case *Config:
 		s.config = v
 	default:
-		log.Printf("PANIC: invalid config type: %T", conf)
+		klog.Fatalf("invalid config type: %T", conf)
 	}
 }
 
@@ -87,10 +88,10 @@ func (s Source) Discover() (source.Features, error) {
 		for key := range configLabelFields {
 			keys = append(keys, key)
 		}
-		log.Printf("WARNING: invalid fields '%v' in deviceLabelFields, ignoring...", keys)
+		klog.Warningf("invalid fields '%v' in deviceLabelFields, ignoring...", keys)
 	}
 	if len(deviceLabelFields) == 0 {
-		log.Printf("WARNING: no valid fields in deviceLabelFields defined, using the defaults")
+		klog.Warningf("no valid fields in deviceLabelFields defined, using the defaults")
 		deviceLabelFields = []string{"vendor", "device"}
 	}
 


### PR DESCRIPTION
Greatly expands logging capabilities and flexibility with verbosity options, among other things.

Also, implement dynamic configuration of klog. I.e. make it possible to dynamically (at run-time) alter most of the logging configuration from the config file.
