### PR TITLE
source: implement FeatureSource interface

### DIFF
--- a/pkg/api/feature/feature.go
+++ b/pkg/api/feature/feature.go
@@ -20,28 +20,28 @@ package feature
 // features to empty values
 func NewDomainFeatures() *DomainFeatures {
 	return &DomainFeatures{
-		Keys:      make(map[string]*KeyFeatureSet),
-		Values:    make(map[string]*ValueFeatureSet),
-		Instances: make(map[string]*InstanceFeatureSet)}
+		Keys:      make(map[string]KeyFeatureSet),
+		Values:    make(map[string]ValueFeatureSet),
+		Instances: make(map[string]InstanceFeatureSet)}
 }
 
-func NewKeyFeatures(keys ...string) *KeyFeatureSet {
+func NewKeyFeatures(keys ...string) KeyFeatureSet {
 	e := make(map[string]Nil, len(keys))
 	for _, k := range keys {
 		e[k] = Nil{}
 	}
-	return &KeyFeatureSet{Elements: e}
+	return KeyFeatureSet{Elements: e}
 }
 
-func NewValueFeatures(values map[string]string) *ValueFeatureSet {
+func NewValueFeatures(values map[string]string) ValueFeatureSet {
 	if values == nil {
 		values = make(map[string]string)
 	}
-	return &ValueFeatureSet{Elements: values}
+	return ValueFeatureSet{Elements: values}
 }
 
-func NewInstanceFeatures(instances []InstanceFeature) *InstanceFeatureSet {
-	return &InstanceFeatureSet{Elements: instances}
+func NewInstanceFeatures(instances []InstanceFeature) InstanceFeatureSet {
+	return InstanceFeatureSet{Elements: instances}
 }
 
 func NewInstanceFeature(attrs map[string]string) *InstanceFeature {

--- a/pkg/api/feature/types.go
+++ b/pkg/api/feature/types.go
@@ -22,9 +22,9 @@ type Features map[string]*DomainFeatures
 
 // DomainFeatures is the collection of all discovered features of one domain.
 type DomainFeatures struct {
-	Keys      map[string]*KeyFeatureSet      `protobuf:"bytes,1,rep,name=keys"`
-	Values    map[string]*ValueFeatureSet    `protobuf:"bytes,2,rep,name=values"`
-	Instances map[string]*InstanceFeatureSet `protobuf:"bytes,3,rep,name=instances"`
+	Keys      map[string]KeyFeatureSet      `protobuf:"bytes,1,rep,name=keys"`
+	Values    map[string]ValueFeatureSet    `protobuf:"bytes,2,rep,name=values"`
+	Instances map[string]InstanceFeatureSet `protobuf:"bytes,3,rep,name=instances"`
 }
 
 // KeyFeatureSet is a set of simple features only containing names without values.

--- a/source/cpu/cpu_test.go
+++ b/source/cpu/cpu_test.go
@@ -1,6 +1,3 @@
-//go:build !amd64
-// +build !amd64
-
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -19,7 +16,21 @@ limitations under the License.
 
 package cpu
 
-// Discover if c-states are enabled
-func detectCstate() (map[string]string, error) {
-	return nil, nil
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
+)
+
+func TestCpuSource(t *testing.T) {
+	assert.Equal(t, src.Name(), Name)
+
+	// Check that GetLabels works with empty features
+	src.features = feature.NewDomainFeatures()
+	l, err := src.GetLabels()
+
+	assert.Nil(t, err, err)
+	assert.Empty(t, l)
+
 }

--- a/source/cpu/cpuid_amd64.go
+++ b/source/cpu/cpuid_amd64.go
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cpuidutils
+package cpu
 
 import (
 	"github.com/klauspost/cpuid/v2"
 )
 
-// GetCpuidFlags returns feature names for all the supported CPU features.
-func GetCpuidFlags() []string {
+// getCpuidFlags returns feature names for all the supported CPU features.
+func getCpuidFlags() []string {
 	return cpuid.CPU.FeatureSet()
 }

--- a/source/cpu/cpuid_arm.go
+++ b/source/cpu/cpuid_arm.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cpuidutils
+package cpu
 
 /*
 #include <sys/auxv.h>
@@ -90,7 +90,7 @@ var flagNames_arm = map[uint64]string{
 	CPU_ARM_FEATURE_CRC32:    "CRC32",
 }
 
-func GetCpuidFlags() []string {
+func getCpuidFlags() []string {
 	r := make([]string, 0, 20)
 	hwcap := uint64(C.gethwcap())
 	for i := uint(0); i < 64; i++ {

--- a/source/cpu/cpuid_arm64.go
+++ b/source/cpu/cpuid_arm64.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cpuidutils
+package cpu
 
 /*
 #include <sys/auxv.h>
@@ -80,7 +80,7 @@ var flagNames_arm64 = map[uint64]string{
 	CPU_ARM64_FEATURE_SVE:      "SVE",
 }
 
-func GetCpuidFlags() []string {
+func getCpuidFlags() []string {
 	r := make([]string, 0, 20)
 	hwcap := uint64(C.gethwcap())
 	for i := uint(0); i < 64; i++ {

--- a/source/cpu/cpuid_ppc64le.go
+++ b/source/cpu/cpuid_ppc64le.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cpuidutils
+package cpu
 
 /*
 #include <sys/auxv.h>
@@ -126,7 +126,7 @@ var flag2Names_ppc64le = map[uint64]string{
 	PPC_FEATURE2_HTM_NO_SUSPEND: "HTM-NO-SUSPEND",
 }
 
-func GetCpuidFlags() []string {
+func getCpuidFlags() []string {
 	r := make([]string, 0, 30)
 	hwcap := uint64(C.gethwcap())
 	hwcap2 := uint64(C.gethwcap2())

--- a/source/cpu/cpuid_s390x.go
+++ b/source/cpu/cpuid_s390x.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cpuidutils
+package cpu
 
 /*
 #include <sys/auxv.h>
@@ -71,7 +71,7 @@ var flagNames_s390x = map[uint64]string{
 	HWCAP_S390_DFLT:      "DFLT",
 }
 
-func GetCpuidFlags() []string {
+func getCpuidFlags() []string {
 	r := make([]string, 0, 20)
 	hwcap := uint64(C.gethwcap())
 	for i := uint(0); i < 64; i++ {

--- a/source/cpu/power_amd64.go
+++ b/source/cpu/power_amd64.go
@@ -23,6 +23,8 @@ import (
 	"strconv"
 	"strings"
 
+	"k8s.io/klog/v2"
+
 	"sigs.k8s.io/node-feature-discovery/pkg/cpuid"
 	"sigs.k8s.io/node-feature-discovery/source"
 )
@@ -31,6 +33,18 @@ const (
 	// CPUID EAX input values
 	LEAF_PROCESSOR_FREQUENCY_INFORMATION = 0x16
 )
+
+func discoverSST() map[string]string {
+	features := make(map[string]string)
+
+	if bf, err := discoverSSTBF(); err != nil {
+		klog.Errorf("failed to detect SST-BF: %v", err)
+	} else if bf {
+		features["bf.enabled"] = strconv.FormatBool(bf)
+	}
+
+	return features
+}
 
 func discoverSSTBF() (bool, error) {
 	// Get processor's "nominal base frequency" (in MHz) from CPUID

--- a/source/custom/custom.go
+++ b/source/custom/custom.go
@@ -58,7 +58,7 @@ type customSource struct {
 
 // Singleton source instance
 var (
-	src customSource
+	src                           = customSource{config: newDefaultConfig()}
 	_   source.LabelSource        = &src
 	_   source.ConfigurableSource = &src
 )

--- a/source/custom/rules/cpuid_rule.go
+++ b/source/custom/rules/cpuid_rule.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2020-2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,26 +17,25 @@ limitations under the License.
 package rules
 
 import (
-	"sigs.k8s.io/node-feature-discovery/source/internal/cpuidutils"
+	"fmt"
+
+	"sigs.k8s.io/node-feature-discovery/source"
+	"sigs.k8s.io/node-feature-discovery/source/cpu"
 )
 
-// CpuIDRule implements Rule
+// CpuIDRule implements Rule for the custom source
 type CpuIDRule []string
 
-var cpuIdFlags map[string]struct{}
-
 func (cpuids *CpuIDRule) Match() (bool, error) {
+	flags, ok := source.GetFeatureSource("cpu").GetFeatures().Keys[cpu.CpuidFeature]
+	if !ok {
+		return false, fmt.Errorf("cpuid information not available")
+	}
+
 	for _, f := range *cpuids {
-		if _, ok := cpuIdFlags[f]; !ok {
+		if _, ok := flags.Elements[f]; !ok {
 			return false, nil
 		}
 	}
 	return true, nil
-}
-
-func init() {
-	cpuIdFlags = make(map[string]struct{})
-	for _, f := range cpuidutils.GetCpuidFlags() {
-		cpuIdFlags[f] = struct{}{}
-	}
 }

--- a/source/custom/rules/nodename_rule.go
+++ b/source/custom/rules/nodename_rule.go
@@ -17,14 +17,13 @@ limitations under the License.
 package rules
 
 import (
-	"os"
+	"fmt"
 	"regexp"
 
 	"k8s.io/klog/v2"
-)
 
-var (
-	nodeName = os.Getenv("NODE_NAME")
+	"sigs.k8s.io/node-feature-discovery/source"
+	"sigs.k8s.io/node-feature-discovery/source/system"
 )
 
 // NodenameRule matches on nodenames configured in a ConfigMap
@@ -34,6 +33,11 @@ type NodenameRule []string
 var _ Rule = NodenameRule{}
 
 func (n NodenameRule) Match() (bool, error) {
+	nodeName, ok := source.GetFeatureSource("system").GetFeatures().Values[system.NameFeature].Elements["nodename"]
+	if !ok {
+		return false, fmt.Errorf("node name not available")
+	}
+
 	for _, nodenamePattern := range n {
 		klog.V(1).Infof("matchNodename %s", nodenamePattern)
 		match, err := regexp.MatchString(nodenamePattern, nodeName)

--- a/source/kernel/kconfig.go
+++ b/source/kernel/kconfig.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kernelutils
+package kernel
 
 import (
 	"bytes"
@@ -26,9 +26,9 @@ import (
 	"regexp"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 
-	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/node-feature-discovery/source"
 )
 
@@ -52,13 +52,13 @@ func readKconfigGzip(filename string) ([]byte, error) {
 }
 
 // ParseKconfig reads kconfig and return a map
-func ParseKconfig(configPath string) (map[string]string, error) {
+func parseKconfig(configPath string) (map[string]string, error) {
 	kconfig := map[string]string{}
 	raw := []byte(nil)
 	var err error
 	var searchPaths []string
 
-	kVer, err := GetKernelVersion()
+	kVer, err := getVersion()
 	if err != nil {
 		searchPaths = []string{
 			"/proc/config.gz",

--- a/source/kernel/kernel.go
+++ b/source/kernel/kernel.go
@@ -29,9 +29,10 @@ import (
 const Name = "kernel"
 
 const (
-	ConfigFeature  = "config"
-	SelinuxFeature = "selinux"
-	VersionFeature = "version"
+	ConfigFeature       = "config"
+	LoadedModuleFeature = "loadedmodule"
+	SelinuxFeature      = "selinux"
+	VersionFeature      = "version"
 )
 
 // Configuration file options
@@ -127,6 +128,12 @@ func (s *kernelSource) Discover() error {
 		klog.Errorf("failed to read kconfig: %s", err)
 	} else {
 		s.features.Values[ConfigFeature] = feature.NewValueFeatures(kconfig)
+	}
+
+	if kmods, err := getLoadedModules(); err != nil {
+		klog.Errorf("failed to get loaded kernel modules: %v", err)
+	} else {
+		s.features.Keys[LoadedModuleFeature] = feature.NewKeyFeatures(kmods...)
 	}
 
 	if selinux, err := SelinuxEnabled(); err != nil {

--- a/source/kernel/kernel.go
+++ b/source/kernel/kernel.go
@@ -17,16 +17,22 @@ limitations under the License.
 package kernel
 
 import (
-	"regexp"
-	"strings"
+	"strconv"
 
 	"k8s.io/klog/v2"
 
+	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils"
 	"sigs.k8s.io/node-feature-discovery/source"
-	"sigs.k8s.io/node-feature-discovery/source/internal/kernelutils"
 )
 
 const Name = "kernel"
+
+const (
+	ConfigFeature  = "config"
+	SelinuxFeature = "selinux"
+	VersionFeature = "version"
+)
 
 // Configuration file options
 type Config struct {
@@ -47,14 +53,16 @@ func newDefaultConfig() *Config {
 	}
 }
 
-// kernelSource implements the LabelSource and ConfigurableSource interfaces.
+// kernelSource implements the FeatureSource, LabelSource and ConfigurableSource interfaces.
 type kernelSource struct {
-	config *Config
+	config   *Config
+	features *feature.DomainFeatures
 }
 
 // Singleton source instance
 var (
-	src kernelSource
+	src                           = kernelSource{config: newDefaultConfig()}
+	_   source.FeatureSource      = &src
 	_   source.LabelSource        = &src
 	_   source.ConfigurableSource = &src
 )
@@ -82,69 +90,62 @@ func (s *kernelSource) Priority() int { return 0 }
 
 // GetLabels method of the LabelSource interface
 func (s *kernelSource) GetLabels() (source.FeatureLabels, error) {
-	features := source.FeatureLabels{}
+	labels := source.FeatureLabels{}
+	features := s.GetFeatures()
 
-	// Read kernel version
-	version, err := parseVersion()
-	if err != nil {
-		klog.Errorf("failed to get kernel version: %s", err)
-	} else {
-		for key := range version {
-			features["version."+key] = version[key]
-		}
-	}
-
-	// Read kconfig
-	kconfig, err := kernelutils.ParseKconfig(s.config.KconfigFile)
-	if err != nil {
-		klog.Errorf("failed to read kconfig: %s", err)
+	for k, v := range features.Values[VersionFeature].Elements {
+		labels[VersionFeature+"."+k] = v
 	}
 
 	// Check flags
 	for _, opt := range s.config.ConfigOpts {
-		if val, ok := kconfig[opt]; ok {
-			features["config."+opt] = val
+		if val, ok := features.Values[ConfigFeature].Elements[opt]; ok {
+			labels[ConfigFeature+"."+opt] = val
 		}
 	}
 
-	selinux, err := SelinuxEnabled()
-	if err != nil {
-		klog.Warning(err)
-	} else if selinux {
-		features["selinux.enabled"] = true
+	for k, v := range features.Values[SelinuxFeature].Elements {
+		labels[SelinuxFeature+"."+k] = v
 	}
 
-	return features, nil
+	return labels, nil
 }
 
-// Read and parse kernel version
-func parseVersion() (map[string]string, error) {
-	version := map[string]string{}
+// Discover method of the FeatureSource interface
+func (s *kernelSource) Discover() error {
+	s.features = feature.NewDomainFeatures()
 
-	full, err := kernelutils.GetKernelVersion()
-	if err != nil {
-		return nil, err
+	// Read kernel version
+	if version, err := parseVersion(); err != nil {
+		klog.Errorf("failed to get kernel version: %s", err)
+	} else {
+		s.features.Values[VersionFeature] = feature.NewValueFeatures(version)
 	}
 
-	// Replace forbidden symbols
-	fullRegex := regexp.MustCompile("[^-A-Za-z0-9_.]")
-	full = fullRegex.ReplaceAllString(full, "_")
-	// Label values must start and end with an alphanumeric
-	full = strings.Trim(full, "-_.")
-
-	version["full"] = full
-
-	// Regexp for parsing version components
-	re := regexp.MustCompile(`^(?P<major>\d+)(\.(?P<minor>\d+))?(\.(?P<revision>\d+))?(-.*)?$`)
-	if m := re.FindStringSubmatch(full); m != nil {
-		for i, name := range re.SubexpNames() {
-			if i != 0 && name != "" {
-				version[name] = m[i]
-			}
-		}
+	// Read kconfig
+	if kconfig, err := parseKconfig(s.config.KconfigFile); err != nil {
+		klog.Errorf("failed to read kconfig: %s", err)
+	} else {
+		s.features.Values[ConfigFeature] = feature.NewValueFeatures(kconfig)
 	}
 
-	return version, nil
+	if selinux, err := SelinuxEnabled(); err != nil {
+		klog.Warning(err)
+	} else {
+		s.features.Values[SelinuxFeature] = feature.NewValueFeatures(nil)
+		s.features.Values[SelinuxFeature].Elements["enabled"] = strconv.FormatBool(selinux)
+	}
+
+	utils.KlogDump(3, "discovered kernel features:", "  ", s.features)
+
+	return nil
+}
+
+func (s *kernelSource) GetFeatures() *feature.DomainFeatures {
+	if s.features == nil {
+		s.features = feature.NewDomainFeatures()
+	}
+	return s.features
 }
 
 func init() {

--- a/source/kernel/kernel_test.go
+++ b/source/kernel/kernel_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018-2020 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,17 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kernelutils
+package kernel
 
 import (
-	"io/ioutil"
-	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
 )
 
-func GetKernelVersion() (string, error) {
-	unameRaw, err := ioutil.ReadFile("/proc/sys/kernel/osrelease")
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(unameRaw)), nil
+func TestKernelSource(t *testing.T) {
+	assert.Equal(t, src.Name(), Name)
+
+	// Check that GetLabels works with empty features
+	src.features = feature.NewDomainFeatures()
+	l, err := src.GetLabels()
+
+	assert.Nil(t, err, err)
+	assert.Empty(t, l)
+
 }

--- a/source/kernel/modules.go
+++ b/source/kernel/modules.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kernel
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+)
+
+const kmodProcfsPath = "/proc/modules"
+
+func getLoadedModules() ([]string, error) {
+	out, err := ioutil.ReadFile(kmodProcfsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %s: %s", kmodProcfsPath, err.Error())
+	}
+
+	lines := strings.Split(string(out), "\n")
+	loadedMods := make([]string, len(lines))
+	for _, line := range lines {
+		// skip empty lines
+		if len(line) == 0 {
+			continue
+		}
+		// append loaded module
+		loadedMods = append(loadedMods, strings.Fields(line)[0])
+	}
+	return loadedMods, nil
+}

--- a/source/kernel/version.go
+++ b/source/kernel/version.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2018-2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kernel
+
+import (
+	"io/ioutil"
+	"regexp"
+	"strings"
+)
+
+// Read and parse kernel version
+func parseVersion() (map[string]string, error) {
+	version := map[string]string{}
+
+	full, err := getVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	// Replace forbidden symbols
+	fullRegex := regexp.MustCompile("[^-A-Za-z0-9_.]")
+	full = fullRegex.ReplaceAllString(full, "_")
+	// Label values must start and end with an alphanumeric
+	full = strings.Trim(full, "-_.")
+
+	version["full"] = full
+
+	// Regexp for parsing version components
+	re := regexp.MustCompile(`^(?P<major>\d+)(\.(?P<minor>\d+))?(\.(?P<revision>\d+))?(-.*)?$`)
+	if m := re.FindStringSubmatch(full); m != nil {
+		for i, name := range re.SubexpNames() {
+			if i != 0 && name != "" {
+				version[name] = m[i]
+			}
+		}
+	}
+
+	return version, nil
+}
+
+func getVersion() (string, error) {
+	unameRaw, err := ioutil.ReadFile("/proc/sys/kernel/osrelease")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(unameRaw)), nil
+}

--- a/source/local/local_test.go
+++ b/source/local/local_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package local
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
+)
+
+func TestLocalSource(t *testing.T) {
+	assert.Equal(t, src.Name(), Name)
+
+	// Check that GetLabels works with empty features
+	src.features = feature.NewDomainFeatures()
+	l, err := src.GetLabels()
+
+	assert.Nil(t, err, err)
+	assert.Empty(t, l)
+
+}

--- a/source/pci/pci_test.go
+++ b/source/pci/pci_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pci
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
+)
+
+func TestPciSource(t *testing.T) {
+	assert.Equal(t, src.Name(), Name)
+
+	// Check that GetLabels works with empty features
+	src.features = feature.NewDomainFeatures()
+	l, err := src.GetLabels()
+
+	assert.Nil(t, err, err)
+	assert.Empty(t, l)
+
+}

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -65,6 +65,7 @@ func TestConfigurableSources(t *testing.T) {
 
 func TestFeatureSources(t *testing.T) {
 	sources := source.GetAllFeatureSources()
+	assert.NotZero(t, len(sources))
 
 	for n, s := range sources {
 		msg := fmt.Sprintf("testing FeatureSource %q failed", n)

--- a/source/system/system.go
+++ b/source/system/system.go
@@ -24,23 +24,35 @@ import (
 
 	"k8s.io/klog/v2"
 
+	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils"
 	"sigs.k8s.io/node-feature-discovery/source"
 )
 
 var osReleaseFields = [...]string{
 	"ID",
 	"VERSION_ID",
+	"VERSION_ID.major",
+	"VERSION_ID.minor",
 }
 
 const Name = "system"
 
-// systemSource implements the LabelSource interface.
-type systemSource struct{}
+const (
+	OsReleaseFeature = "osrelease"
+	NameFeature      = "name"
+)
+
+// systemSource implements the FeatureSource and LabelSource interfaces.
+type systemSource struct {
+	features *feature.DomainFeatures
+}
 
 // Singleton source instance
 var (
 	src systemSource
-	_   source.LabelSource = &src
+	_   source.FeatureSource = &src
+	_   source.LabelSource   = &src
 )
 
 func (s *systemSource) Name() string { return Name }
@@ -50,29 +62,54 @@ func (s *systemSource) Priority() int { return 0 }
 
 // GetLabels method of the LabelSource interface
 func (s *systemSource) GetLabels() (source.FeatureLabels, error) {
-	features := source.FeatureLabels{}
+	labels := source.FeatureLabels{}
+	features := s.GetFeatures()
 
+	for _, key := range osReleaseFields {
+		if value, exists := features.Values[OsReleaseFeature].Elements[key]; exists {
+			feature := "os_release." + key
+			labels[feature] = value
+		}
+	}
+	return labels, nil
+}
+
+// Discover method of the FeatureSource interface
+func (s *systemSource) Discover() error {
+	s.features = feature.NewDomainFeatures()
+
+	// Get node name
+	s.features.Values[NameFeature] = feature.NewValueFeatures(nil)
+	s.features.Values[NameFeature].Elements["nodename"] = os.Getenv("NODE_NAME")
+
+	// Get os-release information
 	release, err := parseOSRelease()
 	if err != nil {
 		klog.Errorf("failed to get os-release: %s", err)
 	} else {
-		for _, key := range osReleaseFields {
-			if value, exists := release[key]; exists {
-				feature := "os_release." + key
-				features[feature] = value
+		s.features.Values[OsReleaseFeature] = feature.NewValueFeatures(release)
 
-				if key == "VERSION_ID" {
-					versionComponents := splitVersion(value)
-					for subKey, subValue := range versionComponents {
-						if subValue != "" {
-							features[feature+"."+subKey] = subValue
-						}
-					}
+		if v, ok := release["VERSION_ID"]; ok {
+			versionComponents := splitVersion(v)
+			for subKey, subValue := range versionComponents {
+				if subValue != "" {
+					s.features.Values[OsReleaseFeature].Elements["VERSION_ID."+subKey] = subValue
 				}
 			}
 		}
 	}
-	return features, nil
+
+	utils.KlogDump(3, "discovered system features:", "  ", s.features)
+
+	return nil
+}
+
+// GetFeatures method of the FeatureSource Interface
+func (s *systemSource) GetFeatures() *feature.DomainFeatures {
+	if s.features == nil {
+		s.features = feature.NewDomainFeatures()
+	}
+	return s.features
 }
 
 // Read and parse os-release file

--- a/source/system/system_test.go
+++ b/source/system/system_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
+)
+
+func TestSystemSource(t *testing.T) {
+	assert.Equal(t, src.Name(), Name)
+
+	// Check that GetLabels works with empty features
+	src.features = feature.NewDomainFeatures()
+	l, err := src.GetLabels()
+
+	assert.Nil(t, err, err)
+	assert.Empty(t, l)
+
+}

--- a/source/usb/usb_test.go
+++ b/source/usb/usb_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package usb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
+)
+
+func TestUsbSource(t *testing.T) {
+	assert.Equal(t, src.Name(), Name)
+
+	// Check that GetLabels works with empty features
+	src.features = feature.NewDomainFeatures()
+	l, err := src.GetLabels()
+
+	assert.Nil(t, err, err)
+	assert.Empty(t, l)
+
+}


### PR DESCRIPTION
Convert the `cpu`, `kernel`, `pci`, `usb`, `system`, `custom` and `local` sources to implement the `FeatureSource` interface, i.e. do feature discovery and creation of feature labels separately.

Changes the related custom rules to utilize `GetFeatures()` method of the feature sources.

Also moves different "utils" from `source/internal` to the respective sources.

This PR is split from #464, to make review easier. It demonstrates usage of the new `FeatureSource` interface with some of the sources. Other sources will be converted in future PRs.