### PR TITLE
nfd-worker: don't log labels returned by sources by default

### DIFF
--- a/pkg/nfd-worker/nfd-worker.go
+++ b/pkg/nfd-worker/nfd-worker.go
@@ -508,6 +508,7 @@ func createFeatureLabels(sources []source.FeatureSource, labelWhiteList regexp.R
 	labels = Labels{}
 
 	// Do feature discovery from all configured sources.
+	klog.Info("starting feature discovery...")
 	for _, source := range sources {
 		labelsFromSource, err := getFeatureLabels(source, labelWhiteList)
 		if err != nil {
@@ -516,11 +517,11 @@ func createFeatureLabels(sources []source.FeatureSource, labelWhiteList regexp.R
 		}
 
 		for name, value := range labelsFromSource {
-			// Log discovered feature.
-			klog.Infof("%s = %s", name, value)
 			labels[name] = value
 		}
 	}
+	klog.Info("feature discovery completed")
+	utils.KlogDump(1, "labels discovered by feature sources:", "  ", labels)
 	return labels
 }
 

--- a/pkg/utils/dump.go
+++ b/pkg/utils/dump.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
+)
+
+func KlogDump(v klog.Level, heading, prefix string, obj interface{}) {
+	if klog.V(v).Enabled() {
+		klog.InfoDepth(1, heading)
+
+		d := strings.Split(Dump(obj), "\n")
+		// Print all but the last empty line
+		for i := 0; i < len(d)-1; i++ {
+			klog.InfoDepth(1, prefix+d[i])
+		}
+	}
+}
+
+// Dump dumps an object into YAML textual format
+func Dump(obj interface{}) string {
+	out, err := yaml.Marshal(obj)
+	if err != nil {
+		return fmt.Sprintf("<!!! FAILED TO MARSHAL %T (%v) !!!>\n", obj, err)
+	}
+	return string(out)
+}


### PR DESCRIPTION
Reduce default log verbosity. Only print out labels if log verbosity is 1 or higher (e.g. '-v 1' command line). Also, dump the labels in a reproducible (sorted) format.

Produces logs like this with `-v 1`:
```
I0311 07:15:34.257115   23856 nfd-worker.go:523] labels discovered by feature sources:
I0311 07:15:34.257333   23856 nfd-worker.go:523]   cpu-cpuid.ADX: "true"
I0311 07:15:34.257346   23856 nfd-worker.go:523]   cpu-cpuid.AESNI: "true"
I0311 07:15:34.257367   23856 nfd-worker.go:523]   cpu-cpuid.AVX: "true"
I0311 07:15:34.257373   23856 nfd-worker.go:523]   cpu-cpuid.AVX2: "true"
I0311 07:15:34.257379   23856 nfd-worker.go:523]   cpu-cpuid.FMA3: "true"
I0311 07:15:34.257384   23856 nfd-worker.go:523]   cpu-cpuid.HYPERVISOR: "true"
I0311 07:15:34.257390   23856 nfd-worker.go:523]   cpu-cpuid.SSE4: "true"
I0311 07:15:34.257395   23856 nfd-worker.go:523]   cpu-cpuid.SSE42: "true"
```