### PR TITLE
release 0.8: cherry-picks from master

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -35,9 +35,14 @@ Please do not remove items from the checklist
 - [ ] Submit a PR against [k8s.io](https://github.com/kubernetes/k8s.io), updating `k8s.gcr.io/images/k8s-staging-nfd/images.yaml` to promote the container image to production
 - [ ] Wait for the PR to be merged and verify that the image (`k8s.gcr.io/nfd/node-feature-discovery:$VERSION`) is available.
 - [ ] Publish the draft release prepared at the [Github releases page](https://github.com/kubernetes-sigs/node-feature-discovery/releases)
+      which will also trigger a Helm repo index update to add the latest release
 - [ ] Add a link to the tagged release in this issue.
 - [ ] Send an announcement email to `kubernetes-dev@googlegroups.com` with the subject `[ANNOUNCE] node-feature-discovery $VERSION is released`
 - [ ] Add a link to the release announcement in this issue
+- [ ] For a major release, update README in master branch
+  - [ ] Update references e.g. by running `scripts/prepare-release.sh $VERSION` but **only** committing README.md, and,
+        submit a PR
+  - [ ] Wait for the PR to be merged
 - [ ] Close this issue
 
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,6 +6,8 @@ on:
       - release-*
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
+  release:
+    types: [published]
 jobs:
   build:
     name: Update gh-pages

--- a/deployment/node-feature-discovery/values.yaml
+++ b/deployment/node-feature-discovery/values.yaml
@@ -208,7 +208,7 @@ worker:
 
   nodeSelector: {}
 
-  tolerations: {}
+  tolerations: []
 
   annotations: {}
 

--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -143,7 +143,17 @@ Node Feature Discovery Helm chart allow to easily deploy and manage NFD.
 
 #### Deployment
 
-To install the chart with the release name node-feature-discovery:
+To install the latest stable version:
+
+```bash
+export NFD_NS=node-feature-discovery
+helm repo add nfd http://kubernetes-sigs.github.io/node-feature-discovery/charts
+helm repo update
+helm install nfd/node-feature-discovery --namespace $NFD_NS --create-namespace --generate-name
+```
+
+To install the latest development version you need to clone the NFD Git
+repository and install from there.
 
 ```bash
 git clone https://github.com/kubernetes-sigs/node-feature-discovery/
@@ -152,9 +162,8 @@ export NFD_NS=node-feature-discovery
 helm install node-feature-discovery ./node-feature-discovery/ --namespace $NFD_NS --create-namespace
 ```
 
-The command deploys Node Feature Discovery on the Kubernetes cluster in the
-default configuration.  The Configuration section describes how it can be
-configured during installation.
+See the [configuration](#configuration) section below for instructions how to
+alter the deployment parameters.
 
 In order to deploy the [minimal](#minimal) image you need to override the image
 tag:
@@ -169,14 +178,14 @@ You can override values from `values.yaml` and provide a file with custom values
 
 ```bash
 export NFD_NS=node-feature-discovery
-helm install node-feature-discovery ./node-feature-discovery/ -f <path/to/custom/values.yaml> --namespace $NFD_NS --create-namespace
+helm install nfd/node-feature-discovery -f <path/to/custom/values.yaml> --namespace $NFD_NS --create-namespace
 ```
 
 To specify each parameter separately you can provide them to helm install command:
 
 ```bash
 export NFD_NS=node-feature-discovery
-helm install node-feature-discovery ./node-feature-discovery/ --set nameOverride=NFDinstance --set master.replicaCount=2 --namespace $NFD_NS --create-namespace
+helm install nfd/node-feature-discovery --set nameOverride=NFDinstance --set master.replicaCount=2 --namespace $NFD_NS --create-namespace
 ```
 
 #### Uninstalling the chart

--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -222,6 +222,8 @@ We have introduced the following Chart parameters.
 
 ##### Master pod parameters
 
+| Name | Type | Default | description |
+| ---- | ---- | ------- | ----------- |
 | `master.*` | dict |  | NFD master deployment configuration |
 | `master.instance` | string |  |  Instance name. Used to separate annotation namespaces for multiple parallel deployments |
 | `master.replicaCount` | integer | 1 | Number of desired pods. This is a pointer to distinguish between explicit zero and not specified |
@@ -236,6 +238,8 @@ We have introduced the following Chart parameters.
 
 ##### Worker pod parameters
 
+| Name | Type | Default | description |
+| ---- | ---- | ------- | ----------- |
 | `worker.*` | dict |  | NFD master daemonset configuration |
 | `worker.configmapName` | string | `nfd-worker-conf` | NFD worker pod ConfigMap name |
 | `worker.config` | string | `` | NFD worker service configuration |


### PR DESCRIPTION
- github: update gh-pages on published releases – will streamline release process in case we need v0.8.x point releases
- docs: describe Helm repo as the primary option for Helm
- docs: Add Table header to master/worker chart parameters
- helm: fix nfd worker tolerations value