### PR TITLE
Makefile: let gofmt-verify write changes back to files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ gofmt:
 	@$(GO_FMT) -w -l $$(find . -name '*.go')
 
 gofmt-verify:
-	@out=`$(GO_FMT) -l -d $$(find . -name '*.go')`; \
+	@out=`$(GO_FMT) -w -l -d $$(find . -name '*.go')`; \
 	if [ -n "$$out" ]; then \
 	    echo "$$out"; \
 	    exit 1; \


### PR DESCRIPTION
Let gofmt write the result (suggested changes) back to the source files,
instead of just printing out the diff. Reduces manual work.