### PR TITLE
Add Readiness and liveliness probes to nfd-master

### DIFF
--- a/deployment/base/master-worker-combined/master-worker-daemonset.yaml
+++ b/deployment/base/master-worker-combined/master-worker-daemonset.yaml
@@ -19,6 +19,17 @@ spec:
       - name: nfd-master
         image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
         imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 10
         command:
         - "nfd-master"
       - name: nfd-worker

--- a/deployment/base/master/master-deployment.yaml
+++ b/deployment/base/master/master-deployment.yaml
@@ -20,6 +20,17 @@ spec:
         - name: nfd-master
           image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
           imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 10
           command:
             - "nfd-master"
           args: []

--- a/deployment/helm/node-feature-discovery/templates/master.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master.yaml
@@ -32,6 +32,17 @@ spec:
             {{- toYaml .Values.master.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          livenessProbe:
+            exec:
+              command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 10
           ports:
           - containerPort: 8080
             name: grpc

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -36,6 +36,8 @@ import (
 	api "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"sigs.k8s.io/node-feature-discovery/pkg/apihelper"
 	pb "sigs.k8s.io/node-feature-discovery/pkg/labeler"
 	"sigs.k8s.io/node-feature-discovery/pkg/utils"
@@ -186,6 +188,7 @@ func (m *nfdMaster) Run() error {
 	}
 	m.server = grpc.NewServer(serverOpts...)
 	pb.RegisterLabelerServer(m.server, m)
+	grpc_health_v1.RegisterHealthServer(m.server, health.NewServer())
 	klog.Infof("gRPC server serving on port: %d", m.args.Port)
 
 	// Run gRPC server


### PR DESCRIPTION
Fixes #522 

This patch seeks to:

- https://github.com/kubernetes-sigs/node-feature-discovery/commit/273cfffe62936300f575bca72205bff0cc8bae3d enable readinessprobe for nfd-master
- https://github.com/kubernetes-sigs/node-feature-discovery/pull/563/commits/f4e8e20ea5c963c0cb4610f702abf0ed889b90a9 add livenessprobe for nfd-master