### PR TITLE
backports/v0.9: docs: mention minimum required kubectl version

### DIFF
--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -18,8 +18,8 @@ sort: 3
 ## Requirements
 
 1. Linux (x86_64/Arm64/Arm)
-1. [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl)
-   (properly set up and configured to work with your Kubernetes cluster)
+1. [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) v1.21 or
+   later (properly set up and configured to work with your Kubernetes cluster)
 
 ## Image variants
 


### PR DESCRIPTION
Kubectl prior to v1.21 contains too old version of kustomize for our
(kustomize-based) deployment to work.

(cherry picked from commit 9e9ff951b21bfd3732085afe278094ead09a4232)