### PR TITLE
nfd-worker: disable sources more easily

### DIFF
--- a/cmd/nfd-worker/main.go
+++ b/cmd/nfd-worker/main.go
@@ -128,7 +128,8 @@ func initFlags(flagset *flag.FlagSet) (*worker.Args, *worker.ConfigOverrideArgs)
 	overrides.NoPublish = flagset.Bool("no-publish", false,
 		"Do not publish discovered features, disable connection to nfd-master.")
 	flagset.Var(overrides.LabelSources, "label-sources",
-		"Comma separated list of label sources. Special value 'all' enables all feature sources.")
+		"Comma separated list of label sources. Special value 'all' enables all feature sources. "+
+			"Prefix the source name with '-' to disable it.")
 	flagset.Var(overrides.LabelWhiteList, "label-whitelist",
 		"Regular expression to filter label names to publish to the Kubernetes API server. "+
 			"NB: the label namespace is omitted i.e. the filter is only applied to the name part after '/'. "+
@@ -138,6 +139,7 @@ func initFlags(flagset *flag.FlagSet) (*worker.Args, *worker.ConfigOverrideArgs)
 			"DEPRECATED: This parameter should be set via the config file")
 	flagset.Var(overrides.LabelSources, "sources",
 		"Comma separated list of label sources. Special value 'all' enables all feature sources. "+
+			"Prefix the source name with '-' to disable it. "+
 			"DEPRECATED: use -label-sources instead")
 
 	return args, overrides

--- a/docs/advanced/worker-commandline-reference.md
+++ b/docs/advanced/worker-commandline-reference.md
@@ -139,7 +139,9 @@ nfd-worker -server-name-override=localhost
 ### -label-sources
 
 The `-label-sources` flag specifies a comma-separated list of enabled label
-sources. A special value `all` enables all sources. Consider using the
+sources. A special value `all` enables all sources. Prefixing a source name
+with `-` indicates that the source will be disabled instead - this is only
+meaningful when used in conjunction with `all`. Consider using the
 `core.labelSources` config file option, instead, allowing dynamic
 configurability.
 

--- a/docs/advanced/worker-configuration-reference.md
+++ b/docs/advanced/worker-configuration-reference.md
@@ -48,7 +48,8 @@ core:
 `core.labelSources` specifies the list of enabled label sources. A special
 value `all` enables all sources.
 
-Note: Overridden by the `-label-sources` command line flag (if specified).
+Note: Overridden by the `-label-sources` and `-sources` command line flags and
+the `core.sources` configurations option (if any of them is specified).
 
 Default: `[all]`
 
@@ -56,7 +57,7 @@ Example:
 
 ```yaml
 core:
-  sources:
+  labelSources:
     - system
     - custom
 ```

--- a/docs/advanced/worker-configuration-reference.md
+++ b/docs/advanced/worker-configuration-reference.md
@@ -46,7 +46,9 @@ core:
 ### core.labelSources
 
 `core.labelSources` specifies the list of enabled label sources. A special
-value `all` enables all sources.
+value `all` enables all sources. Prefixing a source name with `-` indicates
+that the source will be disabled instead - this is only meaningful when used in
+conjunction with `all`.
 
 Note: Overridden by the `-label-sources` and `-sources` command line flags and
 the `core.sources` configurations option (if any of them is specified).
@@ -57,9 +59,19 @@ Example:
 
 ```yaml
 core:
+  # Enable all but cpu and system sources
   labelSources:
-    - system
-    - custom
+    - "all"
+    - "-cpu"
+    - "-system"
+```
+
+```yaml
+core:
+  # Enable only cpu and system sources
+  labelSources:
+    - "cpu"
+    - "system"
 ```
 
 ### core.sources

--- a/pkg/nfd-client/worker/nfd-worker.go
+++ b/pkg/nfd-client/worker/nfd-worker.go
@@ -303,8 +303,18 @@ func (w *nfdWorker) configureCore(c coreConfig) error {
 				}
 			}
 		} else {
-			if s := source.GetLabelSource(name); s != nil {
-				enabled[name] = s
+			disable := false
+			strippedName := name
+			if strings.HasPrefix(name, "-") {
+				strippedName = name[1:]
+				disable = true
+			}
+			if s := source.GetLabelSource(strippedName); s != nil {
+				if !disable {
+					enabled[strippedName] = s
+				} else {
+					delete(enabled, strippedName)
+				}
 			} else {
 				klog.Warningf("skipping unknown source %q specified in core.sources (or -sources)", name)
 			}


### PR DESCRIPTION
Make it easier to disable single sources by prefixing the source name
with a dash ('-') in the core.sources config option (or -sources cmdline
flag).