### PR TITLE
test/e2e: make e2e tests run on single-node cluster

### DIFF
--- a/test/e2e/node_feature_discovery.go
+++ b/test/e2e/node_feature_discovery.go
@@ -655,7 +655,7 @@ var _ = SIGDescribe("Node Feature Discovery", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(nodeList.Items)).ToNot(BeZero())
 
-				targetNodeName := ""
+				targetNodeName := nodeList.Items[0].Name
 				for _, node := range nodeList.Items {
 					if _, ok := node.Labels["node-role.kubernetes.io/master"]; !ok {
 						targetNodeName = node.Name


### PR DESCRIPTION
Lift the restriction to run custom rule tests on non-master node. Try to
find one but do not fail if that fails. Makes the end-to-end tests
runnable on single-node clusters such a simple minikube deployments.