### PR TITLE
source/fake: implement FeatureSource

### DIFF
--- a/pkg/nfd-client/worker/nfd-worker-internal_test.go
+++ b/pkg/nfd-client/worker/nfd-worker-internal_test.go
@@ -227,8 +227,9 @@ core:
 		w, err := NewNfdWorker(&Args{
 			ConfigFile: configFile,
 			Overrides: ConfigOverrideArgs{
-				LabelSources: &utils.StringSliceVal{"fake"},
-				NoPublish:    &noPublish},
+				FeatureSources: &utils.StringSliceVal{"fake"},
+				LabelSources:   &utils.StringSliceVal{"fake"},
+				NoPublish:      &noPublish},
 		})
 		So(err, ShouldBeNil)
 		worker := w.(*nfdWorker)
@@ -315,7 +316,7 @@ func TestNewNfdWorker(t *testing.T) {
 			worker := w.(*nfdWorker)
 			So(worker.configure("", ""), ShouldBeNil)
 			Convey("all sources should be enabled and the whitelist regexp should be empty", func() {
-				So(len(worker.featureSources), ShouldEqual, len(source.GetAllFeatureSources()))
+				So(len(worker.featureSources), ShouldEqual, len(source.GetAllFeatureSources())-1)
 				So(len(worker.labelSources), ShouldEqual, len(source.GetAllLabelSources())-1)
 				So(worker.config.Core.LabelWhiteList, ShouldResemble, emptyRegexp)
 			})

--- a/source/fake/fake.go
+++ b/source/fake/fake.go
@@ -19,15 +19,26 @@ package fake
 import (
 	"fmt"
 
+	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils"
 	"sigs.k8s.io/node-feature-discovery/source"
 )
 
 const Name = "fake"
 
+const FlagFeature = "flag"
+const AttributeFeature = "attribute"
+const InstanceFeature = "instance"
+
 // Configuration file options
 type Config struct {
-	Labels map[string]string `json:"labels"`
+	Labels            map[string]string `json:"labels"`
+	FlagFeatures      []string          `json:"flagFeatures"`
+	AttributeFeatures map[string]string `json:"attributeFeatures"`
+	InstanceFeatures  []FakeInstance    `json:"instanceFeatures"`
 }
+
+type FakeInstance map[string]string
 
 // newDefaultConfig returns a new config with defaults values
 func newDefaultConfig() *Config {
@@ -37,17 +48,43 @@ func newDefaultConfig() *Config {
 			"fakefeature2": "true",
 			"fakefeature3": "true",
 		},
+		FlagFeatures: []string{"flag_1", "flag_2", "flag_3"},
+		AttributeFeatures: map[string]string{
+			"attr_1": "true",
+			"attr_2": "false",
+			"attr_3": "10",
+		},
+		InstanceFeatures: []FakeInstance{
+			FakeInstance{
+				"name":   "instance_1",
+				"attr_1": "true",
+				"attr_2": "false",
+				"attr_3": "10",
+				"attr_4": "foobar",
+			},
+			FakeInstance{
+				"name":   "instance_2",
+				"attr_1": "true",
+				"attr_2": "true",
+				"attr_3": "100",
+			},
+			FakeInstance{
+				"name": "instance_3",
+			},
+		},
 	}
 }
 
-// fakeSource implements the LabelSource and ConfigurableSource interfaces.
+// fakeSource implements the FeatureSource, LabelSource and ConfigurableSource interfaces.
 type fakeSource struct {
-	config *Config
+	config   *Config
+	features *feature.DomainFeatures
 }
 
 // Singleton source instance
 var (
 	src fakeSource
+	_   source.FeatureSource      = &src
 	_   source.LabelSource        = &src
 	_   source.ConfigurableSource = &src
 )
@@ -71,18 +108,44 @@ func (s *fakeSource) SetConfig(conf source.Config) {
 	}
 }
 
+// Discover method of the FeatureSource interface
+func (s *fakeSource) Discover() error {
+	s.features = feature.NewDomainFeatures()
+
+	s.features.Keys[AttributeFeature] = feature.NewKeyFeatures(s.config.FlagFeatures...)
+	s.features.Values[AttributeFeature] = feature.NewValueFeatures(s.config.AttributeFeatures)
+
+	instances := make([]feature.InstanceFeature, len(s.config.InstanceFeatures))
+	for i, instanceAttributes := range s.config.InstanceFeatures {
+		instances[i] = *feature.NewInstanceFeature(instanceAttributes)
+	}
+	s.features.Instances[InstanceFeature] = feature.NewInstanceFeatures(instances)
+
+	utils.KlogDump(3, "discovered fake features:", "  ", s.features)
+
+	return nil
+}
+
+// GetFeatures method of the FeatureSource Interface.
+func (s *fakeSource) GetFeatures() *feature.DomainFeatures {
+	if s.features == nil {
+		s.features = feature.NewDomainFeatures()
+	}
+	return s.features
+}
+
 // Priority method of the LabelSource interface
 func (s *fakeSource) Priority() int { return 0 }
 
 // GetLabels method of the LabelSource interface
 func (s *fakeSource) GetLabels() (source.FeatureLabels, error) {
-	// Adding three fake features.
-	features := make(source.FeatureLabels, len(s.config.Labels))
+	labels := make(source.FeatureLabels, len(s.config.Labels))
+
 	for k, v := range s.config.Labels {
-		features[k] = v
+		labels[k] = v
 	}
 
-	return features, nil
+	return labels, nil
 }
 
 // IsTestSource method of the LabelSource interface

--- a/source/fake/fake.go
+++ b/source/fake/fake.go
@@ -55,13 +55,13 @@ var (
 // Name returns an identifier string for this feature source.
 func (s *fakeSource) Name() string { return Name }
 
-// NewConfig method of the LabelSource interface
+// NewConfig method of the ConfigurableSource interface
 func (s *fakeSource) NewConfig() source.Config { return newDefaultConfig() }
 
-// GetConfig method of the LabelSource interface
+// GetConfig method of the ConfigurableSource interface
 func (s *fakeSource) GetConfig() source.Config { return s.config }
 
-// SetConfig method of the LabelSource interface
+// SetConfig method of the ConfigurableSource interface
 func (s *fakeSource) SetConfig(conf source.Config) {
 	switch v := conf.(type) {
 	case *Config:
@@ -70,9 +70,6 @@ func (s *fakeSource) SetConfig(conf source.Config) {
 		panic(fmt.Sprintf("invalid config type: %T", conf))
 	}
 }
-
-// Configure method of the LabelSource interface
-func (s *fakeSource) Configure([]byte) error { return nil }
 
 // Priority method of the LabelSource interface
 func (s *fakeSource) Priority() int { return 0 }


### PR DESCRIPTION
Makes it possible to create fake features for custom rules, enabling
testing.

Depends on #605 