### PR TITLE
source/kernel: drop length check of kconfig values

### DIFF
--- a/source/kernel/kconfig.go
+++ b/source/kernel/kconfig.go
@@ -25,9 +25,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/util/validation"
-	"k8s.io/klog/v2"
-
 	"sigs.k8s.io/node-feature-discovery/source"
 )
 
@@ -113,10 +110,6 @@ func parseKconfig(configPath string) (map[string]string, error) {
 				kconfig[name] = "true"
 			} else {
 				value := strings.Trim(split[1], `"`)
-				if len(value) > validation.LabelValueMaxLength {
-					klog.Warningf("ignoring kconfig option '%s': value exceeds max length of %d characters", name, validation.LabelValueMaxLength)
-					continue
-				}
 				kconfig[name] = value
 			}
 		}


### PR DESCRIPTION
Do not do length checking here. We do not need/want to limit the values
here because they could still be used in custom rules. Moreover, we do
more proper validation of label all label values in nfd-worker, anyway.