### PR TITLE
deployment: align topologyupdater overlays

### DIFF
--- a/deployment/overlays/topologyupdater/kustomization.yaml
+++ b/deployment/overlays/topologyupdater/kustomization.yaml
@@ -4,8 +4,9 @@ kind: Kustomization
 namespace: node-feature-discovery
 
 bases:
+- ../../base/rbac
 - ../../base/rbac-topologyupdater
-- ../../base/worker-daemonset
+- ../../base/master
 - ../../base/noderesourcetopologies-crd
 - ../../base/topologyupdater-daemonset
 
@@ -13,4 +14,5 @@ resources:
 - namespace.yaml
 
 components:
+- ../../components/common
 - ../../components/topology-updater


### PR DESCRIPTION
Align "topologyupdater" overlay with "topologyupdater-job". Both should
deploy topologyupdater as a standalone application. Previously the
topologyupdater overlay did not deploy nfd-master at all (but deployed
nfd-worker instead) causing the pods to end up in crashloopbackoff as
there was no master to communicate with.