### PR TITLE
source/iommu: deprecate and disable by default 

### DIFF
--- a/docs/get-started/features.md
+++ b/docs/get-started/features.md
@@ -429,13 +429,15 @@ labels by defining them in the `nfd-worker` configuration file.
 | rdma  | capable | The node has an RDMA capable Network adapter |
 | rdma | enabled | The node has the needed RDMA modules loaded to run RDMA traffic |
 
-### IOMMU
+### IOMMU (deprecated)
 
 The **iommu** feature source supports the following labels:
 
 | Feature name   | Description                                                 |
 | :------------: | :---------------------------------------------------------: |
 | enabled        | IOMMU is present and enabled in the kernel
+
+**DEPRECATED**: The **iommu** source is deprecated and not enabled by default.
 
 ### Kernel
 

--- a/docs/get-started/introduction.md
+++ b/docs/get-started/introduction.md
@@ -52,7 +52,6 @@ supposed to be running on each node of the cluster.
 Feature discovery is divided into domain-specific feature sources:
 
 - CPU
-- IOMMU
 - Kernel
 - Memory
 - Network
@@ -62,6 +61,7 @@ Feature discovery is divided into domain-specific feature sources:
 - USB
 - Custom (rule-based custom features)
 - Local (hooks for user-specific features)
+- IOMMU (*deprecated*)
 
 Each feature source is responsible for detecting a set of features which. in
 turn, are turned into node feature labels.  Feature labels are prefixed with
@@ -75,7 +75,6 @@ An overview of the default feature labels:
 {
   "feature.node.kubernetes.io/cpu-<feature-name>": "true",
   "feature.node.kubernetes.io/custom-<feature-name>": "true",
-  "feature.node.kubernetes.io/iommu-<feature-name>": "true",
   "feature.node.kubernetes.io/kernel-<feature name>": "<feature value>",
   "feature.node.kubernetes.io/memory-<feature-name>": "true",
   "feature.node.kubernetes.io/network-<feature-name>": "true",

--- a/pkg/nfd-client/worker/nfd-worker-internal_test.go
+++ b/pkg/nfd-client/worker/nfd-worker-internal_test.go
@@ -317,7 +317,7 @@ func TestNewNfdWorker(t *testing.T) {
 			So(worker.configure("", ""), ShouldBeNil)
 			Convey("all sources should be enabled and the whitelist regexp should be empty", func() {
 				So(len(worker.featureSources), ShouldEqual, len(source.GetAllFeatureSources())-1)
-				So(len(worker.labelSources), ShouldEqual, len(source.GetAllLabelSources())-1)
+				So(len(worker.labelSources), ShouldEqual, len(source.GetAllLabelSources())-2)
 				So(worker.config.Core.LabelWhiteList, ShouldResemble, emptyRegexp)
 			})
 		})

--- a/pkg/nfd-client/worker/nfd-worker.go
+++ b/pkg/nfd-client/worker/nfd-worker.go
@@ -302,7 +302,7 @@ func (w *nfdWorker) configureCore(c coreConfig) error {
 	for _, name := range c.FeatureSources {
 		if name == "all" {
 			for n, s := range source.GetAllFeatureSources() {
-				if ts, ok := s.(source.TestSource); !ok || !ts.IsTestSource() {
+				if ts, ok := s.(source.SupplementalSource); !ok || !ts.DisableByDefault() {
 					featureSources[n] = s
 				}
 			}
@@ -337,7 +337,7 @@ func (w *nfdWorker) configureCore(c coreConfig) error {
 	for _, name := range c.LabelSources {
 		if name == "all" {
 			for n, s := range source.GetAllLabelSources() {
-				if ts, ok := s.(source.TestSource); !ok || !ts.IsTestSource() {
+				if ts, ok := s.(source.SupplementalSource); !ok || !ts.DisableByDefault() {
 					labelSources[n] = s
 				}
 			}

--- a/source/fake/fake.go
+++ b/source/fake/fake.go
@@ -148,8 +148,8 @@ func (s *fakeSource) GetLabels() (source.FeatureLabels, error) {
 	return labels, nil
 }
 
-// IsTestSource method of the LabelSource interface
-func (s *fakeSource) IsTestSource() bool { return true }
+// DisableByDefault method of the SupplementalSource interface.
+func (s *fakeSource) DisableByDefault() bool { return true }
 
 func init() {
 	source.Register(&src)

--- a/source/iommu/iommu.go
+++ b/source/iommu/iommu.go
@@ -56,6 +56,9 @@ func (s *iommuSource) GetLabels() (source.FeatureLabels, error) {
 	return features, nil
 }
 
+// DisableByDefault method of the SupplementalSource interface.
+func (s *iommuSource) DisableByDefault() bool { return true }
+
 func init() {
 	source.Register(&src)
 }

--- a/source/source.go
+++ b/source/source.go
@@ -66,12 +66,15 @@ type ConfigurableSource interface {
 	SetConfig(Config)
 }
 
-// TestSource represents a source purposed for testing only
-type TestSource interface {
+// SupplementalSource represents a source that does not belong to the core set
+// sources to be used in production, e.g. is deprecated, very experimental or
+// purposed for testing only.
+type SupplementalSource interface {
 	Source
 
-	// IsTestSource returns true if the source is not for production
-	IsTestSource() bool
+	// DisableByDefault returns true if the source should be disabled by
+	// default in production.
+	DisableByDefault() bool
 }
 
 // FeatureLabelValue represents the value of one feature label


### PR DESCRIPTION
Deprecate the iommu source and disable it by default.

First step of #676 