### PR TITLE
test/e2e: drop /boot mount

### DIFF
--- a/test/e2e/node_feature_discovery.go
+++ b/test/e2e/node_feature_discovery.go
@@ -324,11 +324,6 @@ func nfdWorkerPodSpec(image string, extraArgs []string) v1.PodSpec {
 				},
 				VolumeMounts: []v1.VolumeMount{
 					{
-						Name:      "host-boot",
-						MountPath: "/host-boot",
-						ReadOnly:  true,
-					},
-					{
 						Name:      "host-os-release",
 						MountPath: "/host-etc/os-release",
 						ReadOnly:  true,
@@ -354,15 +349,6 @@ func nfdWorkerPodSpec(image string, extraArgs []string) v1.PodSpec {
 		ServiceAccountName: "nfd-master-e2e",
 		DNSPolicy:          v1.DNSClusterFirstWithHostNet,
 		Volumes: []v1.Volume{
-			{
-				Name: "host-boot",
-				VolumeSource: v1.VolumeSource{
-					HostPath: &v1.HostPathVolumeSource{
-						Path: "/boot",
-						Type: newHostPathType(v1.HostPathDirectory),
-					},
-				},
-			},
 			{
 				Name: "host-os-release",
 				VolumeSource: v1.VolumeSource{


### PR DESCRIPTION
This is not currently needed by end-to-end tests. Dropping it enables
testing in restricted environments that don't have /boot directory.