### PR TITLE
deployment: Implicitly generate the worker ConfigMap name

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/nfd-worker-conf.yaml
+++ b/deployment/helm/node-feature-discovery/templates/nfd-worker-conf.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.worker.configmapName }}
+  name: {{ include "node-feature-discovery.fullname" . }}-worker-conf
   labels:
   {{- include "node-feature-discovery.labels" . | nindent 4 }}
 data:

--- a/deployment/helm/node-feature-discovery/templates/worker.yaml
+++ b/deployment/helm/node-feature-discovery/templates/worker.yaml
@@ -109,7 +109,7 @@ spec:
             path: "/etc/kubernetes/node-feature-discovery/features.d/"
         - name: nfd-worker-conf
           configMap:
-            name: {{ .Values.worker.configmapName }}
+            name: {{ include "node-feature-discovery.fullname" . }}-worker-conf
             items:
               - key: nfd-worker.conf
                 path: nfd-worker.conf

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -83,7 +83,6 @@ master:
                 values: [""]
 
 worker:
-  configmapName: nfd-worker-conf
   config: ### <NFD-WORKER-CONF-START-DO-NOT-REMOVE>
     #core:
     #  labelWhiteList:

--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -314,7 +314,6 @@ We have introduced the following Chart parameters.
 | Name | Type | Default | description |
 | ---- | ---- | ------- | ----------- |
 | `worker.*` | dict |  | NFD worker daemonset configuration |
-| `worker.configmapName` | string | `nfd-worker-conf` | NFD worker pod ConfigMap name |
 | `worker.config` | dict |  | NFD worker [configuration](../advanced/worker-configuration-reference.md) |
 | `worker.podSecurityContext` | dict | {} | SecurityContext holds pod-level security attributes and common container settings |
 | `worker.securityContext` | dict | {} | Container [security settings](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
@@ -464,11 +463,15 @@ preferred method is to use a ConfigMap which provides easy deployment and
 re-configurability.
 
 The provided nfd-worker deployment templates create an empty configmap and
-mount it inside the nfd-worker containers. Configuration can be edited with:
+mount it inside the nfd-worker containers. In kustomize deployments,
+configuration can be edited with:
 
 ```bash
 kubectl -n ${NFD_NS} edit configmap nfd-worker-conf
 ```
+
+In Helm deployments, [Worker pod parameter](#worker-pod-parameters)
+`worker.config` can be used to edit the respective configuration.
 
 See
 [nfd-worker configuration file reference](../advanced/worker-configuration-reference.md)


### PR DESCRIPTION
fixes https://github.com/kubernetes-sigs/node-feature-discovery/pull/627#issuecomment-948316754

1. `"node-feature-discovery.fullname"` is used to prefix the worker ConfigMap name
2. `worker.configmapName` Helm parameter is dropped
3. This change is documented.

**Comments**:

Since the template filename is still `nfd-worker-conf.yaml`, it makes sense to have the name suffix `-worker-conf`.

Generally, we should consider renaming the template file, to e.g. `configmap.yaml`, and drop that resource name suffix. This would make that ConfigMap resource the single source of information for any (future) nfd pod configuration (worker, master, etc.). Should I proceed with this here?