### PR TITLE
source/kernel: don't advertise selinux.enabled=false

### DIFF
--- a/source/kernel/kernel.go
+++ b/source/kernel/kernel.go
@@ -105,8 +105,8 @@ func (s *kernelSource) GetLabels() (source.FeatureLabels, error) {
 		}
 	}
 
-	for k, v := range features.Values[SelinuxFeature].Elements {
-		labels[SelinuxFeature+"."+k] = v
+	if enabled, ok := features.Values[SelinuxFeature].Elements["enabled"]; ok && enabled == "true" {
+		labels["selinux.enabled"] = "true"
 	}
 
 	return labels, nil


### PR DESCRIPTION
Commit 094501916155c183775e4e941d55a4d9ca5f38a0 changed the behavior so
that NFD started to advertise also "false" status of selinux.enabled
label. This patch reverts this behavior (i.e. we only have
selinux.enabled=true). The rationale behind is avoiding any excess
labels - selinux.enabled=false label would be pointless noise in most
deployments.