### PR TITLE
deployment/helm: don't force sleep-interval in  worker cmdline flags

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/worker.yaml
+++ b/deployment/helm/node-feature-discovery/templates/worker.yaml
@@ -41,7 +41,6 @@ spec:
         command:
         - "nfd-worker"
         args:
-        - "--sleep-interval=60s"
         - "--server={{ include "node-feature-discovery.fullname" . }}-master:{{ .Values.master.service.port }}"
 ## Enable TLS authentication (1/3)
 ## The example below assumes having the root certificate named ca.crt stored in


### PR DESCRIPTION
Drop --sleep-interval from the template. We really don't want to do that
as. First, it's the default value so no use repeating that in the
template. And more importantly, the commandline flag will override
anything that will be provided in the worker config file, making it
impossible for users to specify the sleep interval (other than by
editing the template directly).