### PR TITLE
source/custom: dump config in more human-readable form

### DIFF
--- a/source/custom/custom.go
+++ b/source/custom/custom.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/klog/v2"
 
+	"sigs.k8s.io/node-feature-discovery/pkg/utils"
 	"sigs.k8s.io/node-feature-discovery/source"
 	"sigs.k8s.io/node-feature-discovery/source/custom/rules"
 )
@@ -37,7 +38,7 @@ type MatchRule struct {
 
 type FeatureSpec struct {
 	Name    string      `json:"name"`
-	Value   *string     `json:"value"`
+	Value   *string     `json:"value,omitempty"`
 	MatchOn []MatchRule `json:"matchOn"`
 }
 
@@ -77,7 +78,7 @@ func (s Source) Discover() (source.Features, error) {
 	features := source.Features{}
 	allFeatureConfig := append(getStaticFeatureConfig(), *s.config...)
 	allFeatureConfig = append(allFeatureConfig, getDirectoryFeatureConfig()...)
-	klog.V(1).Infof("Custom features: %+v", allFeatureConfig)
+	utils.KlogDump(2, "custom features configuration:", "  ", allFeatureConfig)
 	// Iterate over features
 	for _, customFeature := range allFeatureConfig {
 		featureExist, err := s.discoverFeature(customFeature)


### PR DESCRIPTION
You get log entries like this (with `-v 1`):
```
I0310 21:59:19.778694   12976 custom.go:84] custom features configuration:
I0310 21:59:19.778963   12976 custom.go:84]   - matchOn:
I0310 21:59:19.778981   12976 custom.go:84]     - pciId:
I0310 21:59:19.778985   12976 custom.go:84]         vendor:
I0310 21:59:19.778988   12976 custom.go:84]         - 15b3
I0310 21:59:19.778991   12976 custom.go:84]     name: rdma.capable
I0310 21:59:19.778994   12976 custom.go:84]   - matchOn:
I0310 21:59:19.778997   12976 custom.go:84]     - loadedKMod:
I0310 21:59:19.779000   12976 custom.go:84]       - ib_uverbs
I0310 21:59:19.779004   12976 custom.go:84]       - rdma_ucm
I0310 21:59:19.779009   12976 custom.go:84]     name: rdma.available
I0310 21:59:19.779015   12976 custom.go:84]   - matchOn:
I0310 21:59:19.779018   12976 custom.go:84]     - kConfig:
I0310 21:59:19.779023   12976 custom.go:84]       - X86
I0310 21:59:19.779026   12976 custom.go:84]     name: kconfig-test

```