### PR TITLE
test/e2e: make openshift bits optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ IMAGE_EXTRA_TAGS := $(foreach tag,$(IMAGE_EXTRA_TAG_NAMES),$(IMAGE_REPO):$(tag))
 
 K8S_NAMESPACE ?= node-feature-discovery
 
+OPENSHIFT ?=
+
 # We use different mount prefix for local and container builds.
 # Take CONTAINER_HOSTMOUNT_PREFIX from HOSTMOUNT_PREFIX if only the latter is specified
 ifdef HOSTMOUNT_PREFIX
@@ -127,7 +129,9 @@ test:
 
 e2e-test:
 	@if [ -z ${KUBECONFIG} ]; then echo "[ERR] KUBECONFIG missing, must be defined"; exit 1; fi
-	$(GO_CMD) test -v ./test/e2e/ -args -nfd.repo=$(IMAGE_REPO) -nfd.tag=$(IMAGE_TAG_NAME) -kubeconfig=$(KUBECONFIG) -nfd.e2e-config=$(E2E_TEST_CONFIG) -ginkgo.focus="\[NFD\]"
+	$(GO_CMD) test -v ./test/e2e/ -args -nfd.repo=$(IMAGE_REPO) -nfd.tag=$(IMAGE_TAG_NAME) \
+	    -kubeconfig=$(KUBECONFIG) -nfd.e2e-config=$(E2E_TEST_CONFIG) -ginkgo.focus="\[NFD\]" \
+	    $(if $(OPENSHIFT),-nfd.openshift,)
 
 push:
 	$(IMAGE_PUSH_CMD) $(IMAGE_TAG)

--- a/docs/advanced/developer-guide.md
+++ b/docs/advanced/developer-guide.md
@@ -110,6 +110,7 @@ makefile overrides.
 | K8S_NAMESPACE              | nfd-master and nfd-worker namespace                               | kube-system
 | KUBECONFIG                 | Kubeconfig for running e2e-tests                                  | *empty*
 | E2E_TEST_CONFIG            | Parameterization file of e2e-tests (see [example][e2e-config-sample]) | *empty*
+| OPENSHIFT                  | Non-empty value enables OpenShift specific support (currently only effective in e2e tests) | *empty*
 
 For example, to use a custom registry:
 

--- a/test/e2e/node_feature_discovery.go
+++ b/test/e2e/node_feature_discovery.go
@@ -49,6 +49,7 @@ var (
 	dockerRepo    = flag.String("nfd.repo", "gcr.io/k8s-staging-nfd/node-feature-discovery", "Docker repository to fetch image from")
 	dockerTag     = flag.String("nfd.tag", "master", "Docker tag to use")
 	e2eConfigFile = flag.String("nfd.e2e-config", "", "Configuration parameters for end-to-end tests")
+	openShift     = flag.Bool("nfd.openshift", false, "Enable OpenShift specific bits")
 
 	conf *e2eConfig
 )
@@ -168,14 +169,17 @@ func createClusterRole(cs clientset.Interface) (*rbacv1.ClusterRole, error) {
 				Resources: []string{"nodes"},
 				Verbs:     []string{"get", "patch", "update"},
 			},
-			{
+		},
+	}
+	if *openShift {
+		cr.Rules = append(cr.Rules,
+			rbacv1.PolicyRule{
 				// needed on OpenShift clusters
 				APIGroups:     []string{"security.openshift.io"},
 				Resources:     []string{"securitycontextconstraints"},
 				ResourceNames: []string{"hostaccess"},
 				Verbs:         []string{"use"},
-			},
-		},
+			})
 	}
 	return cs.RbacV1().ClusterRoles().Update(context.TODO(), cr, metav1.UpdateOptions{})
 }


### PR DESCRIPTION
Only enabled if OPENSHIFT is specified in the environment when running
make e2e-test, for example:

```
$ OPENSHIFT=y make e2e-test
```