### PR TITLE
source: make per-source unit tests stricter

### DIFF
--- a/source/cpu/cpu_test.go
+++ b/source/cpu/cpu_test.go
@@ -20,14 +20,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
 )
 
 func TestCpuSource(t *testing.T) {
 	assert.Equal(t, src.Name(), Name)
 
 	// Check that GetLabels works with empty features
-	src.features = feature.NewDomainFeatures()
+	src.features = nil
 	l, err := src.GetLabels()
 
 	assert.Nil(t, err, err)

--- a/source/kernel/kernel_test.go
+++ b/source/kernel/kernel_test.go
@@ -20,14 +20,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
 )
 
 func TestKernelSource(t *testing.T) {
 	assert.Equal(t, src.Name(), Name)
 
 	// Check that GetLabels works with empty features
-	src.features = feature.NewDomainFeatures()
+	src.features = nil
 	l, err := src.GetLabels()
 
 	assert.Nil(t, err, err)

--- a/source/local/local_test.go
+++ b/source/local/local_test.go
@@ -20,14 +20,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
 )
 
 func TestLocalSource(t *testing.T) {
 	assert.Equal(t, src.Name(), Name)
 
 	// Check that GetLabels works with empty features
-	src.features = feature.NewDomainFeatures()
+	src.features = nil
 	l, err := src.GetLabels()
 
 	assert.Nil(t, err, err)

--- a/source/memory/memory_test.go
+++ b/source/memory/memory_test.go
@@ -20,14 +20,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
 )
 
 func TestMemorySource(t *testing.T) {
 	assert.Equal(t, src.Name(), Name)
 
 	// Check that GetLabels works with empty features
-	src.features = feature.NewDomainFeatures()
+	src.features = nil
 	l, err := src.GetLabels()
 
 	assert.Nil(t, err, err)

--- a/source/network/network_test.go
+++ b/source/network/network_test.go
@@ -20,14 +20,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
 )
 
 func TestNetworkSource(t *testing.T) {
 	assert.Equal(t, src.Name(), Name)
 
 	// Check that GetLabels works with empty features
-	src.features = feature.NewDomainFeatures()
+	src.features = nil
 	l, err := src.GetLabels()
 
 	assert.Nil(t, err, err)

--- a/source/pci/pci_test.go
+++ b/source/pci/pci_test.go
@@ -20,14 +20,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
 )
 
 func TestPciSource(t *testing.T) {
 	assert.Equal(t, src.Name(), Name)
 
 	// Check that GetLabels works with empty features
-	src.features = feature.NewDomainFeatures()
+	src.features = nil
 	l, err := src.GetLabels()
 
 	assert.Nil(t, err, err)

--- a/source/storage/storage_test.go
+++ b/source/storage/storage_test.go
@@ -20,14 +20,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
 )
 
 func TestStorageSource(t *testing.T) {
 	assert.Equal(t, src.Name(), Name)
 
 	// Check that GetLabels works with empty features
-	src.features = feature.NewDomainFeatures()
+	src.features = nil
 	l, err := src.GetLabels()
 
 	assert.Nil(t, err, err)

--- a/source/system/system_test.go
+++ b/source/system/system_test.go
@@ -20,14 +20,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
 )
 
 func TestSystemSource(t *testing.T) {
 	assert.Equal(t, src.Name(), Name)
 
 	// Check that GetLabels works with empty features
-	src.features = feature.NewDomainFeatures()
+	src.features = nil
 	l, err := src.GetLabels()
 
 	assert.Nil(t, err, err)

--- a/source/usb/usb_test.go
+++ b/source/usb/usb_test.go
@@ -20,14 +20,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
 )
 
 func TestUsbSource(t *testing.T) {
 	assert.Equal(t, src.Name(), Name)
 
 	// Check that GetLabels works with empty features
-	src.features = feature.NewDomainFeatures()
+	src.features = nil
 	l, err := src.GetLabels()
 
 	assert.Nil(t, err, err)


### PR DESCRIPTION
Now the tests check that GetLabels() works even without calling
Discover() at all.