### PR TITLE
source/iommu: implement FeatureSource

### DIFF
--- a/source/iommu/iommu_test.go
+++ b/source/iommu/iommu_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package iommu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
+)
+
+func TestIommuSource(t *testing.T) {
+	assert.Equal(t, src.Name(), Name)
+
+	// Check that GetLabels works with empty features
+	src.features = feature.NewDomainFeatures()
+	l, err := src.GetLabels()
+
+	assert.Nil(t, err, err)
+	assert.Empty(t, l)
+
+}


### PR DESCRIPTION
Separate feature discovery and creation of feature labels. Makes the
iommu.enabled feature available for custom rules. No other iommu
attributes are detected.

Example custom rule utilizing the iommu feature:

```
  - name: "my iommu rule"
    labels:
      my-iommu-feature: "true"
    matchFeatures:
      - feature: iommu.iommu
        matchExpressions:
          "enabled": {op: IsTrue}
```

Also, add minimalist unit test.