### PR TITLE
pkg/apis/nfd: drop excess field from the CRD

### DIFF
--- a/deployment/base/nfd-crds/nodefeaturerule-crd.yaml
+++ b/deployment/base/nfd-crds/nodefeaturerule-crd.yaml
@@ -48,12 +48,6 @@ spec:
                         type: string
                       description: Labels to create if the rule matches.
                       type: object
-                    labelsTemplate:
-                      description: LabelsTemplate specifies a template to expand for
-                        dynamically generating multiple labels. Data (after template
-                        expansion) must be keys with an optional value (<key>[=<value>])
-                        separated by newlines.
-                      type: string
                     matchAny:
                       description: MatchAny specifies a list of matchers one of which
                         must match.

--- a/deployment/helm/node-feature-discovery/manifests/nodefeaturerule-crd.yaml
+++ b/deployment/helm/node-feature-discovery/manifests/nodefeaturerule-crd.yaml
@@ -48,12 +48,6 @@ spec:
                         type: string
                       description: Labels to create if the rule matches.
                       type: object
-                    labelsTemplate:
-                      description: LabelsTemplate specifies a template to expand for
-                        dynamically generating multiple labels. Data (after template
-                        expansion) must be keys with an optional value (<key>[=<value>])
-                        separated by newlines.
-                      type: string
                     matchAny:
                       description: MatchAny specifies a list of matchers one of which
                         must match.

--- a/pkg/apis/nfd/v1alpha1/types.go
+++ b/pkg/apis/nfd/v1alpha1/types.go
@@ -57,12 +57,6 @@ type Rule struct {
 	// +optional
 	Labels map[string]string `json:"labels"`
 
-	// LabelsTemplate specifies a template to expand for dynamically generating
-	// multiple labels. Data (after template expansion) must be keys with an
-	// optional value (<key>[=<value>]) separated by newlines.
-	// +optional
-	LabelsTemplate string `json:"labelsTemplate"`
-
 	// MatchFeatures specifies a set of matcher terms all of which must match.
 	// +optional
 	MatchFeatures FeatureMatcher `json:"matchFeatures"`


### PR DESCRIPTION
Drop stale leftover "LabelsTemplate" field from the rule spec.