### PR TITLE
Only add kustomization.yaml in the root to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 bin/
 demo/helper-scripts/*.pdf
 demo/helper-scripts/*.log
-kustomization.yaml
+/kustomization.yaml


### PR DESCRIPTION
The current addition of kustomization.yaml to gitignore file
means that any file in the project tree with the name
kustomization.yaml will be ignored. However, that is not
the desired behaviour. One of the primary example of this
is when we add deployments corresponding to nfd-topology-updater,
we want to be able to ensure that the kustomization.yamls are not
ignored.

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>