### PR TITLE
Fix broken link for worker-conf example

### DIFF
--- a/docs/advanced/worker-configuration-reference.md
+++ b/docs/advanced/worker-configuration-reference.md
@@ -20,7 +20,7 @@ sort: 4
 ---
 
 See the
-[sample configuration file](https://github.com/kubernetes-sigs/node-feature-discovery/blob/{{site.release}}/nfd-worker.conf.example)
+[sample configuration file](https://github.com/kubernetes-sigs/node-feature-discovery/blob/{{site.release}}/deployment/components/worker-config/nfd-worker.conf.example)
 for a full example configuration.
 
 ## core


### PR DESCRIPTION
needs to be backported to v0.9.0 
Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>