### PR TITLE
docs: fix mistake in md format

### DIFF
--- a/docs/get-started/features.md
+++ b/docs/get-started/features.md
@@ -1,4 +1,4 @@
---
+---
 title: "Feature discovery"
 layout: default
 sort: 4


### PR DESCRIPTION
Accidentally introduced in a57a25f63cb37c6e3aad45be52343c4b175a58f0.