### PR TITLE
gitignore: add kustomization.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin/
 demo/helper-scripts/*.pdf
 demo/helper-scripts/*.log
+kustomization.yaml


### PR DESCRIPTION
Want to ignore kustomization.yaml which is auto-generated by the make
yamls target.