### PR TITLE
logs should all be lower case when possible

### DIFF
--- a/cmd/nfd-master/main.go
+++ b/cmd/nfd-master/main.go
@@ -45,7 +45,7 @@ func main() {
 
 	_ = flags.Parse(os.Args[1:])
 	if len(flags.Args()) > 0 {
-		fmt.Printf("unknown command line argument: %s\n", flags.Args()[0])
+		fmt.Fprintf(flags.Output(), "unknown command line argument: %s\n", flags.Args()[0])
 		flags.Usage()
 		os.Exit(2)
 	}
@@ -63,7 +63,7 @@ func main() {
 	// Get new NfdMaster instance
 	instance, err := master.NewNfdMaster(args)
 	if err != nil {
-		klog.Exitf("Failed to initialize NfdMaster instance: %v", err)
+		klog.Exitf("failed to initialize NfdMaster instance: %v", err)
 	}
 
 	if err = instance.Run(); err != nil {

--- a/cmd/nfd-worker/main.go
+++ b/cmd/nfd-worker/main.go
@@ -54,7 +54,7 @@ func main() {
 	// Get new NfdWorker instance
 	instance, err := worker.NewNfdWorker(args)
 	if err != nil {
-		klog.Exitf("Failed to initialize NfdWorker instance: %v", err)
+		klog.Exitf("failed to initialize NfdWorker instance: %v", err)
 	}
 
 	if err = instance.Run(); err != nil {
@@ -67,7 +67,7 @@ func parseArgs(flags *flag.FlagSet, osArgs ...string) *worker.Args {
 
 	_ = flags.Parse(osArgs)
 	if len(flags.Args()) > 0 {
-		fmt.Printf("unknown command line argument: %s\n", flags.Args()[0])
+		fmt.Fprintf(flags.Output(), "unknown command line argument: %s\n", flags.Args()[0])
 		flags.Usage()
 		os.Exit(2)
 	}

--- a/pkg/nfd-worker/nfd-worker.go
+++ b/pkg/nfd-worker/nfd-worker.go
@@ -460,15 +460,15 @@ func (w *nfdWorker) configure(filepath string, overrides string) error {
 		} else {
 			err = yaml.Unmarshal(data, c)
 			if err != nil {
-				return fmt.Errorf("Failed to parse config file: %s", err)
+				return fmt.Errorf("failed to parse config file: %s", err)
 			}
-			klog.Infof("Configuration successfully loaded from %q", filepath)
+			klog.Infof("configuration successfully loaded from %q", filepath)
 		}
 	}
 
 	// Parse config overrides
 	if err := yaml.Unmarshal([]byte(overrides), c); err != nil {
-		return fmt.Errorf("Failed to parse --options: %s", err)
+		return fmt.Errorf("failed to parse --options: %s", err)
 	}
 
 	if w.args.Overrides.LabelWhiteList != nil {
@@ -558,7 +558,7 @@ func getFeatureLabels(source source.FeatureSource, labelWhiteList regexp.Regexp)
 		// Validate label name.
 		errs := validation.IsQualifiedName(nameForValidation)
 		if len(errs) > 0 {
-			klog.Warningf("Ignoring invalid feature name '%s': %s", label, errs)
+			klog.Warningf("ignoring invalid feature name '%s': %s", label, errs)
 			continue
 		}
 
@@ -566,7 +566,7 @@ func getFeatureLabels(source source.FeatureSource, labelWhiteList regexp.Regexp)
 		// Validate label value
 		errs = validation.IsValidLabelValue(value)
 		if len(errs) > 0 {
-			klog.Warningf("Ignoring invalid feature value %s=%s: %s", label, value, errs)
+			klog.Warningf("ignoring invalid feature value %s=%s: %s", label, value, errs)
 			continue
 		}
 
@@ -587,7 +587,7 @@ func advertiseFeatureLabels(client pb.LabelerClient, labels Labels) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	klog.Infof("Sending labeling request to nfd-master")
+	klog.Infof("sending labeling request to nfd-master")
 
 	labelReq := pb.SetLabelsRequest{Labels: labels,
 		NfdVersion: version.Get(),

--- a/source/internal/kernelutils/kernel_kconfig.go
+++ b/source/internal/kernelutils/kernel_kconfig.go
@@ -51,7 +51,7 @@ func readKconfigGzip(filename string) ([]byte, error) {
 	return ioutil.ReadAll(r)
 }
 
-// Read kconfig into a map
+// ParseKconfig reads kconfig and return a map
 func ParseKconfig(configPath string) (map[string]string, error) {
 	kconfig := map[string]string{}
 	raw := []byte(nil)
@@ -95,7 +95,7 @@ func ParseKconfig(configPath string) (map[string]string, error) {
 	}
 
 	if raw == nil {
-		return nil, fmt.Errorf("Failed to read kernel config from %+v:", append([]string{configPath}, searchPaths...))
+		return nil, fmt.Errorf("failed to read kernel config from %+v", append([]string{configPath}, searchPaths...))
 	}
 
 	// Regexp for matching kconfig flags

--- a/source/internal/pci_utils.go
+++ b/source/internal/pci_utils.go
@@ -58,7 +58,7 @@ func readPciDevInfo(devPath string, deviceAttrSpec map[string]bool) (PciDeviceIn
 		attrVal, err := readSinglePciAttribute(devPath, attr)
 		if err != nil {
 			if must {
-				return info, fmt.Errorf("Failed to read device %s: %s", attr, err)
+				return info, fmt.Errorf("failed to read device %s: %s", attr, err)
 			}
 			continue
 

--- a/source/iommu/iommu.go
+++ b/source/iommu/iommu.go
@@ -43,7 +43,7 @@ func (s Source) Discover() (source.Features, error) {
 	// Check if any iommu devices are available
 	devices, err := ioutil.ReadDir(source.SysfsDir.Path("class/iommu/"))
 	if err != nil {
-		return nil, fmt.Errorf("Failed to check for IOMMU support: %v", err)
+		return nil, fmt.Errorf("failed to check for IOMMU support: %v", err)
 	}
 
 	if len(devices) > 0 {

--- a/source/kernel/kernel.go
+++ b/source/kernel/kernel.go
@@ -74,7 +74,7 @@ func (s *Source) Discover() (source.Features, error) {
 	// Read kernel version
 	version, err := parseVersion()
 	if err != nil {
-		klog.Errorf("Failed to get kernel version: %s", err)
+		klog.Errorf("failed to get kernel version: %s", err)
 	} else {
 		for key := range version {
 			features["version."+key] = version[key]
@@ -84,7 +84,7 @@ func (s *Source) Discover() (source.Features, error) {
 	// Read kconfig
 	kconfig, err := kernelutils.ParseKconfig(s.config.KconfigFile)
 	if err != nil {
-		klog.Errorf("Failed to read kconfig: %s", err)
+		klog.Errorf("failed to read kconfig: %s", err)
 	}
 
 	// Check flags

--- a/source/kernel/selinux.go
+++ b/source/kernel/selinux.go
@@ -27,7 +27,7 @@ import (
 func SelinuxEnabled() (bool, error) {
 	status, err := ioutil.ReadFile(source.SysfsDir.Path("fs/selinux/enforce"))
 	if err != nil {
-		return false, fmt.Errorf("Failed to detect the status of selinux, please check if the system supports selinux and make sure /sys on the host is mounted into the container: %s", err.Error())
+		return false, fmt.Errorf("failed to detect the status of selinux, please check if the system supports selinux and make sure /sys on the host is mounted into the container: %s", err.Error())
 	}
 	if status[0] == byte('1') {
 		// selinux is enabled.

--- a/source/local/local.go
+++ b/source/local/local.go
@@ -114,7 +114,7 @@ func getFeaturesFromHooks() (source.Features, error) {
 			klog.Infof("hook directory %v does not exist", hookDir)
 			return features, nil
 		}
-		return features, fmt.Errorf("Unable to access %v: %v", hookDir, err)
+		return features, fmt.Errorf("unable to access %v: %v", hookDir, err)
 	}
 
 	for _, file := range files {
@@ -189,7 +189,7 @@ func getFeaturesFromFiles() (source.Features, error) {
 			klog.Infof("features directory %v does not exist", featureFilesDir)
 			return features, nil
 		}
-		return features, fmt.Errorf("Unable to access %v: %v", featureFilesDir, err)
+		return features, fmt.Errorf("unable to access %v: %v", featureFilesDir, err)
 	}
 
 	for _, file := range files {

--- a/source/network/network.go
+++ b/source/network/network.go
@@ -80,7 +80,7 @@ func (s Source) Discover() (source.Features, error) {
 			total := bytes.TrimSpace(totalBytes)
 			t, err := strconv.Atoi(string(total))
 			if err != nil {
-				klog.Errorf("Error in obtaining maximum supported number of virtual functions for network interface: %s: %v", name, err)
+				klog.Errorf("error in obtaining maximum supported number of virtual functions for network interface: %s: %v", name, err)
 				continue
 			}
 			if t > 0 {
@@ -95,7 +95,7 @@ func (s Source) Discover() (source.Features, error) {
 				num := bytes.TrimSpace(numBytes)
 				n, err := strconv.Atoi(string(num))
 				if err != nil {
-					klog.Errorf("Error in obtaining the configured number of virtual functions for network interface: %s: %v", name, err)
+					klog.Errorf("error in obtaining the configured number of virtual functions for network interface: %s: %v", name, err)
 					continue
 				}
 				if n > 0 {

--- a/source/pci/pci.go
+++ b/source/pci/pci.go
@@ -104,7 +104,7 @@ func (s Source) Discover() (source.Features, error) {
 
 	devs, err := pciutils.DetectPci(deviceAttrs)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to detect PCI devices: %s", err.Error())
+		return nil, fmt.Errorf("failed to detect PCI devices: %s", err.Error())
 	}
 
 	// Iterate over all device classes

--- a/source/usb/usb.go
+++ b/source/usb/usb.go
@@ -103,7 +103,7 @@ func (s Source) Discover() (source.Features, error) {
 
 	devs, err := usbutils.DetectUsb(deviceAttrs)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to detect USB devices: %s", err.Error())
+		return nil, fmt.Errorf("failed to detect USB devices: %s", err.Error())
 	}
 
 	// Iterate over all device classes


### PR DESCRIPTION
Standardize logs to be lower cased 
Bonus: Fixed a func comment to start with the func name 

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>