### PR TITLE
Better error reporting of kernel and cpu feature sources

### DIFF
--- a/source/cpu/cpu.go
+++ b/source/cpu/cpu.go
@@ -147,10 +147,10 @@ func (s *Source) Discover() (source.Features, error) {
 	}
 
 	// Detect cstate configuration
-	cstate, err := detectCstate()
+	cstate, ok, err := detectCstate()
 	if err != nil {
-		klog.Errorf("failed to detect cstate: %v", err)
-	} else {
+		klog.Error(err)
+	} else if ok {
 		features["cstate.enabled"] = cstate
 	}
 

--- a/source/cpu/pstate.go
+++ b/source/cpu/pstate.go
@@ -19,6 +19,8 @@ package cpu
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -35,10 +37,21 @@ func detectPstate() (map[string]string, error) {
 		return nil, nil
 	}
 
+	// Check that sysfs is available
+	sysfsBase := source.SysfsDir.Path("devices/system/cpu")
+	if _, err := os.Stat(sysfsBase); err != nil {
+		return nil, fmt.Errorf("unable to detect pstate status: %w", err)
+	}
+	pstateDir := filepath.Join(sysfsBase, "intel_pstate")
+	if _, err := os.Stat(pstateDir); os.IsNotExist(err) {
+		klog.V(1).Info("intel pstate driver not enabled")
+		return nil, nil
+	}
+
 	// Get global pstate status
-	data, err := ioutil.ReadFile(source.SysfsDir.Path("devices/system/cpu/intel_pstate/status"))
+	data, err := ioutil.ReadFile(filepath.Join(pstateDir, "status"))
 	if err != nil {
-		return nil, fmt.Errorf("could not read pstate status: %s", err.Error())
+		return nil, fmt.Errorf("could not read pstate status: %w", err)
 	}
 	status := strings.TrimSpace(string(data))
 	if status == "off" {
@@ -49,7 +62,7 @@ func detectPstate() (map[string]string, error) {
 	features := map[string]string{"status": status}
 
 	// Check turbo boost
-	bytes, err := ioutil.ReadFile(source.SysfsDir.Path("devices/system/cpu/intel_pstate/no_turbo"))
+	bytes, err := ioutil.ReadFile(filepath.Join(pstateDir, "no_turbo"))
 	if err != nil {
 		klog.Errorf("can't detect whether turbo boost is enabled: %s", err.Error())
 	} else {
@@ -65,7 +78,8 @@ func detectPstate() (map[string]string, error) {
 	}
 
 	// Determine scaling governor that is being used
-	policies, err := ioutil.ReadDir(source.SysfsDir.Path("devices/system/cpu/cpufreq"))
+	cpufreqDir := filepath.Join(sysfsBase, "cpufreq")
+	policies, err := ioutil.ReadDir(cpufreqDir)
 	if err != nil {
 		klog.Errorf("failed to read cpufreq directory: %s", err.Error())
 		return features, nil
@@ -74,7 +88,7 @@ func detectPstate() (map[string]string, error) {
 	scaling := ""
 	for _, policy := range policies {
 		// Ensure at least one cpu is using this policy
-		cpus, err := ioutil.ReadFile(source.SysfsDir.Path("devices/system/cpu/cpufreq", policy.Name(), "affected_cpus"))
+		cpus, err := ioutil.ReadFile(filepath.Join(cpufreqDir, policy.Name(), "affected_cpus"))
 		if err != nil {
 			klog.Errorf("could not read cpufreq policy %s affected_cpus", policy.Name())
 			continue
@@ -84,7 +98,7 @@ func detectPstate() (map[string]string, error) {
 			continue
 		}
 
-		data, err := ioutil.ReadFile(source.SysfsDir.Path("devices/system/cpu/cpufreq", policy.Name(), "scaling_governor"))
+		data, err := ioutil.ReadFile(filepath.Join(cpufreqDir, policy.Name(), "scaling_governor"))
 		if err != nil {
 			klog.Errorf("could not read cpufreq policy %s scaling_governor", policy.Name())
 			continue


### PR DESCRIPTION
- source/cpu: better error reporting
  Drop confusing errors in the log when intel pstate or cstate driver is
  not enabled in the system. However, we still log an error if sysfs is
  not available at all, in which case we're not able to detect these
  correctly.
- source/kernel: better error reporting
  Get rid of distracting error in the log in case selinux is not enabled
  in the kernel. Still print an error only if sysfs/fs directory is not
  available, though, which indicates that we're not able to correctly
  detect the presence of selinux.

Fixes #527 