### PR TITLE
Fix nfd worker tolerations value

### DIFF
--- a/deployment/node-feature-discovery/values.yaml
+++ b/deployment/node-feature-discovery/values.yaml
@@ -210,7 +210,7 @@ worker:
 
   nodeSelector: {}
 
-  tolerations: []
+  tolerations: {}
 
   annotations: {}
 


### PR DESCRIPTION
Tolerations value is array therefore we need to pass
[] and not {} as a default value.