### PR TITLE
Wildcard for matching against all keys in label rules

### DIFF
--- a/deployment/base/nfd-crds/cr-sample.yaml
+++ b/deployment/base/nfd-crds/cr-sample.yaml
@@ -88,6 +88,14 @@ spec:
               vendor: {op: In, value: ["8086"]}
               class: {op: In, value: ["02"]}
 
+    - name: "my AVX feature"
+      labels:
+        "my-avx-feature": "true"
+      matchFeatures:
+        - feature: cpu.cpuid
+          matchExpressions:
+            '*': {op: InRegexp, value: ["^AVX512"]}
+
     # The following features demonstreate label templating capabilities
     - name: "my system template feature"
       labelsTemplate: |
@@ -137,3 +145,12 @@ spec:
           matchExpressions:
             my.kernel.feature: {op: IsTrue}
             my.dummy.var: {op: Gt, value: ["0"]}
+
+    - name: "my kernel wildcard template feature"
+      labelsTemplate: |
+        {{ range .kernel.config }}my-kconfig.{{ .Name }}={{ .Value }}
+        {{ end }}
+      matchFeatures:
+        - feature: kernel.config
+          matchExpressions:
+            '*': {op: In, value: ["SWAP", "X86", "AARCH64"]}

--- a/deployment/components/worker-config/nfd-worker.conf.example
+++ b/deployment/components/worker-config/nfd-worker.conf.example
@@ -204,6 +204,14 @@
 #                vendor: {op: In, value: ["8086"]}
 #                class: {op: In, value: ["02"]}
 #
+#    - name: "my AVX feature"
+#      labels:
+#        "my-avx-feature": "true"
+#      matchFeatures:
+#        - feature: cpu.cpuid
+#          matchExpressions:
+#            '*': {op: InRegexp, value: ["^AVX512"]}
+#
 #    # The following features demonstreate label templating capabilities
 #    - name: "my-template-test"
 #      labelsTemplate: |
@@ -253,3 +261,12 @@
 #          matchExpressions:
 #            my.kernel.feature: {op: IsTrue}
 #            my.dummy.var: {op: Gt, value: ["0"]}
+#
+#    - name: "my kernel wildcard template feature"
+#      labelsTemplate: |
+#        {{ range .kernel.config }}my-kconfig.{{ .Name }}={{ .Value }}
+#        {{ end }}
+#      matchFeatures:
+#        - feature: kernel.config
+#          matchExpressions:
+#            '*': {op: In, value: ["SWAP", "X86", "AARCH64"]}

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -293,6 +293,14 @@ worker:
     #                vendor: {op: In, value: ["8086"]}
     #                class: {op: In, value: ["02"]}
     #
+    #    - name: "my AVX feature"
+    #      labels:
+    #        "my-avx-feature": "true"
+    #      matchFeatures:
+    #        - feature: cpu.cpuid
+    #          matchExpressions:
+    #            '*': {op: InRegexp, value: ["^AVX512"]}
+    #
     #    # The following features demonstreate label templating capabilities
     #    - name: "my-template-test"
     #      labelsTemplate: |
@@ -342,6 +350,15 @@ worker:
     #          matchExpressions:
     #            my.kernel.feature: {op: IsTrue}
     #            my.dummy.var: {op: Gt, value: ["0"]}
+    #
+    #    - name: "my kernel wildcard template feature"
+    #      labelsTemplate: |
+    #        {{ range .kernel.config }}my-kconfig.{{ .Name }}={{ .Value }}
+    #        {{ end }}
+    #      matchFeatures:
+    #        - feature: kernel.config
+    #          matchExpressions:
+    #            '*': {op: In, value: ["SWAP", "X86", "AARCH64"]}
 ### <NFD-WORKER-CONF-END-DO-NOT-REMOVE>
 
   podSecurityContext: {}

--- a/pkg/apis/nfd/v1alpha1/rule_test.go
+++ b/pkg/apis/nfd/v1alpha1/rule_test.go
@@ -214,6 +214,7 @@ func TestTemplating(t *testing.T) {
 						"key-1": "val-1",
 						"keu-2": "val-2",
 						"key-3": "val-3",
+						"key-4": "val-4",
 					},
 				},
 			},
@@ -365,4 +366,29 @@ var-2=
 	_, err = r2.Execute(f)
 	assert.Error(t, err)
 
+	//
+	// Test wildcard
+	//
+	r3 := Rule{
+		LabelsTemplate: "{{range .domain_1.vf_1}}{{.Name}}={{.Value}}\n{{end}}",
+		MatchFeatures: FeatureMatcher{
+			FeatureMatcherTerm{
+				Feature: "domain_1.vf_1",
+				MatchExpressions: MatchExpressionSet{Expressions: Expressions{
+					"*":     MustCreateMatchExpression(MatchIn, "key-1", "key-4"),
+					"key-5": MustCreateMatchExpression(MatchDoesNotExist),
+				},
+				},
+			},
+		},
+	}
+	expectedLabels = map[string]string{
+		"key-1": "val-1",
+		"key-4": "val-4",
+		"key-5": "",
+	}
+
+	m, err = r3.Execute(f)
+	assert.Nilf(t, err, "unexpected error: %v", err)
+	assert.Equal(t, expectedLabels, m.Labels, "instances should have matched")
 }

--- a/pkg/apis/nfd/v1alpha1/types.go
+++ b/pkg/apis/nfd/v1alpha1/types.go
@@ -199,3 +199,7 @@ const (
 	// output of preceding rules.
 	RuleBackrefFeature = "matched"
 )
+
+// MatchAllNames is a special key in MatchExpressionSet to use field names
+// (keys from the input) instead of values when matching.
+const MatchAllNames = "*"


### PR DESCRIPTION
Extend the feature rule format with a special wildcard that can be used
in matchExpressions. By using '*' as the field name in an expressoin
makes is possible to run the expression agains all feature names,
instead of the value of one feature.

This can be useful in template rules for creating per-feature labels,
based on feature names (instead of values) and in "normal"
(non-template) rules for checking if (at least) one of certain feature
names are present.

An example of creating an "avx512" label if any AVX512* CPUID feature is
present:

```
  - name: "avx512-any-feature"
    labels: {avx512: "true"}
    matchFeatures:
      - feature: cpu.cpuid:
        matchExpressions:
          "*": {op: InRegexp, value: ["^AVX512"]}
```

An example of a template rule creating a dynamic set of labels  based on
the existence of kconfig options.

```
  - name: "kconfig-template-features"
    labelsTemplate: |
      {{range .kernel.config}}kconfig-{{.Name}}={{.Value}}
      {{end}}
    matchFeatures:
      - feature: kernel.config
        matchExpressions:
          "*": {op: In, value: [SWAP, X86, ARM]}
```

Depends on #550 