### PR TITLE
scripts: increase e2e-test image poll timeout to 12mins

### DIFF
--- a/scripts/test-infra/test-e2e.sh
+++ b/scripts/test-infra/test-e2e.sh
@@ -19,8 +19,8 @@ i=1
 while true; do
     if make poll-images; then
         break
-    elif [ $i -ge 10 ]; then
-        "ERROR: too many tries when polling for image"
+    elif [ $i -ge 12 ]; then
+        echo "ERROR: too many tries when polling for image"
         exit 1
     fi
     sleep 60


### PR DESCRIPTION
Rare timeouts (narrowly missing) with 10 minutes observed, try
increasing by 2 minutes.

Also fix printing of error message in case of a timeout.