### PR TITLE
helm: add extraLabelNs master flag

### DIFF
--- a/deployment/node-feature-discovery/Chart.yaml
+++ b/deployment/node-feature-discovery/Chart.yaml
@@ -12,4 +12,4 @@ keywords:
   - feature-detection
   - node-labels
 type: application
-version: 0.1.1
+version: 0.1.2

--- a/deployment/node-feature-discovery/templates/master.yaml
+++ b/deployment/node-feature-discovery/templates/master.yaml
@@ -48,6 +48,9 @@ spec:
             {{- if .Values.master.instance | empty | not }}
             - "--instance={{ .Values.master.instance }}"
             {{- end }}
+            {{- if .Values.master.extraLabelNs | empty | not }}
+            - "--extra-label-ns={{- join "," .Values.master.extraLabelNs }}"
+            {{- end }}
 ## Enable TLS authentication
 ## The example below assumes having the root certificate named ca.crt stored in
 ## a ConfigMap named nfd-ca-cert, and, the TLS authentication credentials stored

--- a/deployment/node-feature-discovery/values.yaml
+++ b/deployment/node-feature-discovery/values.yaml
@@ -5,7 +5,7 @@ image:
   # tag, if defined will use the given image tag, else Chart.AppVersion will be used
   # tag
 imagePullSecrets: []
-  
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -20,6 +20,8 @@ fullnameOverride: ""
 
 master:
   instance:
+  extraLabelNs: []
+
   replicaCount: 1
 
   podSecurityContext: {}

--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -226,6 +226,7 @@ We have introduced the following Chart parameters.
 | ---- | ---- | ------- | ----------- |
 | `master.*` | dict |  | NFD master deployment configuration |
 | `master.instance` | string |  |  Instance name. Used to separate annotation namespaces for multiple parallel deployments |
+| `master.extraLabelNs` | array | [] | List of allowed extra label namespaces |
 | `master.replicaCount` | integer | 1 | Number of desired pods. This is a pointer to distinguish between explicit zero and not specified |
 | `master.podSecurityContext` | dict | {} | SecurityContext holds pod-level security attributes and common container settings |
 | `master.service.type` | string | ClusterIP | NFD master service type |


### PR DESCRIPTION
Add `extraLabelNs` master flag in the Helm chart.
I did a patch update on the chart version but maybe it should be a minor update?