### PR TITLE
Remove --sleep-interval flag from worker deployment templates

### DIFF
--- a/nfd-daemonset-combined.yaml.template
+++ b/nfd-daemonset-combined.yaml.template
@@ -94,8 +94,6 @@ spec:
             runAsNonRoot: true
           command:
             - "nfd-worker"
-          args:
-            - "--sleep-interval=60s"
           volumeMounts:
             - name: host-boot
               mountPath: "/host-boot"

--- a/nfd-worker-daemonset.yaml.template
+++ b/nfd-worker-daemonset.yaml.template
@@ -35,7 +35,6 @@ spec:
           command:
             - "nfd-worker"
           args:
-            - "--sleep-interval=60s"
             - "--server=nfd-master:8080"
 ## Enable TLS authentication (1/3)
 ## The example below assumes having a Secret named nfd-worker-cert with


### PR DESCRIPTION
We don't want that as it makes dynamic configuration of the
sleep-interval via the config file impossible. It was set to the
internal default value, anyway.