### PR TITLE
pkg/apis/nfd: stricter format checking for template labels

### DIFF
--- a/pkg/apis/nfd/v1alpha1/rule.go
+++ b/pkg/apis/nfd/v1alpha1/rule.go
@@ -85,14 +85,14 @@ func (r *Rule) executeLabelsTemplate(in matchedFeatures, out map[string]string) 
 	if r.labelsTemplate == nil {
 		t, err := newTemplateHelper(r.LabelsTemplate)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to parse LabelsTemplate: %w", err)
 		}
 		r.labelsTemplate = t
 	}
 
 	labels, err := r.labelsTemplate.expandMap(in)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to expand LabelsTemplate: %w", err)
 	}
 	for k, v := range labels {
 		out[k] = v
@@ -212,7 +212,7 @@ func (h *templateHelper) expandMap(data interface{}) (map[string]string, error) 
 		if trimmed := strings.TrimSpace(item); trimmed != "" {
 			split := strings.SplitN(trimmed, "=", 2)
 			if len(split) == 1 {
-				out[split[0]] = ""
+				return nil, fmt.Errorf("missing value in expanded template line %q, (format must be '<key>=<value>')", trimmed)
 			} else {
 				out[split[0]] = split[1]
 			}


### PR DESCRIPTION
Require that the expanded LabelsTemplate has values. That is, the
(expanded) template must consist of key=value pairs separated by
newlines. No default value will be assigned and we now return an error
if a (non-empty) line not conforming with the key=value format is
encountered.

Commit c8d73666d described that the value defaults to "true" if not
specified. That was not the case and we defaulted to an empty string,
instead.

An example:

```
  - name: "my rule"
    labelsTemplate: |
      my.label.1=foo
      my.label.2=
```

Would create these labels:

```
  "my.label.1": "foo"
  "my.label.2": ""
```

Further, the following:

```
  - name: "my failing rule"
    labelsTemplate: |
      my.label.3
```

will cause an error in the rule processing.
