### PR TITLE
[helm] fix nfd worker tolerations value

### DIFF
--- a/deployment/node-feature-discovery/values.yaml
+++ b/deployment/node-feature-discovery/values.yaml
@@ -208,7 +208,7 @@ worker:
 
   nodeSelector: {}
 
-  tolerations: {}
+  tolerations: []
 
   annotations: {}
 


### PR DESCRIPTION
the tolerations value is array therefore we need to pass
[] and not {}

Signed-off-by: Moshe Levi <moshele@nvidia.com>