### PR TITLE
deployment: clean up base/topologyupdater-daemonset

### DIFF
--- a/deployment/base/topologyupdater-daemonset/topologyupdater-daemonset.yaml
+++ b/deployment/base/topologyupdater-daemonset/topologyupdater-daemonset.yaml
@@ -22,8 +22,4 @@ spec:
           command:
             - "nfd-topology-updater"
           args:
-            - "--kubelet-config-file=/host-var/lib/kubelet/config.yaml"
-            - "--podresources-socket=/host-var/lib/kubelet/pod-resources/kubelet.sock"
-            - "--sleep-interval=3s"
-            - "--watch-namespace=*"
-            - "--server=nfd-master:8080"
+            - "-server=nfd-master:8080"

--- a/deployment/components/topology-updater/kustomization.yaml
+++ b/deployment/components/topology-updater/kustomization.yaml
@@ -10,3 +10,7 @@ patches:
   target:
     labelSelector: app=nfd
     name: nfd-topology-updater
+- path: sleep-interval-flag.yaml
+  target:
+    labelSelector: app=nfd
+    name: nfd-topology-updater

--- a/deployment/components/topology-updater/sleep-interval-flag.yaml
+++ b/deployment/components/topology-updater/sleep-interval-flag.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "-sleep-interval=3s"

--- a/deployment/components/topology-updater/topologyupdater-mounts.yaml
+++ b/deployment/components/topology-updater/topologyupdater-mounts.yaml
@@ -10,6 +10,7 @@
   - name: kubelet-podresources-sock
     hostPath:
       path: /var/lib/kubelet/pod-resources/kubelet.sock
+
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts
   value:
@@ -19,3 +20,11 @@
     mountPath: /host-var/lib/kubelet/pod-resources/kubelet.sock
   - name: host-sys
     mountPath: /host-sys
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "-kubelet-config-file=/host-var/lib/kubelet/config.yaml"
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "-podresources-socket=/host-var/lib/kubelet/pod-resources/kubelet.sock"


### PR DESCRIPTION
The base should really have the very bare minimum. Remove all redundant
(at default-value) args and move the others to the specific
topologyupdater kustomize component. This also makes these settings
re-usable in user-specific overlays (that are not based on
topologyupdater-daemonset).