### PR TITLE
WIP: Add detection of IBM Z Crypto Express Cards

### DIFF
--- a/docs/get-started/features.md
+++ b/docs/get-started/features.md
@@ -525,6 +525,14 @@ The **system** feature source supports the following labels:
 |             | VERSION_ID.major | First component of the OS version id (e.g. '6')
 |             | VERSION_ID.minor | Second component of the OS version id (e.g. '7')
 
+### Crypto
+
+The **crypto** feature source supports the following labels:
+
+| Feature     | Attribute        | Description                                 |
+| ----------- | ---------------- | --------------------------------------------|
+| cex         | present          | Node has at least one Crypto Express Adapter
+
 ### Local -- user-specific features
 
 NFD has a special feature source named *local* which is designed for getting

--- a/pkg/nfd-worker/nfd-worker.go
+++ b/pkg/nfd-worker/nfd-worker.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/node-feature-discovery/pkg/version"
 	"sigs.k8s.io/node-feature-discovery/source"
 	"sigs.k8s.io/node-feature-discovery/source/cpu"
+	"sigs.k8s.io/node-feature-discovery/source/crypto"
 	"sigs.k8s.io/node-feature-discovery/source/custom"
 	"sigs.k8s.io/node-feature-discovery/source/fake"
 	"sigs.k8s.io/node-feature-discovery/source/iommu"
@@ -139,6 +140,7 @@ func NewNfdWorker(args *Args) (NfdWorker, error) {
 			&system.Source{},
 			&usb.Source{},
 			&custom.Source{},
+			&crypto.Source{},
 			// local needs to be the last source so that it is able to override
 			// labels from other sources
 			&local.Source{},

--- a/source/crypto/cex_s390x.go
+++ b/source/crypto/cex_s390x.go
@@ -1,0 +1,77 @@
+// +build s390x
+
+/*
+Copyright 2021 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crypto
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/node-feature-discovery/source"
+)
+
+type CEX struct {
+	Name string
+	Type string
+}
+
+func discoverCEX() ([]*CEX, error) {
+	cards := []*CEX{}
+	sysfsBasePath := source.SysfsDir.Path("bus/ap/devices")
+
+	devices, err := ioutil.ReadDir(sysfsBasePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []*CEX{}, nil
+		} else {
+			return nil, err
+		}
+	}
+
+	// Iterate over devices
+	for _, device := range devices {
+		if !strings.HasPrefix(device.Name(), "card") {
+			continue
+		}
+		card, err := readCex(sysfsBasePath, device.Name())
+		if err != nil {
+			klog.Errorf("Failed to read Crypto Express %s: %v", device.Name(), err)
+			continue
+		}
+		cards = append(cards, card)
+	}
+
+	return cards, nil
+}
+
+func readCex(basePath string, name string) (*CEX, error) {
+	card := new(CEX)
+	cardPath := path.Join(basePath, name)
+
+	card.Name = name
+	data, err := ioutil.ReadFile(cardPath + "/type")
+	if err != nil {
+		return nil, err
+	}
+	cardType := string(data)
+	card.Type = strings.Trim(cardType, "\n")
+	return card, nil
+}

--- a/source/crypto/cex_stub.go
+++ b/source/crypto/cex_stub.go
@@ -1,0 +1,29 @@
+// +build !s390x
+
+/*
+Copyright 2021 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crypto
+
+type CEX struct {
+	Name    string
+	Type    string
+	Domains []string
+}
+
+func discoverCEX() ([]*CEX, error) {
+	return []*CEX{}, nil
+}

--- a/source/crypto/crypto.go
+++ b/source/crypto/crypto.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crypto
+
+import (
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/node-feature-discovery/source"
+)
+
+type Config struct{}
+
+// newDefaultConfig returns a new config with pre-populated defaults
+func newDefaultConfig() *Config {
+	return &Config{}
+}
+
+// Implement FeatureSource interface
+type Source struct {
+	config *Config
+}
+
+func (s Source) Name() string { return "crypto" }
+
+// NewConfig method of the FeatureSource interface
+func (s *Source) NewConfig() source.Config { return newDefaultConfig() }
+
+// GetConfig method of the FeatureSource interface
+func (s *Source) GetConfig() source.Config { return s.config }
+
+// SetConfig method of the FeatureSource interface
+func (s *Source) SetConfig(conf source.Config) {
+	switch v := conf.(type) {
+	case *Config:
+		s.config = v
+	default:
+		klog.Fatalf("invalid config type: %T", conf)
+	}
+}
+
+func (s *Source) Discover() (source.Features, error) {
+	features := source.Features{}
+
+	// Check for Crypto Express Cards
+	cards, err := discoverCEX()
+	if err != nil {
+		klog.Errorf("failed to detect Crypto Express: %v", err)
+	} else if cards != nil && len(cards) > 0 {
+		features["cex.present"] = true
+	}
+
+	return features, nil
+}


### PR DESCRIPTION
Add feature detection for IBM Crypto Express Cards.
Detect the available crypto cards, their type and the assigned domains.

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>