### PR TITLE
Documentation capturing enablement of NFD-Topology-Updater in NFD

### DIFF
--- a/docs/advanced/developer-guide.md
+++ b/docs/advanced/developer-guide.md
@@ -257,6 +257,72 @@ stand-alone directly with `docker run`. See the
 [template spec](https://github.com/kubernetes-sigs/node-feature-discovery/blob/{{site.release}}/nfd-worker-daemonset.yaml.template)
 for up-to-date information about the required volume mounts.
 
+
+### NFD-Topology-Updater
+
+In order to run nfd-topology as a "stand-alone" container against your
+standalone nfd-master you need to run them in the same network namespace:
+
+```bash
+$ docker run --rm --network=container:nfd-test ${NFD_CONTAINER_IMAGE} nfd-topology-updater
+2019/02/01 14:48:56 Node Feature Discovery Topology Updater <NFD_VERSION>
+...
+```
+
+If you just want to try out feature discovery without connecting to nfd-master,
+pass the `--no-publish` flag to nfd-topology-updater.
+
+Command line flags of nfd-topology-updater:
+
+```bash
+$ docker run --rm ${NFD_CONTAINER_IMAGE} nfd-topology-updater --help
+...
+nfd-topology-updater.
+
+  Usage:
+  nfd-topology-updater [--no-publish][--oneshot | --sleep-interval=<seconds>][--server=<server>]
+                       [--server-name-override=<name>] [--ca-file=<path>] [--cert-file=<path>]
+                       [--key-file=<path>][--container-runtime=<runtime>] [--podresources-socket=<path>]
+                       [--watch-namespace=<namespace>] [--sysfs=<mountpoint>] [--kubelet-config-file=<path>]
+  nfd-topology-updater -h | --help
+  nfd-topology-updater --version
+
+  Options:
+  -h --help                       Show this screen.
+  --version                       Output version and exit.
+  --ca-file=<path>                Root certificate for verifying connections
+                                  [Default: ]
+  --cert-file=<path>              Certificate used for authenticating connections
+                                  [Default: ]
+  --key-file=<path>               Private key matching --cert-file
+                                  [Default: ]
+  --server=<server>               NFD server address to connect to.
+                                  [Default: localhost:8080]
+  --server-name-override=<name>   Name (CN) expect from server certificate, useful
+                                  in testing
+                                  [Default: ]
+  --no-publish                    Do not publish discovered features to the
+                                  cluster-local Kubernetes API server.
+  --oneshot                       Update once and exit.
+  --sleep-interval=<seconds>      Time to sleep between re-labeling. Non-positive
+                                  value implies no re-labeling (i.e. infinite
+                                  sleep). [Default: 60s]
+  --watch-namespace=<namespace>   Namespace to watch pods for. Use "" for all namespaces.
+  --sysfs=<mountpoint>            Mount point of the sysfs.
+                                  [Default: /host]
+  --kubelet-config-file=<path>    Kubelet config file path.
+                                  [Default: /podresources/config.yaml]
+  --podresources-socket=<path>    Pod Resource Socket path to use.
+                                  [Default: /podresources/kubelet.sock]
+```
+
+**NOTE** Some feature sources need certain directories and/or files from the
+host mounted inside the NFD container. Thus, you need to provide Docker with the
+correct `--volume` options in order for them to work correctly when run
+stand-alone directly with `docker run`. See the
+[template spec](https://github.com/kubernetes-sigs/node-feature-discovery/blob/{{ site.release }}/nfd-worker-daemonset.yaml.template)
+for up-to-date information about the required volume mounts.
+
 ## Documentation
 
 All documentation resides under the

--- a/docs/advanced/topology-updater-commandline-reference.md
+++ b/docs/advanced/topology-updater-commandline-reference.md
@@ -1,0 +1,199 @@
+---
+title: "Topology Updater Cmdline Reference"
+layout: default
+sort: 8
+---
+
+# NFD-Topology-Updater Commandline Flags
+{: .no_toc }
+
+## Table of Contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+To quickly view available command line flags execute `nfd-topology-updater --help`.
+In a docker container:
+
+```bash
+docker run gcr.io/k8s-staging-nfd/node-feature-discovery:master nfd-topology-updater --help
+```
+
+### -h, --help
+
+Print usage and exit.
+
+### --version
+
+Print version and exit.
+
+### --server
+
+The `--server` flag specifies the address of the nfd-master endpoint where to
+connect to.
+
+Default: localhost:8080
+
+Example:
+
+```bash
+nfd-topology-updater --server=nfd-master.nfd.svc.cluster.local:443
+```
+
+### --ca-file
+
+The `--ca-file` is one of the three flags (together with `--cert-file` and
+`--key-file`) controlling the mutual TLS authentication on the topology-updater side.
+This flag specifies the TLS root certificate that is used for verifying the
+authenticity of nfd-master.
+
+Default: *empty*
+
+Note: Must be specified together with `--cert-file` and `--key-file`
+
+Example:
+
+```bash
+nfd-topology-updater --ca-file=/opt/nfd/ca.crt --cert-file=/opt/nfd/updater.crt --key-file=/opt/nfd/updater.key
+```
+
+### --cert-file
+
+The `--cert-file` is one of the three flags (together with `--ca-file` and
+`--key-file`) controlling mutual TLS authentication on the topology-updater side. This
+flag specifies the TLS certificate presented for authenticating outgoing
+requests.
+
+Default: *empty*
+
+Note: Must be specified together with `--ca-file` and `--key-file`
+
+Example:
+
+```bash
+nfd-topology-updater --cert-file=/opt/nfd/updater.crt --key-file=/opt/nfd/updater.key --ca-file=/opt/nfd/ca.crt
+```
+
+### --key-file
+
+The `--key-file` is one of the three flags (together with `--ca-file` and
+`--cert-file`) controlling the mutual TLS authentication on the topology-updater side.
+This flag specifies the private key corresponding the given certificate file
+(`--cert-file`) that is used for authenticating outgoing requests.
+
+Default: *empty*
+
+Note: Must be specified together with `--cert-file` and `--ca-file`
+
+Example:
+
+```bash
+nfd-topology-updater --key-file=/opt/nfd/updater.key --cert-file=/opt/nfd/updater.crt --ca-file=/opt/nfd/ca.crt
+```
+
+### --server-name-override
+
+The `--server-name-override` flag specifies the common name (CN) which to
+expect from the nfd-master TLS certificate. This flag is mostly intended for
+development and debugging purposes.
+
+Default: *empty*
+
+Example:
+
+```bash
+nfd-topology-updater --server-name-override=localhost
+```
+
+### --no-publish
+
+The `--no-publish` flag disables all communication with the nfd-master, making
+it a "dry-run" flag for nfd-topology-updater. NFD-Topology-Updater runs resource hardware topology detection normally,
+but no CRD requests are sent to nfd-master.
+
+Default: *false*
+
+Example:
+
+```bash
+nfd-topology-updater --no-publish
+```
+
+### --oneshot
+
+The `--oneshot` flag causes nfd-topology-updater to exit after one pass of resource hardware topology
+detection.
+
+Default: *false*
+
+Example:
+
+```bash
+nfd-topology-updater --oneshot --no-publish
+```
+
+### --sleep-interval
+
+The `--sleep-interval` specifies the interval between resource hardware topology re-examination (and
+CRD updation). A non-positive value implies infinite sleep interval, i.e.
+no re-detection is done.
+
+Default: 60s
+
+Example:
+
+```bash
+nfd-topology-updater --sleep-interval=1h
+```
+
+### --watch-namespace
+
+The `--watch-namespace` specifies the namespace to ensure that resource hardware topology examination
+only happens for the pods running in the specified namespace. Pods  that are not running in the specified
+namespace are not considered during resource accounting. An empty value would mean that all the pods would
+be considered during the accounting process.
+
+Default: *empty*
+
+Example:
+
+```bash
+nfd-topology-updater --watch-namespace=rte
+```
+### --sysfs
+
+The `--sysfs` specifies the root mountpoint that topology-updater uses when looking for information about the host system.
+Default: /host
+
+Example:
+
+```bash
+nfd-topology-updater --sysfs=/host
+```
+### --kubelet-config-file
+
+The `--kubelet-config-file` specifies the path to the Kubelet's configuration file.
+
+Default:  /podresources/config.yaml
+
+Example:
+
+```bash
+nfd-topology-updater --kubelet-config-file=/var/lib/kubelet/config.yaml
+```
+
+### --podresources-socket
+
+The `--podresources-socket` specifies the path to the Unix socket where kubelet exports a gRPC service
+to enable discovery of in-use CPUs and devices, and to provide metadata for them.
+
+Default:  /podresources/kubelet.sock
+
+Example:
+
+```bash
+nfd-topology-updater --podresources-socket=/var/lib/kubelet/pod-resources/kubelet.sock
+```

--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -96,25 +96,27 @@ The template specs provided in the repo can be used directly:
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-master.yaml.template
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-worker-daemonset.yaml.template
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-topology-updater-daemonset.yaml.template
 ```
 
 This will required RBAC rules and deploy nfd-master (as a deployment) and
-nfd-worker (as a daemonset) in the `node-feature-discovery` namespace.
+nfd-worker and nfd-topology-updater (as daemonset) in the `node-feature-discovery` namespace.
 
 Alternatively you can download the templates and customize the deployment
 manually. For example, to deploy the [minimal](#minimal) image.
 
 #### Master-worker pod
 
-You can also run nfd-master and nfd-worker inside the same pod
+You can also run nfd-master, nfd-worker and nfd-topology-updater inside the same pod
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-daemonset-combined.yaml.template
 ```
 
-This creates a DaemonSet runs both nfd-worker and nfd-master in the same Pod.
+This creates a DaemonSet runs nfd-worker, nfd-master and nfd-topology-updater in the same Pod.
 In this case no nfd-master is run on the master node(s), but, the worker nodes
 are able to label themselves which may be desirable e.g. in single-node setups.
+Also, NodeResourceTopology CRD instances are created corresponding to the worker nodes.
 
 #### Worker one-shot
 
@@ -128,7 +130,24 @@ curl -fs https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discover
     kubectl apply -f -
 ```
 
-The example above launces as many jobs as there are non-master nodes. Note that
+The example above launches as many jobs as there are non-master nodes. Note that
+this approach does not guarantee running once on every node. For example,
+tainted, non-ready nodes or some other reasons in Job scheduling may cause some
+node(s) will run extra job instance(s) to satisfy the request.
+
+#### Topology Updater One-shot
+
+NFD Topology Updater can alternatively be configured as a one-shot job.
+The Job template may be used to achieve this:
+
+```bash
+NUM_NODES=$(kubectl get no -o jsonpath='{.items[*].metadata.name}' | wc -w)
+curl -fs https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-topology-updater-job.yaml.template | \
+    sed s"/NUM_NODES/$NUM_NODES/" | \
+    kubectl apply -f -
+```
+
+The example above launches as many jobs as there are non-master nodes. Note that
 this approach does not guarantee running once on every node. For example,
 tainted, non-ready nodes or some other reasons in Job scheduling may cause some
 node(s) will run extra job instance(s) to satisfy the request.
@@ -285,7 +304,7 @@ labels. The provided template will configure these for you.
 
 NFD-Worker is preferably run as a Kubernetes DaemonSet. This assures
 re-labeling on regular intervals capturing changes in the system configuration
-and mames sure that new nodes are labeled as they are added to the cluster.
+and makes sure that new nodes are labeled as they are added to the cluster.
 Worker connects to the nfd-master service to advertise hardware features.
 
 When run as a daemonset, nodes are re-labeled at an interval specified using
@@ -294,6 +313,22 @@ the `-sleep-interval` option. In the
 the default interval is set to 60s which is also the default when no
 `-sleep-interval` is specified. Also, the configuration file is re-read on
 each iteration providing a simple mechanism of run-time reconfiguration.
+
+### NFD-Topology-Updater
+
+NFD-Worker is preferably run as a Kubernetes DaemonSet. This assures
+re-examination (and CRD updation) on regular intervals capturing changes in the
+allocated resources and hence the allocatable resources on a per zone basis. It
+makes sure that more CRD instances are created as new nodes get added to the
+cluster. Topology-Updater connects to the nfd-master service to creates CRD
+intances corresponding to nodes.
+
+When run as a daemonset, nodes are re-examined for the allocated resources
+(to determine the information of the allocatable resources on a per zone basis
+where a zone can be a NUMA node) at an interval specified using the
+`-sleep-interval` option. In the
+[template](https://github.com/kubernetes-sigs/node-feature-discovery/blob/{{ site.release }}/nfd-topology-daemonset.yaml.template#L37) the default interval is set to 60s which is also the default when no -sleep-interval is specified.
+
 
 ### Communication security with TLS
 

--- a/docs/get-started/introduction.md
+++ b/docs/get-started/introduction.md
@@ -21,10 +21,11 @@ This software enables node feature discovery for Kubernetes. It detects
 hardware features available on each node in a Kubernetes cluster, and
 advertises those features using node labels.
 
-NFD consists of two software components:
+NFD consists of three software components:
 
 1. nfd-master
 1. nfd-worker
+1. nfd-topology-updater
 
 ## NFD-Master
 
@@ -38,7 +39,16 @@ NFD-Worker is a daemon responsible for feature detection. It then communicates
 the information to nfd-master which does the actual node labeling.  One
 instance of nfd-worker is supposed to be running on each node of the cluster,
 
-## Feature discovery
+## NFD-Topology-Updater
+
+NFD-Topology-Updater is a daemon responsible for examining allocated resources
+on a worker node to account for allocatable resources on a per-zone basis (where
+a zone can be a NUMA node). It then communicates the information to nfd-master
+which does the CRD creation corresponding to all the nodes in the cluster. One
+instance of nfd-topology-updater is supposed to be running on each node of the
+cluster.
+
+## Feature Discovery
 
 Feature discovery is divided into domain-specific feature sources:
 
@@ -96,3 +106,43 @@ Unapplicable annotations are not created, i.e. for example master.version is
 only created on nodes running nfd-master.
 
 
+
+## NodeResourceTopology CRD
+
+When run with NFD-Topology-Updater, NFD creates CRD intances corresponding to node resource hardware topology such as:
+
+ ```yaml
+apiVersion: topology.node.k8s.io/v1alpha1
+kind: NodeResourceTopology
+metadata:
+  name: node1
+topologyPolicies: ["SingleNUMANode"]
+zones:
+  - name: node-0
+    type: Node
+    resources:
+      - name: cpu
+        capacity: 20
+        allocatable: 10
+      - name: vendor/nic1
+        capacity: 3
+        allocatable: 3
+  - name: node-1
+    type: Node
+    resources:
+      - name: cpu
+        capacity: 30
+        allocatable: 15
+      - name: vendor/nic2
+        capacity: 6
+        allocatable: 6
+  - name: node-2
+    type: Node
+    resources:
+      - name: cpu
+        capacity: 30
+        allocatable: 15
+      - name: vendor/nic1
+        capacity: 3
+        allocatable: 3
+ ```

--- a/docs/get-started/quick-start.md
+++ b/docs/get-started/quick-start.md
@@ -22,16 +22,25 @@ Deploy nfd-worker as a daemonset
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-worker-daemonset.yaml.template
 ```
 
+Deploy nfd-topology-updater as a daemonset
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-topology-updater-daemonset.yaml.template
+```
+
 ## Verify
 
 Wait until NFD master and worker are running.
 
 ```bash
 $ kubectl -n node-feature-discovery get ds,deploy
-NAME                        DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
-daemonset.apps/nfd-worker   3         3         3       3            3           <none>          5s
+NAME                                  DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
+daemonset.apps/nfd-topology-updater   2         2         2       2            2           <none>          5s
+daemonset.apps/nfd-worker             2         2         2       2            2           <none>          10s
+
 NAME                         READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/nfd-master   1/1     1            1           17s
+
 ```
 
 Check that NFD feature labels have been created
@@ -45,6 +54,15 @@ $ kubectl get no -o json | jq .items[].metadata.labels
   "feature.node.kubernetes.io/cpu-cpuid.AESNI": "true",
   "feature.node.kubernetes.io/cpu-cpuid.AVX": "true",
 ...
+```
+
+Check that the NodeResourceTopology CRD instances are created
+```bash
+$ kubectl get noderesourcetopologies.topology.node.k8s.io
+NAME                 AGE
+kind-control-plane   23s
+kind-worker          23s
+
 ```
 
 ## Use node labels
@@ -76,3 +94,51 @@ $ kubectl get po feature-dependent-pod -o wide
 NAME                    READY   STATUS    RESTARTS   AGE   IP          NODE     NOMINATED NODE   READINESS GATES
 feature-dependent-pod   1/1     Running   0          23s   10.36.0.4   node-2   <none>           <none>
 ```
+
+## Show the CRDs
+
+```bash
+$ kubectl describe noderesourcetopologies.topology.node.k8s.io kind-control-plane
+Name:         kind-control-plane
+Namespace:    default
+Labels:       <none>
+Annotations:  <none>
+API Version:  topology.node.k8s.io/v1alpha1
+Kind:         NodeResourceTopology
+...
+Topology Policies:
+  single-numa-node
+Zones:
+    Name:             node-0
+    Costs:
+      node-0:  10
+      node-1:  20
+    Resources:
+        Name:         Cpu
+        Allocatable:  3
+        Capacity:     3
+        Name:         vendor/nic1
+        Allocatable:  2
+        Capacity:     2
+        Name:         vendor/nic2
+        Allocatable:  2
+        Capacity:     2
+    Type:             Node
+    Name:             node-1
+    Costs:
+      node-0:  20
+      node-1:  10
+    Resources:
+        Name:         Cpu
+        Allocatable:  4
+        Capacity:     4
+        Name:         vendor/nic1
+        Allocatable:  2
+        Capacity:     2
+        Name:         vendor/nic2
+        Allocatable:  2
+        Capacity:     2
+    Type:             Node
+Events:               <none>
+```
+The CRD instances created can be used to gain insight into the allocatable resources along with the granularity of those resources at a per-zone level (represented by node-0 and node-1 in the above example) or can be used by an external entity (e.g. topology-aware scheduler plugin) to take an action based on the gathered information.


### PR DESCRIPTION
Prior to this feature, NFD consisted of only software components namely
nfd-master and nfd-worker. We have introduced another software component
called nfd-topology-updater.

NFD-Topology-Updater is a daemon responsible for examining allocated resources
on a worker node to account for allocatable resources on a per-zone basis (where
a zone can be a NUMA node). It then communicates the information to nfd-master
which does the CRD creation corresponding to all the nodes in the cluster. One
instance of nfd-topology-updater is supposed to be running on each node of the
cluster.

Implementation PR: https://github.com/kubernetes-sigs/node-feature-discovery/pull/525
Issue: #333

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>