### PR TITLE
nfd-worker: add core.featureSources config option

### DIFF
--- a/cmd/nfd-worker/main.go
+++ b/cmd/nfd-worker/main.go
@@ -80,6 +80,8 @@ func parseArgs(flags *flag.FlagSet, osArgs ...string) *worker.Args {
 		switch f.Name {
 		case "no-publish":
 			args.Overrides.NoPublish = overrides.NoPublish
+		case "feature-sources":
+			args.Overrides.FeatureSources = overrides.FeatureSources
 		case "label-sources":
 			args.Overrides.LabelSources = overrides.LabelSources
 		case "label-whitelist":
@@ -123,12 +125,16 @@ func initFlags(flagset *flag.FlagSet) (*worker.Args, *worker.ConfigOverrideArgs)
 	// Flags overlapping with config file options
 	overrides := &worker.ConfigOverrideArgs{
 		LabelWhiteList: &utils.RegexpVal{},
+		FeatureSources: &utils.StringSliceVal{},
 		LabelSources:   &utils.StringSliceVal{},
 	}
 	overrides.NoPublish = flagset.Bool("no-publish", false,
 		"Do not publish discovered features, disable connection to nfd-master.")
+	flagset.Var(overrides.FeatureSources, "feature-sources",
+		"Comma separated list of feature sources. Special value 'all' enables all sources. "+
+			"Prefix the source name with '-' to disable it.")
 	flagset.Var(overrides.LabelSources, "label-sources",
-		"Comma separated list of label sources. Special value 'all' enables all feature sources. "+
+		"Comma separated list of label sources. Special value 'all' enables all sources. "+
 			"Prefix the source name with '-' to disable it.")
 	flagset.Var(overrides.LabelWhiteList, "label-whitelist",
 		"Regular expression to filter label names to publish to the Kubernetes API server. "+

--- a/cmd/nfd-worker/main_test.go
+++ b/cmd/nfd-worker/main_test.go
@@ -38,6 +38,7 @@ func TestParseArgs(t *testing.T) {
 				So(args.Overrides.NoPublish, ShouldBeNil)
 				So(args.Overrides.LabelWhiteList, ShouldBeNil)
 				So(args.Overrides.SleepInterval, ShouldBeNil)
+				So(args.Overrides.FeatureSources, ShouldBeNil)
 				So(args.Overrides.LabelSources, ShouldBeNil)
 			})
 		})
@@ -46,6 +47,7 @@ func TestParseArgs(t *testing.T) {
 			args := parseArgs(flags,
 				"-no-publish",
 				"-label-whitelist=.*rdt.*",
+				"-feature-sources=cpu",
 				"-label-sources=fake1,fake2,fake3",
 				"-sleep-interval=30s")
 
@@ -53,6 +55,7 @@ func TestParseArgs(t *testing.T) {
 				So(args.Oneshot, ShouldBeFalse)
 				So(*args.Overrides.NoPublish, ShouldBeTrue)
 				So(*args.Overrides.SleepInterval, ShouldEqual, 30*time.Second)
+				So(*args.Overrides.FeatureSources, ShouldResemble, utils.StringSliceVal{"cpu"})
 				So(*args.Overrides.LabelSources, ShouldResemble, utils.StringSliceVal{"fake1", "fake2", "fake3"})
 				So(args.Overrides.LabelWhiteList.Regexp.String(), ShouldResemble, ".*rdt.*")
 			})

--- a/deployment/components/worker-config/nfd-worker.conf.example
+++ b/deployment/components/worker-config/nfd-worker.conf.example
@@ -2,6 +2,7 @@
 #  labelWhiteList:
 #  noPublish: false
 #  sleepInterval: 60s
+#  featureSources: [all]
 #  labelSources: [all]
 #  klog:
 #    addDirHeader: false

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -91,6 +91,7 @@ worker:
     #  labelWhiteList:
     #  noPublish: false
     #  sleepInterval: 60s
+    #  featureSources: [all]
     #  labelSources: [all]
     #  klog:
     #    addDirHeader: false

--- a/docs/advanced/worker-commandline-reference.md
+++ b/docs/advanced/worker-commandline-reference.md
@@ -136,6 +136,28 @@ Example:
 nfd-worker -server-name-override=localhost
 ```
 
+### -feature-sources
+
+The `-feature-sources` flag specifies a comma-separated list of enabled feature
+sources. A special value `all` enables all sources. Prefixing a source name
+with `-` indicates that the source will be disabled instead - this is only
+meaningful when used in conjunction with `all`. This command line flag allows
+completely disabling the feature detection so that neither standard feature
+labels are generated nor the raw feature data is available for custom rule
+processing.  Consider using the `core.featureSources` config file option,
+instead, allowing dynamic configurability.
+
+Note: This flag takes precedence over the `core.featureSources` configuration
+file option.
+
+Default: all
+
+Example:
+
+```bash
+nfd-worker -feature-sources=all,-pci
+```
+
 ### -label-sources
 
 The `-label-sources` flag specifies a comma-separated list of enabled label

--- a/docs/advanced/worker-configuration-reference.md
+++ b/docs/advanced/worker-configuration-reference.md
@@ -43,12 +43,44 @@ core:
   sleepInterval: 60s
 ```
 
+### core.featureSources
+
+`core.featureSources` specifies the list of enabled feature sources. A special
+value `all` enables all sources. Prefixing a source name with `-` indicates
+that the source will be disabled instead - this is only meaningful when used in
+conjunction with `all`. This option allows completely disabling the feature
+detection so that neither standard feature labels are generated nor the raw
+feature data is available for custom rule processing.
+
+Default: `[all]`
+
+Example:
+
+```yaml
+core:
+  # Enable all but cpu and local sources
+  featureSources:
+    - "all"
+    - "-cpu"
+    - "-local"
+```
+
+```yaml
+core:
+  # Enable only cpu and local sources
+  featureSources:
+    - "cpu"
+    - "local"
+```
+
 ### core.labelSources
 
 `core.labelSources` specifies the list of enabled label sources. A special
 value `all` enables all sources. Prefixing a source name with `-` indicates
 that the source will be disabled instead - this is only meaningful when used in
-conjunction with `all`.
+conjunction with `all`. This configuration option affects the generation of
+node labels but not the actual discovery of the underlying feature data that is
+used e.g. in custom/`NodeFeatureRule` rules.
 
 Note: Overridden by the `-label-sources` and `-sources` command line flags and
 the `core.sources` configurations option (if any of them is specified).

--- a/pkg/nfd-client/worker/nfd-worker-internal_test.go
+++ b/pkg/nfd-client/worker/nfd-worker-internal_test.go
@@ -308,7 +308,7 @@ func TestNewNfdWorker(t *testing.T) {
 			worker := w.(*nfdWorker)
 			So(worker.configure("", ""), ShouldBeNil)
 			Convey("all sources should be enabled and the whitelist regexp should be empty", func() {
-				So(len(worker.enabledSources), ShouldEqual, len(source.GetAllLabelSources())-1)
+				So(len(worker.labelSources), ShouldEqual, len(source.GetAllLabelSources())-1)
 				So(worker.config.Core.LabelWhiteList, ShouldResemble, emptyRegexp)
 			})
 		})
@@ -322,8 +322,8 @@ func TestNewNfdWorker(t *testing.T) {
 			worker := w.(*nfdWorker)
 			So(worker.configure("", ""), ShouldBeNil)
 			Convey("proper sources should be enabled", func() {
-				So(len(worker.enabledSources), ShouldEqual, 1)
-				So(worker.enabledSources[0].Name(), ShouldEqual, "fake")
+				So(len(worker.labelSources), ShouldEqual, 1)
+				So(worker.labelSources[0].Name(), ShouldEqual, "fake")
 				So(worker.config.Core.LabelWhiteList, ShouldResemble, emptyRegexp)
 			})
 		})

--- a/pkg/nfd-client/worker/nfd-worker.go
+++ b/pkg/nfd-client/worker/nfd-worker.go
@@ -94,6 +94,7 @@ type ConfigOverrideArgs struct {
 	// Deprecated
 	LabelWhiteList *utils.RegexpVal
 	SleepInterval  *time.Duration
+	FeatureSources *utils.StringSliceVal
 	LabelSources   *utils.StringSliceVal
 }
 
@@ -436,6 +437,9 @@ func (w *nfdWorker) configure(filepath string, overrides string) error {
 	}
 	if w.args.Overrides.SleepInterval != nil {
 		c.Core.SleepInterval = duration{*w.args.Overrides.SleepInterval}
+	}
+	if w.args.Overrides.FeatureSources != nil {
+		c.Core.FeatureSources = *w.args.Overrides.FeatureSources
 	}
 	if w.args.Overrides.LabelSources != nil {
 		c.Core.LabelSources = *w.args.Overrides.LabelSources

--- a/pkg/nfd-client/worker/nfd-worker.go
+++ b/pkg/nfd-client/worker/nfd-worker.go
@@ -105,7 +105,7 @@ type nfdWorker struct {
 	configFilePath string
 	config         *NFDConfig
 	stop           chan struct{} // channel for signaling stop
-	enabledSources []source.LabelSource
+	labelSources   []source.LabelSource
 }
 
 type duration struct {
@@ -186,7 +186,7 @@ func (w *nfdWorker) Run() error {
 			}
 
 			// Get the set of feature labels.
-			labels := createFeatureLabels(w.enabledSources, w.config.Core.LabelWhiteList.Regexp)
+			labels := createFeatureLabels(w.labelSources, w.config.Core.LabelWhiteList.Regexp)
 
 			// Update the node with the feature labels.
 			if w.client != nil {
@@ -293,13 +293,13 @@ func (w *nfdWorker) configureCore(c coreConfig) error {
 		}
 	}
 
-	// Determine enabled feature sources
-	enabled := make(map[string]source.LabelSource)
+	// Determine enabled label sources
+	labelSources := make(map[string]source.LabelSource)
 	for _, name := range c.LabelSources {
 		if name == "all" {
 			for n, s := range source.GetAllLabelSources() {
 				if ts, ok := s.(source.TestSource); !ok || !ts.IsTestSource() {
-					enabled[n] = s
+					labelSources[n] = s
 				}
 			}
 		} else {
@@ -311,9 +311,9 @@ func (w *nfdWorker) configureCore(c coreConfig) error {
 			}
 			if s := source.GetLabelSource(strippedName); s != nil {
 				if !disable {
-					enabled[strippedName] = s
+					labelSources[name] = s
 				} else {
-					delete(enabled, strippedName)
+					delete(labelSources, strippedName)
 				}
 			} else {
 				klog.Warningf("skipping unknown source %q specified in core.sources (or -sources)", name)
@@ -321,22 +321,22 @@ func (w *nfdWorker) configureCore(c coreConfig) error {
 		}
 	}
 
-	w.enabledSources = make([]source.LabelSource, 0, len(enabled))
-	for _, s := range enabled {
-		w.enabledSources = append(w.enabledSources, s)
+	w.labelSources = make([]source.LabelSource, 0, len(labelSources))
+	for _, s := range labelSources {
+		w.labelSources = append(w.labelSources, s)
 	}
 
-	sort.Slice(w.enabledSources, func(i, j int) bool {
-		iP, jP := w.enabledSources[i].Priority(), w.enabledSources[j].Priority()
+	sort.Slice(w.labelSources, func(i, j int) bool {
+		iP, jP := w.labelSources[i].Priority(), w.labelSources[j].Priority()
 		if iP != jP {
 			return iP < jP
 		}
-		return w.enabledSources[i].Name() < w.enabledSources[j].Name()
+		return w.labelSources[i].Name() < w.labelSources[j].Name()
 	})
 
 	if klog.V(1).Enabled() {
-		n := make([]string, len(w.enabledSources))
-		for i, s := range w.enabledSources {
+		n := make([]string, len(w.labelSources))
+		for i, s := range w.labelSources {
 			n[i] = s.Name()
 		}
 		klog.Infof("enabled label sources: %s", strings.Join(n, ", "))


### PR DESCRIPTION
- Add a configuration option for controlling the enabled "raw" feature
sources. This is useful e.g. in testing and development, plus it also
allows fully shutting down discovery of features that are not needed in
a deployment. Supplements core.labelSources which controls the
enablement of label sources.
-  add `-feature-sources` command line flag
Allows controlling (enable/disable) the "raw" feature detection.
Especially useful for development and testing.