### PR TITLE
docs: fix TOCs

### DIFF
--- a/docs/advanced/architecture.md
+++ b/docs/advanced/architecture.md
@@ -6,12 +6,10 @@ published: false
 ---
 
 # Architecture
-
-{: .no_toc }
+{: .no_toc}
 
 ## Table of contents
-
-{: .no_toc .text-delta }
+{: .no_toc .text-delta}
 
 1. TOC
 {:toc}

--- a/docs/advanced/customization-guide.md
+++ b/docs/advanced/customization-guide.md
@@ -6,12 +6,10 @@ published: false
 ---
 
 # Customization guide
-
-{: .no_toc }
+{: .no_toc}
 
 ## Table of contents
-
-{: .no_toc .text-delta }
+{: .no_toc .text-delta}
 
 1. TOC
 {:toc}

--- a/docs/advanced/developer-guide.md
+++ b/docs/advanced/developer-guide.md
@@ -5,12 +5,10 @@ sort: 1
 ---
 
 # Developer guide
-
-{: .no_toc }
+{: .no_toc}
 
 ## Table of contents
-
-{: .no_toc .text-delta }
+{: .no_toc .text-delta}
 
 1. TOC
 {:toc}

--- a/docs/advanced/e2e-configuration-reference.md
+++ b/docs/advanced/e2e-configuration-reference.md
@@ -6,12 +6,10 @@ published: false
 ---
 
 # Configuration file reference of end-to-end tests
-
-{: .no_toc }
+{: .no_toc}
 
 ## Table of contents
-
-{: .no_toc .text-delta }
+{: .no_toc .text-delta}
 
 1. TOC
 {:toc}

--- a/docs/advanced/master-commandline-reference.md
+++ b/docs/advanced/master-commandline-reference.md
@@ -5,12 +5,10 @@ sort: 2
 ---
 
 # Commandline flags of nfd-master
-
-{: .no_toc }
+{: .no_toc}
 
 ## Table of contents
-
-{: .no_toc .text-delta }
+{: .no_toc .text-delta}
 
 1. TOC
 {:toc}

--- a/docs/advanced/worker-commandline-reference.md
+++ b/docs/advanced/worker-commandline-reference.md
@@ -5,12 +5,10 @@ sort: 3
 ---
 
 # Commandline flags of nfd-worker
-
-{: .no_toc }
+{: .no_toc}
 
 ## Table of contents
-
-{: .no_toc .text-delta }
+{: .no_toc .text-delta}
 
 1. TOC
 {:toc}

--- a/docs/advanced/worker-configuration-reference.md
+++ b/docs/advanced/worker-configuration-reference.md
@@ -5,12 +5,10 @@ sort: 4
 ---
 
 # Configuration file reference of nfd-worker
-
-{: .no_toc }
+{: .no_toc}
 
 ## Table of contents
-
-{: .no_toc .text-delta }
+{: .no_toc .text-delta}
 
 1. TOC
 {:toc}

--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -5,12 +5,10 @@ sort: 3
 ---
 
 # Deployment and usage
-
-{: .no_toc }
+{: .no_toc}
 
 ## Table of contents
-
-{: .no_toc .text-delta }
+{: .no_toc .text-delta}
 
 1. TOC
 {:toc}

--- a/docs/get-started/examples-and-demos.md
+++ b/docs/get-started/examples-and-demos.md
@@ -5,12 +5,10 @@ sort: 5
 ---
 
 # Examples and demos
-
-{: .no_toc }
+{: .no_toc}
 
 ## Table of contents
-
-{: .no_toc .text-delta }
+{: .no_toc .text-delta}
 
 1. TOC
 {:toc}

--- a/docs/get-started/features.md
+++ b/docs/get-started/features.md
@@ -5,12 +5,10 @@ sort: 4
 ---
 
 # Feature discovery
-
-{: .no_toc }
+{: .no_toc}
 
 ## Table of contents
-
-{: .no_toc .text-delta }
+{: .no_toc .text-delta}
 
 1. TOC
 {:toc}

--- a/docs/get-started/introduction.md
+++ b/docs/get-started/introduction.md
@@ -5,12 +5,10 @@ sort: 1
 ---
 
 # Introduction
-
-{: .no_toc }
+{: .no_toc}
 
 ## Table of contents
-
-{: .no_toc .text-delta }
+{: .no_toc .text-delta}
 
 1. TOC
 {:toc}

--- a/docs/mdl-style.rb
+++ b/docs/mdl-style.rb
@@ -1,4 +1,7 @@
 all
+# Exclude MD022 - Headers should be surrounded by blank lines. The kramdown
+# "class magic" (like {: .no_toc}) needs to be directly below the heading line.
+exclude_rule 'MD022'
 # Exclude MD041 - First line in file should be a top level header
 exclude_rule 'MD041'
 rule 'MD013', :tables => false


### PR DESCRIPTION
Make table of contents in the pages cleaner and more readable by
dropping the main heading (H1 level) from TOCs. This was the original
intention with the usage of "no_toc" kramdown magic, which was broken,
however. The kramdown class magic needs to be specified on the line
immediately following the headinds, otherwise it has no effect. We need
to disable MD022 rule of mdlint as it does not understand this magic.