### PR TITLE
source: fix gofmt errors

### DIFF
--- a/source/cpu/cstate_stub.go
+++ b/source/cpu/cstate_stub.go
@@ -1,3 +1,4 @@
+//go:build !amd64
 // +build !amd64
 
 /*

--- a/source/cpu/power_stub.go
+++ b/source/cpu/power_stub.go
@@ -1,3 +1,4 @@
+//go:build !amd64
 // +build !amd64
 
 /*

--- a/source/cpu/pstate_stub.go
+++ b/source/cpu/pstate_stub.go
@@ -1,3 +1,4 @@
+//go:build !amd64
 // +build !amd64
 
 /*

--- a/source/cpu/rdt_amd64.go
+++ b/source/cpu/rdt_amd64.go
@@ -1,3 +1,4 @@
+//go:build amd64
 // +build amd64
 
 /*

--- a/source/cpu/rdt_stub.go
+++ b/source/cpu/rdt_stub.go
@@ -1,3 +1,4 @@
+//go:build !amd64
 // +build !amd64
 
 /*


### PR DESCRIPTION
The tool got pickier with golang v1.17.