### PR TITLE
Helm chart: Fix configMap indenting

### DIFF
--- a/deployment/node-feature-discovery/Chart.yaml
+++ b/deployment/node-feature-discovery/Chart.yaml
@@ -12,4 +12,4 @@ keywords:
   - feature-detection
   - node-labels
 type: application
-version: 0.1.0
+version: 0.1.1

--- a/deployment/node-feature-discovery/templates/nfd-worker-conf.yaml
+++ b/deployment/node-feature-discovery/templates/nfd-worker-conf.yaml
@@ -6,4 +6,4 @@ metadata:
   {{- include "node-feature-discovery.labels" . | nindent 4 }}
 data:
   nfd-worker.conf: |
-  {{ .Values.worker.config | indent 4 }}
+    {{- .Values.worker.config | nindent 4 }}

--- a/deployment/node-feature-discovery/templates/nfd-worker-conf.yaml
+++ b/deployment/node-feature-discovery/templates/nfd-worker-conf.yaml
@@ -5,5 +5,5 @@ metadata:
   labels:
   {{- include "node-feature-discovery.labels" . | nindent 4 }}
 data:
-  nfd-worker.conf: |
+  nfd-worker.conf: |-
     {{- .Values.worker.config | nindent 4 }}


### PR DESCRIPTION
Currently when the `worker.config` key is being filled with a YAML string literal, it does not render properly and causes Helm errors. This is due to the way the indenting and whitespace trimming is handled.

This PR aims to fix that, by stripping the leading whitespace from the `worker.config` value, and forcing a newline.

Expected to work (snippet):
```yaml
worker:
  config: |-
    core:
      sources:
      - custom
      - pci
      - usb
    sources:
      usb:
```

Currently required to work (snippet), notice the indenting of `core:` vs the rest of the config file:
```yaml
worker:
  config: |-
    core:
        sources:
        - custom
        - pci
        - usb
      sources:
        usb:
```
