### PR TITLE
github: update gh-pages on published releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -35,13 +35,14 @@ Please do not remove items from the checklist
 - [ ] Submit a PR against [k8s.io](https://github.com/kubernetes/k8s.io), updating `k8s.gcr.io/images/k8s-staging-nfd/images.yaml` to promote the container image to production
 - [ ] Wait for the PR to be merged and verify that the image (`k8s.gcr.io/nfd/node-feature-discovery:$VERSION`) is available.
 - [ ] Publish the draft release prepared at the [Github releases page](https://github.com/kubernetes-sigs/node-feature-discovery/releases)
+      which will also trigger a Helm repo index update to add the latest release
 - [ ] Add a link to the tagged release in this issue.
 - [ ] Send an announcement email to `kubernetes-dev@googlegroups.com` with the subject `[ANNOUNCE] node-feature-discovery $VERSION is released`
 - [ ] Add a link to the release announcement in this issue
 - [ ] For a major release, update README in master branch
-  - [ ] Update references to point to `$VERSION` and submit a PR
-  - [ ] Wait for the PR to be merged, this will also update the Helm
-        repo index to be updated to contain the latest release
+  - [ ] Update references e.g. by running `scripts/prepare-release.sh $VERSION` but **only** committing README.md, and,
+        submit a PR
+  - [ ] Wait for the PR to be merged
 - [ ] Close this issue
 
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,6 +6,8 @@ on:
       - release-*
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
+  release:
+    types: [published]
 jobs:
   build:
     name: Update gh-pages


### PR DESCRIPTION
This will make the Helm repo to be updated at release time.