### PR TITLE
source/cpu: add additional IBM Z CPU Flags

### DIFF
--- a/source/cpu/cpuid_s390x.go
+++ b/source/cpu/cpuid_s390x.go
@@ -47,6 +47,10 @@ const (
 	HWCAP_S390_VXRS_PDE  = 65536
 	HWCAP_S390_SORT      = 131072
 	HWCAP_S390_DFLT      = 262144
+	HWCAP_NR_VXRS_PDE2   = 524288
+	HWCAP_NR_NNPA        = 1048576
+	HWCAP_NR_PCI_MIO     = 2097152
+	HWCAP_NR_SIE         = 4194304
 )
 
 var flagNames_s390x = map[uint64]string{
@@ -69,6 +73,10 @@ var flagNames_s390x = map[uint64]string{
 	HWCAP_S390_VXRS_PDE:  "VXP",
 	HWCAP_S390_SORT:      "SORT",
 	HWCAP_S390_DFLT:      "DFLT",
+	HWCAP_NR_VXRS_PDE2:   "VXP2",
+	HWCAP_NR_NNPA:        "NNPA",
+	HWCAP_NR_PCI_MIO:     "PCIMIO",
+	HWCAP_NR_SIE:         "SIE",
 }
 
 func getCpuidFlags() []string {

--- a/source/cpu/power_stub.go
+++ b/source/cpu/power_stub.go
@@ -19,6 +19,6 @@ limitations under the License.
 
 package cpu
 
-func discoverSSTBF() (bool, error) {
-	return false, nil
+func discoverSST() map[string]string {
+	return nil
 }


### PR DESCRIPTION
Add the newly supported s390x CPU Flags for the 5.15 Kernel

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>

I also fixed one compiler Issue for non amd64 architectures.