### PR TITLE
kustomize: fix broken master-worker-combined base

### DIFF
--- a/deployment/base/master-worker-combined/master-worker-daemonset.yaml
+++ b/deployment/base/master-worker-combined/master-worker-daemonset.yaml
@@ -19,17 +19,17 @@ spec:
       - name: nfd-master
         image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
         imagePullPolicy: Always
-          livenessProbe:
-            exec:
-              command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
-            initialDelaySeconds: 10
-            periodSeconds: 10
-          readinessProbe:
-            exec:
-              command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            failureThreshold: 10
+        livenessProbe:
+          exec:
+            command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          failureThreshold: 10
         command:
         - "nfd-master"
       - name: nfd-worker


### PR DESCRIPTION
Got broken unnoticed with the addition of liveness and readiness probes.