### PR TITLE
Dockerfile: add minimal image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,20 @@ RUN make install VERSION=$VERSION HOSTMOUNT_PREFIX=$HOSTMOUNT_PREFIX
 RUN make test
 
 
-# Create production image for running node feature discovery
-FROM debian:buster-slim
+# Create full variant of the production image
+FROM debian:buster-slim as full
+
+# Run as unprivileged user
+USER 65534:65534
+
+# Use more verbose logging of gRPC
+ENV GRPC_GO_LOG_SEVERITY_LEVEL="INFO"
+
+COPY --from=builder /go/node-feature-discovery/nfd-worker.conf.example /etc/kubernetes/node-feature-discovery/nfd-worker.conf
+COPY --from=builder /go/bin/* /usr/bin/
+
+# Create minimal variant of the production image
+FROM gcr.io/distroless/base as minimal
 
 # Run as unprivileged user
 USER 65534:65534

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,9 @@ e2e-test:
 	$(GO_CMD) test -v ./test/e2e/ -args -nfd.repo=$(IMAGE_REPO) -nfd.tag=$(IMAGE_TAG_NAME) \
 	    -kubeconfig=$(KUBECONFIG) -nfd.e2e-config=$(E2E_TEST_CONFIG) -ginkgo.focus="\[NFD\]" \
 	    $(if $(OPENSHIFT),-nfd.openshift,)
+	$(GO_CMD) test -v ./test/e2e/ -args -nfd.repo=$(IMAGE_REPO) -nfd.tag=$(IMAGE_TAG_NAME)-minimal \
+	    -kubeconfig=$(KUBECONFIG) -nfd.e2e-config=$(E2E_TEST_CONFIG) -ginkgo.focus="\[NFD\]" \
+	    $(if $(OPENSHIFT),-nfd.openshift,)
 
 push:
 	$(IMAGE_PUSH_CMD) $(IMAGE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -148,17 +148,20 @@ push:
 	$(IMAGE_PUSH_CMD) $(IMAGE_TAG)-minimal
 	for tag in $(IMAGE_EXTRA_TAGS); do $(IMAGE_PUSH_CMD) $$tag; $(IMAGE_PUSH_CMD) $$tag-minimal; done
 
-poll-image:
+poll-images:
 	set -e; \
-	image=$(IMAGE_REPO):$(IMAGE_TAG_NAME); \
+	tags="$(foreach tag,$(IMAGE_TAG_NAME) $(IMAGE_EXTRA_TAG_NAMES),$(tag) $(tag)-minimal)" \
 	base_url=`echo $(IMAGE_REPO) | sed -e s'!\([^/]*\)!\1/v2!'`; \
-	errors=`curl -fsS -X GET https://$$base_url/manifests/$(IMAGE_TAG_NAME)|jq .errors`;  \
-	if [ "$$errors" = "null" ]; then \
-	  echo Image $$image found; \
-	else \
-	  echo Image $$image not found; \
-	  exit 1; \
-	fi;
+	for tag in $$tags; do \
+	    image=$(IMAGE_REPO):$$tag \
+	    errors=`curl -fsS -X GET https://$$base_url/manifests/$$tag|jq .errors`;  \
+	    if [ "$$errors" = "null" ]; then \
+	      echo Image $$image found; \
+	    else \
+	      echo Image $$image not found; \
+	      exit 1; \
+	    fi; \
+	done
 
 site-build:
 	@mkdir -p docs/vendor/bundle

--- a/Makefile
+++ b/Makefile
@@ -72,10 +72,17 @@ install:
 
 image: yamls
 	$(IMAGE_BUILD_CMD) --build-arg VERSION=$(VERSION) \
-		--build-arg HOSTMOUNT_PREFIX=$(CONTAINER_HOSTMOUNT_PREFIX) \
-		-t $(IMAGE_TAG) \
-		$(foreach tag,$(IMAGE_EXTRA_TAGS),-t $(tag)) \
-		$(IMAGE_BUILD_EXTRA_OPTS) ./
+	    --target full \
+	    --build-arg HOSTMOUNT_PREFIX=$(CONTAINER_HOSTMOUNT_PREFIX) \
+	    -t $(IMAGE_TAG) \
+	    $(foreach tag,$(IMAGE_EXTRA_TAGS),-t $(tag)) \
+	    $(IMAGE_BUILD_EXTRA_OPTS) ./
+	$(IMAGE_BUILD_CMD) --build-arg VERSION=$(VERSION) \
+	    --target minimal \
+	    --build-arg HOSTMOUNT_PREFIX=$(CONTAINER_HOSTMOUNT_PREFIX) \
+	    -t $(IMAGE_TAG)-minimal \
+	    $(foreach tag,$(IMAGE_EXTRA_TAGS),-t $(tag)-minimal) \
+	    $(IMAGE_BUILD_EXTRA_OPTS) ./
 
 yamls: $(yaml_instances)
 
@@ -138,7 +145,8 @@ e2e-test:
 
 push:
 	$(IMAGE_PUSH_CMD) $(IMAGE_TAG)
-	for tag in $(IMAGE_EXTRA_TAGS); do $(IMAGE_PUSH_CMD) $$tag; done
+	$(IMAGE_PUSH_CMD) $(IMAGE_TAG)-minimal
+	for tag in $(IMAGE_EXTRA_TAGS); do $(IMAGE_PUSH_CMD) $$tag; $(IMAGE_PUSH_CMD) $$tag-minimal; done
 
 poll-image:
 	set -e; \

--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -23,6 +23,27 @@ sort: 3
 1. [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl)
    (properly set up and configured to work with your Kubernetes cluster)
 
+## Image variants
+
+NFD currently offers two variants of the container image. The "full" variant is
+currently deployed by default.
+
+### Full
+
+This image is based on
+[debian:buster-slim](https://hub.docker.com/_/debian) and contains a full Linux
+system for running shell-based nfd-worker hooks and doing live debugging and
+diagnosis of the NFD images.
+
+### Minimal
+
+This is a minimal image based on
+[gcr.io/distroless/base](https://github.com/GoogleContainerTools/distroless/blob/master/base/README.md)
+and only supports running statically linked binaries.
+
+The container image tag has suffix `-minimal`
+(e.g. `{{ site.container_image }}-minimal`)
+
 ## Deployment options
 
 ### Operator

--- a/docs/get-started/features.md
+++ b/docs/get-started/features.md
@@ -542,6 +542,9 @@ The *local* feature source gets its labels by two different ways:
   `/etc/kubernetes/node-feature-discovery/features.d/` directory. The file
   content is expected to be similar to the hook output (described above).
 
+**NOTE:** The [minimal](deployment-and-usage#minimal) image variant only
+supports running statically linked binaries.
+
 These directories must be available inside the Docker image so Volumes and
 VolumeMounts must be used if standard NFD images are used. The given template
 files mount by default the `source.d` and the `features.d` directories

--- a/scripts/test-infra/test-e2e.sh
+++ b/scripts/test-infra/test-e2e.sh
@@ -17,7 +17,7 @@ echo "$E2E_TEST_CONFIG_DATA" > "$E2E_TEST_CONFIG"
 # Wait for the image to be built and published
 i=1
 while true; do
-    if make poll-image; then
+    if make poll-images; then
         break
     elif [ $i -ge 10 ]; then
         "ERROR: too many tries when polling for image"


### PR DESCRIPTION
Build a "minimal" variant of the nfd image based on
gcr.io/distroless/base. The motivations behind the minimal image are
image hardening (security) and reducing the image footprint (from ca.
108MB down to about 40MB).

The practical effect of deploying the minimal image is that no runtimes
for running worker hooks are present, not even a shell. This means that
only statically linked linked hook binaries are supported. Also, because
of the image hardening live debugging of the minimal image by attaching
to the container is not possible, and, the "full" image needs to be used
for that purpose.

This doesn't change the default usage/deployment of NFD in any way. Just adds a new image variant that can be alternatively deployed. The minimal variant might become the default in the future, though