### PR TITLE
release-0.9: scripts: disable gofmt check in ci

### DIFF
--- a/scripts/test-infra/verify.sh
+++ b/scripts/test-infra/verify.sh
@@ -7,7 +7,6 @@ export PATH=$PATH:$(go env GOPATH)/bin
 curl -sfL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash -s -- --version v3.5.2
 
 # Run verify steps
-make gofmt-verify
 make ci-lint
 make helm-lint
 


### PR DESCRIPTION
The gofmt check started to fail after our CI moved to golang v1.17 based
images.