### PR TITLE
Fix the typo in deployment-and-usage.md

### DIFF
--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -285,7 +285,7 @@ labels. The provided template will configure these for you.
 
 NFD-Worker is preferably run as a Kubernetes DaemonSet. This assures
 re-labeling on regular intervals capturing changes in the system configuration
-and make sure that new nodes are labeled as they are added to the cluster.
+and makes sure that new nodes are labeled as they are added to the cluster.
 Worker connects to the nfd-master service to advertise hardware features.
 
 When run as a daemonset, nodes are re-labeled at an interval specified using

--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -285,7 +285,7 @@ labels. The provided template will configure these for you.
 
 NFD-Worker is preferably run as a Kubernetes DaemonSet. This assures
 re-labeling on regular intervals capturing changes in the system configuration
-and mames sure that new nodes are labeled as they are added to the cluster.
+and make sure that new nodes are labeled as they are added to the cluster.
 Worker connects to the nfd-master service to advertise hardware features.
 
 When run as a daemonset, nodes are re-labeled at an interval specified using


### PR DESCRIPTION
Fixed typo in https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/docs/get-started/deployment-and-usage.md

Fixes #567 