### PR TITLE
source/kernel: unmangled kconfig values for custom rules 

### DIFF
--- a/source/custom/rules/kconfig_rule.go
+++ b/source/custom/rules/kconfig_rule.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/pkg/apis/nfd/v1alpha1"
-	"sigs.k8s.io/node-feature-discovery/source"
 	"sigs.k8s.io/node-feature-discovery/source/kernel"
 )
 
@@ -30,9 +29,9 @@ type KconfigRule struct {
 }
 
 func (r *KconfigRule) Match() (bool, error) {
-	options, ok := source.GetFeatureSource("kernel").GetFeatures().Values[kernel.ConfigFeature]
-	if !ok {
+	options := kernel.GetLegacyKconfig()
+	if options == nil {
 		return false, fmt.Errorf("kernel config options not available")
 	}
-	return r.MatchValues(options.Elements)
+	return r.MatchValues(options)
 }


### PR DESCRIPTION
Stop converting `=y` and `=m` to `"true"` for the raw feature values used
in "kernel.config" custom rule processing.

In practice, this means that to check if a kernel config flag has been
set to "y" or "m", one needs to explicitly check for both of the values:

```
  matchFeatures:
    - feature: kernel.config
      matchExpressions:
        FOO: {op: In, value: ["y", "m"]}
```

instead of (how it used to be):

```
  matchFeatures:
    - feature: kernel.config
      matchExpressions:
        FOO: {op: IsTrue}
```

The legacy kconfig custom rule is unchanged as are the
kernel-config.<flag> feature labels.

Builds on top of #683