### PR TITLE
Revert "test/e2e: drop /boot mount"

### DIFF
--- a/test/e2e/node_feature_discovery.go
+++ b/test/e2e/node_feature_discovery.go
@@ -324,6 +324,11 @@ func nfdWorkerPodSpec(image string, extraArgs []string) v1.PodSpec {
 				},
 				VolumeMounts: []v1.VolumeMount{
 					{
+						Name:      "host-boot",
+						MountPath: "/host-boot",
+						ReadOnly:  true,
+					},
+					{
 						Name:      "host-os-release",
 						MountPath: "/host-etc/os-release",
 						ReadOnly:  true,
@@ -349,6 +354,15 @@ func nfdWorkerPodSpec(image string, extraArgs []string) v1.PodSpec {
 		ServiceAccountName: "nfd-master-e2e",
 		DNSPolicy:          v1.DNSClusterFirstWithHostNet,
 		Volumes: []v1.Volume{
+			{
+				Name: "host-boot",
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{
+						Path: "/boot",
+						Type: newHostPathType(v1.HostPathDirectory),
+					},
+				},
+			},
 			{
 				Name: "host-os-release",
 				VolumeSource: v1.VolumeSource{


### PR DESCRIPTION
This reverts commit 261ab113bffa44c2f3eea60c5533a70b156d3873.

This broke our e2e tests. We need to make this configurable.