### PR TITLE
Use single-dash format of cmdline flags

### DIFF
--- a/cmd/nfd-topology-updater/main_test.go
+++ b/cmd/nfd-topology-updater/main_test.go
@@ -28,8 +28,8 @@ func TestArgsParse(t *testing.T) {
 	Convey("When parsing command line arguments", t, func() {
 		flags := flag.NewFlagSet(ProgramName, flag.ExitOnError)
 
-		Convey("When --no-publish and --oneshot flags are passed", func() {
-			args, finderArgs := parseArgs(flags, "--oneshot", "--no-publish")
+		Convey("When -no-publish and -oneshot flags are passed", func() {
+			args, finderArgs := parseArgs(flags, "-oneshot", "-no-publish")
 
 			Convey("noPublish is set and args.sources is set to the default value", func() {
 				So(args.NoPublish, ShouldBeTrue)
@@ -40,10 +40,10 @@ func TestArgsParse(t *testing.T) {
 			})
 		})
 
-		Convey("When valid args are specified for --kubelet-config-file and --sleep-interval,", func() {
+		Convey("When valid args are specified for -kubelet-config-file and -sleep-interval,", func() {
 			args, finderArgs := parseArgs(flags,
-				"--kubelet-config-file=/path/testconfig.yaml",
-				"--sleep-interval=30s")
+				"-kubelet-config-file=/path/testconfig.yaml",
+				"-sleep-interval=30s")
 
 			Convey("args.sources is set to appropriate values", func() {
 				So(args.NoPublish, ShouldBeFalse)
@@ -54,10 +54,10 @@ func TestArgsParse(t *testing.T) {
 			})
 		})
 
-		Convey("When valid args are specified for --podresources-socket flag and --sleep-interval is specified", func() {
+		Convey("When valid args are specified for -podresources-socket flag and -sleep-interval is specified", func() {
 			args, finderArgs := parseArgs(flags,
-				"--podresources-socket=/path/testkubelet.sock",
-				"--sleep-interval=30s")
+				"-podresources-socket=/path/testkubelet.sock",
+				"-sleep-interval=30s")
 
 			Convey("args.sources is set to appropriate values", func() {
 				So(args.NoPublish, ShouldBeFalse)
@@ -67,9 +67,9 @@ func TestArgsParse(t *testing.T) {
 				So(finderArgs.PodResourceSocketPath, ShouldEqual, "/path/testkubelet.sock")
 			})
 		})
-		Convey("When valid args are specified for--sysfs and --sleep-inteval is specified", func() {
+		Convey("When valid -sleep-inteval is specified", func() {
 			args, finderArgs := parseArgs(flags,
-				"--sleep-interval=30s")
+				"-sleep-interval=30s")
 
 			Convey("args.sources is set to appropriate values", func() {
 				So(args.NoPublish, ShouldBeFalse)
@@ -82,15 +82,15 @@ func TestArgsParse(t *testing.T) {
 
 		Convey("When All valid args are specified", func() {
 			args, finderArgs := parseArgs(flags,
-				"--no-publish",
-				"--sleep-interval=30s",
-				"--kubelet-config-file=/path/testconfig.yaml",
-				"--podresources-socket=/path/testkubelet.sock",
-				"--ca-file=ca",
-				"--cert-file=crt",
-				"--key-file=key")
+				"-no-publish",
+				"-sleep-interval=30s",
+				"-kubelet-config-file=/path/testconfig.yaml",
+				"-podresources-socket=/path/testkubelet.sock",
+				"-ca-file=ca",
+				"-cert-file=crt",
+				"-key-file=key")
 
-			Convey("--no-publish is set and args.sources is set to appropriate values", func() {
+			Convey("-no-publish is set and args.sources is set to appropriate values", func() {
 				So(args.NoPublish, ShouldBeTrue)
 				So(args.CaFile, ShouldEqual, "ca")
 				So(args.CertFile, ShouldEqual, "crt")

--- a/cmd/nfd-worker/main.go
+++ b/cmd/nfd-worker/main.go
@@ -81,13 +81,13 @@ func parseArgs(flags *flag.FlagSet, osArgs ...string) *worker.Args {
 		case "no-publish":
 			args.Overrides.NoPublish = overrides.NoPublish
 		case "label-whitelist":
-			klog.Warningf("--label-whitelist is deprecated, use 'core.labelWhiteList' option in the config file, instead")
+			klog.Warningf("-label-whitelist is deprecated, use 'core.labelWhiteList' option in the config file, instead")
 			args.Overrides.LabelWhiteList = overrides.LabelWhiteList
 		case "sleep-interval":
-			klog.Warningf("--sleep-interval is deprecated, use 'core.sleepInterval' option in the config file, instead")
+			klog.Warningf("-sleep-interval is deprecated, use 'core.sleepInterval' option in the config file, instead")
 			args.Overrides.SleepInterval = overrides.SleepInterval
 		case "sources":
-			klog.Warningf("--sources is deprecated, use 'core.sources' option in the config file, instead")
+			klog.Warningf("-sources is deprecated, use 'core.sources' option in the config file, instead")
 			args.Overrides.Sources = overrides.Sources
 		}
 	})

--- a/cmd/nfd-worker/main_test.go
+++ b/cmd/nfd-worker/main_test.go
@@ -31,7 +31,7 @@ func TestParseArgs(t *testing.T) {
 		flags := flag.NewFlagSet(ProgramName, flag.ExitOnError)
 
 		Convey("When no override args are specified", func() {
-			args := parseArgs(flags, "--oneshot")
+			args := parseArgs(flags, "-oneshot")
 
 			Convey("overrides should be nil", func() {
 				So(args.Oneshot, ShouldBeTrue)
@@ -44,7 +44,7 @@ func TestParseArgs(t *testing.T) {
 
 		Convey("When all override args are specified", func() {
 			args := parseArgs(flags,
-				"--no-publish",
+				"-no-publish",
 				"-label-whitelist=.*rdt.*",
 				"-sources=fake1,fake2,fake3",
 				"-sleep-interval=30s")

--- a/docs/advanced/worker-configuration-reference.md
+++ b/docs/advanced/worker-configuration-reference.md
@@ -31,7 +31,7 @@ feature (re-)detection, and thus also the interval between node re-labeling. A
 non-positive value implies infinite sleep interval, i.e. no re-detection or
 re-labeling is done.
 
-Note: Overridden by the deprecated `--sleep-interval` command line flag (if
+Note: Overridden by the deprecated `-sleep-interval` command line flag (if
 specified).
 
 Default: `60s`
@@ -48,7 +48,7 @@ core:
 `core.sources` specifies the list of enabled feature sources. A special value
 `all` enables all feature sources.
 
-Note: Overridden by the deprecated `--sources` command line flag (if
+Note: Overridden by the deprecated `-sources` command line flag (if
 specified).
 
 Default: `[all]`
@@ -71,7 +71,7 @@ Note: The regular expression is only matches against the "basename" part of the
 label, i.e. to the part of the name after '/'. The label prefix (or namespace)
 is omitted.
 
-Note: Overridden by the deprecated `--label-whitelist` command line flag (if
+Note: Overridden by the deprecated `-label-whitelist` command line flag (if
 specified).
 
 Default: `null`
@@ -89,7 +89,7 @@ Setting `core.noPublish` to `true` disables all communication with the
 nfd-master. It is effectively a "dry-run" flag: nfd-worker runs feature
 detection normally, but no labeling requests are sent to nfd-master.
 
-Note: Overridden by the `--no-publish` command line flag (if specified).
+Note: Overridden by the `-no-publish` command line flag (if specified).
 
 Default: `false`
 

--- a/docs/get-started/features.md
+++ b/docs/get-started/features.md
@@ -1,4 +1,4 @@
----
+--
 title: "Feature discovery"
 layout: default
 sort: 4
@@ -33,7 +33,7 @@ The published node labels encode a few pieces of information:
       sub-namespaces (e.g. `vendor.profile.node.kubernetes.io` and
       `sub.ns.profile.node.kubernetes.io`) are allowed by default
     - additional namespaces may be enabled with the
-      [`--extra-label-ns`](../advanced/master-commandline-reference#-extra-label-ns)
+      [`-extra-label-ns`](../advanced/master-commandline-reference#-extra-label-ns)
       command line flag of nfd-master
 - The source for each label (e.g. `cpu`).
 - The name of the discovered feature as it appears in the underlying

--- a/docs/get-started/introduction.md
+++ b/docs/get-started/introduction.md
@@ -98,7 +98,7 @@ NFD also annotates nodes it is running on:
 | [&lt;instance&gt;.]nfd.node.kubernetes.io/feature-labels     | Comma-separated list of node labels managed by NFD. NFD uses this internally so must not be edited by users.
 | [&lt;instance&gt;.]nfd.node.kubernetes.io/extended-resources | Comma-separated list of node extended resources managed by NFD. NFD uses this internally so must not be edited by users.
 
-NOTE: the [`--instance`](../advanced/master-commandline-reference.md#instance)
+NOTE: the [`-instance`](../advanced/master-commandline-reference.md#instance)
 command line flag affects the annotation names
 
 Unapplicable annotations are not created, i.e. for example master.version is

--- a/pkg/nfd-client/base.go
+++ b/pkg/nfd-client/base.go
@@ -71,13 +71,13 @@ func NewNfdBaseClient(args *Args) (NfdBaseClient, error) {
 	// Check TLS related args
 	if args.CertFile != "" || args.KeyFile != "" || args.CaFile != "" {
 		if args.CertFile == "" {
-			return nfd, fmt.Errorf("--cert-file needs to be specified alongside --key-file and --ca-file")
+			return nfd, fmt.Errorf("-cert-file needs to be specified alongside -key-file and -ca-file")
 		}
 		if args.KeyFile == "" {
-			return nfd, fmt.Errorf("--key-file needs to be specified alongside --cert-file and --ca-file")
+			return nfd, fmt.Errorf("-key-file needs to be specified alongside -cert-file and -ca-file")
 		}
 		if args.CaFile == "" {
-			return nfd, fmt.Errorf("--ca-file needs to be specified alongside --cert-file and --key-file")
+			return nfd, fmt.Errorf("-ca-file needs to be specified alongside -cert-file and -key-file")
 		}
 	}
 

--- a/pkg/nfd-client/topology-updater/nfd-topology-updater_test.go
+++ b/pkg/nfd-client/topology-updater/nfd-topology-updater_test.go
@@ -74,7 +74,7 @@ func teardownTest(ctx testContext) {
 
 func TestNewTopologyUpdater(t *testing.T) {
 	Convey("When initializing new NfdTopologyUpdater instance", t, func() {
-		Convey("When one of --cert-file, --key-file or --ca-file is missing", func() {
+		Convey("When one of -cert-file, -key-file or -ca-file is missing", func() {
 			tmPolicy := "fake-topology-manager-policy"
 			_, err := u.NewTopologyUpdater(u.Args{Args: nfdclient.Args{CertFile: "crt", KeyFile: "key"}}, resourcemonitor.Args{}, tmPolicy)
 			_, err2 := u.NewTopologyUpdater(u.Args{Args: nfdclient.Args{KeyFile: "key", CaFile: "ca"}}, resourcemonitor.Args{}, tmPolicy)

--- a/pkg/nfd-client/worker/nfd-worker.go
+++ b/pkg/nfd-client/worker/nfd-worker.go
@@ -305,7 +305,7 @@ func (w *nfdWorker) configureCore(c coreConfig) error {
 			if s := source.GetLabelSource(name); s != nil {
 				enabled[name] = s
 			} else {
-				klog.Warningf("skipping unknown source %q specified in core.sources (or --sources)", name)
+				klog.Warningf("skipping unknown source %q specified in core.sources (or -sources)", name)
 			}
 		}
 	}
@@ -364,7 +364,7 @@ func (w *nfdWorker) configure(filepath string, overrides string) error {
 
 	// Parse config overrides
 	if err := yaml.Unmarshal([]byte(overrides), c); err != nil {
-		return fmt.Errorf("failed to parse --options: %s", err)
+		return fmt.Errorf("failed to parse -options: %s", err)
 	}
 
 	if w.args.Overrides.LabelWhiteList != nil {

--- a/pkg/nfd-client/worker/nfd-worker_test.go
+++ b/pkg/nfd-client/worker/nfd-worker_test.go
@@ -75,7 +75,7 @@ func teardownTest(ctx testContext) {
 
 func TestNewNfdWorker(t *testing.T) {
 	Convey("When initializing new NfdWorker instance", t, func() {
-		Convey("When one of --cert-file, --key-file or --ca-file is missing", func() {
+		Convey("When one of -cert-file, -key-file or -ca-file is missing", func() {
 			_, err := worker.NewNfdWorker(&worker.Args{Args: nfdclient.Args{CertFile: "crt", KeyFile: "key"}})
 			_, err2 := worker.NewNfdWorker(&worker.Args{Args: nfdclient.Args{KeyFile: "key", CaFile: "ca"}})
 			_, err3 := worker.NewNfdWorker(&worker.Args{Args: nfdclient.Args{CertFile: "crt", CaFile: "ca"}})

--- a/pkg/nfd-master/nfd-master-internal_test.go
+++ b/pkg/nfd-master/nfd-master-internal_test.go
@@ -336,7 +336,7 @@ func TestSetLabels(t *testing.T) {
 			})
 		})
 
-		Convey("When --label-whitelist is specified", func() {
+		Convey("When -label-whitelist is specified", func() {
 			expectedPatches := []apihelper.JsonPatch{
 				apihelper.NewJsonPatch("add", "/metadata/annotations", wvAnnotation, workerVer),
 				apihelper.NewJsonPatch("add", "/metadata/annotations", flAnnotation, "feature-2"),
@@ -355,7 +355,7 @@ func TestSetLabels(t *testing.T) {
 			})
 		})
 
-		Convey("When --extra-label-ns and --instance are specified", func() {
+		Convey("When -extra-label-ns and -instance are specified", func() {
 			// In the gRPC request the label names may omit the default ns
 			instance := "foo"
 			vendorFeatureLabel := "vendor." + FeatureLabelNs + "/feature-4"
@@ -391,7 +391,7 @@ func TestSetLabels(t *testing.T) {
 			mockMaster.annotationNs = AnnotationNsBase
 		})
 
-		Convey("When --resource-labels is specified", func() {
+		Convey("When -resource-labels is specified", func() {
 			expectedPatches := []apihelper.JsonPatch{
 				apihelper.NewJsonPatch("add", "/metadata/annotations", wvAnnotation, workerVer),
 				apihelper.NewJsonPatch("add", "/metadata/annotations", flAnnotation, "feature-2"),
@@ -424,7 +424,7 @@ func TestSetLabels(t *testing.T) {
 		})
 
 		mockMaster.args.NoPublish = true
-		Convey("With '--no-publish'", func() {
+		Convey("With '-no-publish'", func() {
 			_, err := mockMaster.SetLabels(mockCtx, mockReq)
 			Convey("Operation should succeed", func() {
 				So(err, ShouldBeNil)

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -130,7 +130,7 @@ func NewNfdMaster(args *Args) (NfdMaster, error) {
 		nfd.annotationNs = AnnotationNsBase
 	} else {
 		if ok, _ := regexp.MatchString(`^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$`, args.Instance); !ok {
-			return nfd, fmt.Errorf("invalid --instance %q: instance name "+
+			return nfd, fmt.Errorf("invalid -instance %q: instance name "+
 				"must start and end with an alphanumeric character and may only contain "+
 				"alphanumerics, `-`, `_` or `.`", args.Instance)
 		}
@@ -140,13 +140,13 @@ func NewNfdMaster(args *Args) (NfdMaster, error) {
 	// Check TLS related args
 	if args.CertFile != "" || args.KeyFile != "" || args.CaFile != "" {
 		if args.CertFile == "" {
-			return nfd, fmt.Errorf("--cert-file needs to be specified alongside --key-file and --ca-file")
+			return nfd, fmt.Errorf("-cert-file needs to be specified alongside -key-file and -ca-file")
 		}
 		if args.KeyFile == "" {
-			return nfd, fmt.Errorf("--key-file needs to be specified alongside --cert-file and --ca-file")
+			return nfd, fmt.Errorf("-key-file needs to be specified alongside -cert-file and -ca-file")
 		}
 		if args.CaFile == "" {
-			return nfd, fmt.Errorf("--ca-file needs to be specified alongside --cert-file and --key-file")
+			return nfd, fmt.Errorf("-ca-file needs to be specified alongside -cert-file and -key-file")
 		}
 	}
 
@@ -207,7 +207,7 @@ func (m *nfdMaster) Run() error {
 	if err != nil {
 		return err
 	}
-	// Enable mutual TLS authentication if --cert-file, --key-file or --ca-file
+	// Enable mutual TLS authentication if -cert-file, -key-file or -ca-file
 	// is defined
 	if m.args.CertFile != "" || m.args.KeyFile != "" || m.args.CaFile != "" {
 		if err := tlsConfig.UpdateConfig(m.args.CertFile, m.args.KeyFile, m.args.CaFile); err != nil {

--- a/pkg/nfd-master/nfd-master_test.go
+++ b/pkg/nfd-master/nfd-master_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestNewNfdMaster(t *testing.T) {
 	Convey("When initializing new NfdMaster instance", t, func() {
-		Convey("When one of --cert-file, --key-file or --ca-file is missing", func() {
+		Convey("When one of -cert-file, -key-file or -ca-file is missing", func() {
 			_, err := m.NewNfdMaster(&m.Args{CertFile: "crt", KeyFile: "key"})
 			_, err2 := m.NewNfdMaster(&m.Args{KeyFile: "key", CaFile: "ca"})
 			_, err3 := m.NewNfdMaster(&m.Args{CertFile: "crt", CaFile: "ca"})


### PR DESCRIPTION
Use the single-dash (i.e. '-option' instead of '--option') format
consistently accross log messages and documentation. This is the format
that was mostly used, already, and shown by command line help of the
binaries, for example.