### PR TITLE
chore: update tolerations and affinities to control-plane

### DIFF
--- a/deployment/node-feature-discovery/Chart.yaml
+++ b/deployment/node-feature-discovery/Chart.yaml
@@ -12,4 +12,4 @@ keywords:
   - feature-detection
   - node-labels
 type: application
-version: 0.1.2
+version: 0.2.0

--- a/deployment/node-feature-discovery/values.yaml
+++ b/deployment/node-feature-discovery/values.yaml
@@ -58,6 +58,10 @@ master:
     operator: "Equal"
     value: ""
     effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/control-plane"
+    operator: "Equal"
+    value: ""
+    effect: "NoSchedule"
 
   annotations: {}
 
@@ -68,6 +72,12 @@ master:
           preference:
             matchExpressions:
               - key: "node-role.kubernetes.io/master"
+                operator: In
+                values: [""]
+        - weight: 1
+          preference:
+            matchExpressions:
+              - key: "node-role.kubernetes.io/control-plane"
                 operator: In
                 values: [""]
 

--- a/nfd-master.yaml.template
+++ b/nfd-master.yaml.template
@@ -70,8 +70,18 @@ spec:
                   - key: "node-role.kubernetes.io/master"
                     operator: In
                     values: [""]
+            - weight: 1
+              preference:
+                matchExpressions:
+                  - key: "node-role.kubernetes.io/control-plane"
+                    operator: In
+                    values: [""]
       tolerations:
         - key: "node-role.kubernetes.io/master"
+          operator: "Equal"
+          value: ""
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
           operator: "Equal"
           value: ""
           effect: "NoSchedule"

--- a/nfd-prune.yaml.template
+++ b/nfd-prune.yaml.template
@@ -67,8 +67,18 @@ spec:
                   - key: "node-role.kubernetes.io/master"
                     operator: In
                     values: [""]
+            - weight: 1
+              preference:
+                matchExpressions:
+                  - key: "node-role.kubernetes.io/control-plane"
+                    operator: In
+                    values: [""]
       tolerations:
         - key: "node-role.kubernetes.io/master"
+          operator: "Equal"
+          value: ""
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
           operator: "Equal"
           value: ""
           effect: "NoSchedule"


### PR DESCRIPTION
This updates the tolerations and affinities to also respect the term „control-plane“ which will eventually replace „master“