### PR TITLE
source: define source names as consts

### DIFF
--- a/source/cpu/cpu.go
+++ b/source/cpu/cpu.go
@@ -25,6 +25,8 @@ import (
 	"sigs.k8s.io/node-feature-discovery/source/internal/cpuidutils"
 )
 
+const Name = "cpu"
+
 // Configuration file options
 type cpuidConfig struct {
 	AttributeBlacklist []string `json:"attributeBlacklist,omitempty"`
@@ -82,7 +84,7 @@ type Source struct {
 	cpuidFilter *keyFilter
 }
 
-func (s Source) Name() string { return "cpu" }
+func (s Source) Name() string { return Name }
 
 // NewConfig method of the FeatureSource interface
 func (s *Source) NewConfig() source.Config { return newDefaultConfig() }

--- a/source/custom/custom.go
+++ b/source/custom/custom.go
@@ -26,6 +26,8 @@ import (
 	"sigs.k8s.io/node-feature-discovery/source/custom/rules"
 )
 
+const Name = "custom"
+
 // Custom Features Configurations
 type MatchRule struct {
 	PciID      *rules.PciIDRule      `json:"pciId,omitempty"`
@@ -55,7 +57,7 @@ type Source struct {
 }
 
 // Return name of the feature source
-func (s Source) Name() string { return "custom" }
+func (s Source) Name() string { return Name }
 
 // NewConfig method of the FeatureSource interface
 func (s *Source) NewConfig() source.Config { return newDefaultConfig() }

--- a/source/fake/fake.go
+++ b/source/fake/fake.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/node-feature-discovery/source"
 )
 
+const Name = "fake"
+
 // Configuration file options
 type Config struct {
 	Labels map[string]string `json:"labels"`
@@ -44,7 +46,7 @@ type Source struct {
 }
 
 // Name returns an identifier string for this feature source.
-func (s Source) Name() string { return "fake" }
+func (s Source) Name() string { return Name }
 
 // NewConfig method of the FeatureSource interface
 func (s *Source) NewConfig() source.Config { return newDefaultConfig() }

--- a/source/iommu/iommu.go
+++ b/source/iommu/iommu.go
@@ -23,10 +23,12 @@ import (
 	"sigs.k8s.io/node-feature-discovery/source"
 )
 
+const Name = "iommu"
+
 // Implement FeatureSource interface
 type Source struct{}
 
-func (s Source) Name() string { return "iommu" }
+func (s Source) Name() string { return Name }
 
 // NewConfig method of the FeatureSource interface
 func (s *Source) NewConfig() source.Config { return nil }

--- a/source/kernel/kernel.go
+++ b/source/kernel/kernel.go
@@ -26,6 +26,8 @@ import (
 	"sigs.k8s.io/node-feature-discovery/source/internal/kernelutils"
 )
 
+const Name = "kernel"
+
 // Configuration file options
 type Config struct {
 	KconfigFile string
@@ -50,7 +52,7 @@ type Source struct {
 	config *Config
 }
 
-func (s *Source) Name() string { return "kernel" }
+func (s *Source) Name() string { return Name }
 
 // NewConfig method of the FeatureSource interface
 func (s *Source) NewConfig() source.Config { return newDefaultConfig() }

--- a/source/local/local.go
+++ b/source/local/local.go
@@ -30,6 +30,8 @@ import (
 	"sigs.k8s.io/node-feature-discovery/source"
 )
 
+const Name = "local"
+
 // Config
 var (
 	featureFilesDir = "/etc/kubernetes/node-feature-discovery/features.d/"
@@ -39,7 +41,7 @@ var (
 // Implement FeatureSource interface
 type Source struct{}
 
-func (s Source) Name() string { return "local" }
+func (s Source) Name() string { return Name }
 
 // NewConfig method of the FeatureSource interface
 func (s *Source) NewConfig() source.Config { return nil }

--- a/source/memory/memory.go
+++ b/source/memory/memory.go
@@ -26,11 +26,13 @@ import (
 	"sigs.k8s.io/node-feature-discovery/source"
 )
 
+const Name = "memory"
+
 // Source implements FeatureSource.
 type Source struct{}
 
 // Name returns an identifier string for this feature source.
-func (s Source) Name() string { return "memory" }
+func (s Source) Name() string { return Name }
 
 // NewConfig method of the FeatureSource interface
 func (s *Source) NewConfig() source.Config { return nil }

--- a/source/network/network.go
+++ b/source/network/network.go
@@ -28,6 +28,8 @@ import (
 	"sigs.k8s.io/node-feature-discovery/source"
 )
 
+const Name = "network"
+
 // Linux net iface flags (we only specify the first few)
 const (
 	flagUp = 1 << iota
@@ -42,7 +44,7 @@ const sysfsBaseDir = "class/net"
 type Source struct{}
 
 // Name returns an identifier string for this feature source.
-func (s Source) Name() string { return "network" }
+func (s Source) Name() string { return Name }
 
 // NewConfig method of the FeatureSource interface
 func (s *Source) NewConfig() source.Config { return nil }

--- a/source/pci/pci.go
+++ b/source/pci/pci.go
@@ -26,6 +26,8 @@ import (
 	pciutils "sigs.k8s.io/node-feature-discovery/source/internal"
 )
 
+const Name = "pci"
+
 type Config struct {
 	DeviceClassWhitelist []string `json:"deviceClassWhitelist,omitempty"`
 	DeviceLabelFields    []string `json:"deviceLabelFields,omitempty"`
@@ -45,7 +47,7 @@ type Source struct {
 }
 
 // Return name of the feature source
-func (s Source) Name() string { return "pci" }
+func (s Source) Name() string { return Name }
 
 // NewConfig method of the FeatureSource interface
 func (s *Source) NewConfig() source.Config { return newDefaultConfig() }

--- a/source/storage/storage.go
+++ b/source/storage/storage.go
@@ -23,11 +23,13 @@ import (
 	"sigs.k8s.io/node-feature-discovery/source"
 )
 
+const Name = "storage"
+
 // Source implements FeatureSource.
 type Source struct{}
 
 // Name returns an identifier string for this feature source.
-func (s Source) Name() string { return "storage" }
+func (s Source) Name() string { return Name }
 
 // NewConfig method of the FeatureSource interface
 func (s *Source) NewConfig() source.Config { return nil }

--- a/source/system/system.go
+++ b/source/system/system.go
@@ -32,10 +32,12 @@ var osReleaseFields = [...]string{
 	"VERSION_ID",
 }
 
+const Name = "system"
+
 // Implement FeatureSource interface
 type Source struct{}
 
-func (s Source) Name() string { return "system" }
+func (s Source) Name() string { return Name }
 
 // NewConfig method of the FeatureSource interface
 func (s *Source) NewConfig() source.Config { return nil }

--- a/source/usb/usb.go
+++ b/source/usb/usb.go
@@ -26,6 +26,8 @@ import (
 	usbutils "sigs.k8s.io/node-feature-discovery/source/internal"
 )
 
+const Name = "usb"
+
 type Config struct {
 	DeviceClassWhitelist []string `json:"deviceClassWhitelist,omitempty"`
 	DeviceLabelFields    []string `json:"deviceLabelFields,omitempty"`
@@ -48,7 +50,7 @@ type Source struct {
 }
 
 // Return name of the feature source
-func (s Source) Name() string { return "usb" }
+func (s Source) Name() string { return Name }
 
 // NewConfig method of the FeatureSource interface
 func (s *Source) NewConfig() source.Config { return newDefaultConfig() }


### PR DESCRIPTION
Paves the way for future work on more general representation of
feature data and looser coupling of the data and feature source
interface.