### PR TITLE
pkg/api/feature: small improvements

### DIFF
--- a/pkg/api/feature/feature.go
+++ b/pkg/api/feature/feature.go
@@ -25,12 +25,28 @@ func NewDomainFeatures() *DomainFeatures {
 		Instances: make(map[string]*InstanceFeatureSet)}
 }
 
-func NewKeyFeatures() *KeyFeatureSet { return &KeyFeatureSet{Elements: make(map[string]Nil)} }
+func NewKeyFeatures(keys ...string) *KeyFeatureSet {
+	e := make(map[string]Nil, len(keys))
+	for _, k := range keys {
+		e[k] = Nil{}
+	}
+	return &KeyFeatureSet{Elements: e}
+}
 
-func NewValueFeatures() *ValueFeatureSet { return &ValueFeatureSet{Elements: make(map[string]string)} }
+func NewValueFeatures(values map[string]string) *ValueFeatureSet {
+	if values == nil {
+		values = make(map[string]string)
+	}
+	return &ValueFeatureSet{Elements: values}
+}
 
-func NewInstanceFeatures() *InstanceFeatureSet { return &InstanceFeatureSet{} }
+func NewInstanceFeatures(instances []InstanceFeature) *InstanceFeatureSet {
+	return &InstanceFeatureSet{Elements: instances}
+}
 
-func NewInstanceFeature() *InstanceFeature {
-	return &InstanceFeature{Attributes: make(map[string]string)}
+func NewInstanceFeature(attrs map[string]string) *InstanceFeature {
+	if attrs == nil {
+		attrs = make(map[string]string)
+	}
+	return &InstanceFeature{Attributes: attrs}
 }

--- a/pkg/api/feature/feature.go
+++ b/pkg/api/feature/feature.go
@@ -20,9 +20,9 @@ package feature
 // features to empty values
 func NewDomainFeatures() *DomainFeatures {
 	return &DomainFeatures{
-		Keys:      make(map[string]KeyFeatureSet),
-		Values:    make(map[string]ValueFeatureSet),
-		Instances: make(map[string]InstanceFeatureSet)}
+		Keys:      make(map[string]*KeyFeatureSet),
+		Values:    make(map[string]*ValueFeatureSet),
+		Instances: make(map[string]*InstanceFeatureSet)}
 }
 
 func NewKeyFeatures() *KeyFeatureSet { return &KeyFeatureSet{Elements: make(map[string]Nil)} }

--- a/pkg/api/feature/types.go
+++ b/pkg/api/feature/types.go
@@ -22,9 +22,9 @@ type Features map[string]*DomainFeatures
 
 // DomainFeatures is the collection of all discovered features of one domain.
 type DomainFeatures struct {
-	Keys      map[string]KeyFeatureSet      `protobuf:"bytes,1,rep,name=keys"`
-	Values    map[string]ValueFeatureSet    `protobuf:"bytes,2,rep,name=values"`
-	Instances map[string]InstanceFeatureSet `protobuf:"bytes,3,rep,name=instances"`
+	Keys      map[string]*KeyFeatureSet      `protobuf:"bytes,1,rep,name=keys"`
+	Values    map[string]*ValueFeatureSet    `protobuf:"bytes,2,rep,name=values"`
+	Instances map[string]*InstanceFeatureSet `protobuf:"bytes,3,rep,name=instances"`
 }
 
 // KeyFeatureSet is a set of simple features only containing names without values.


### PR DESCRIPTION
Slight improvements on the internal pkg/api/feature api.
- use pointers of structs:
  Make it easier to mutate the feature sets.
- generator functions with initial values:
  Flavor the generator helper functions with arguments for specifying the
set of features to put into the generated objects.