### PR TITLE
source/local: don't prefix label names with the filename

### DIFF
--- a/docs/get-started/features.md
+++ b/docs/get-started/features.md
@@ -569,20 +569,15 @@ update them to match your needs.
 In both cases, the labels can be binary or non binary, using either `<name>` or
 `<name>=<value>` format.
 
-Unlike the other feature sources, the name of the file, instead of the name of
-the feature source (that would be `local` in this case), is used as a prefix in
-the label name, normally. However, if the `<name>` of the label starts with a
-slash (`/`) it is used as the label name as is, without any additional prefix.
-This makes it possible for the user to fully control the feature label names,
-e.g. for overriding labels created by other feature sources.
+`local` has precedence over other label sources which makes it possible to
+override labels created by them.
 
 You can also override the default namespace of your labels using this format:
 `<namespace>/<name>[=<value>]`. If using something else than
 `[<sub-ns>.]feature.node.kubernetes.io` or
 `[<sub-ns>.]profile.node.kubernetes.io`, you must whitelist your namespace
 using the `-extra-label-ns` option on the master.
-In this case, the name of the
-file will not be added to the label name. For example, if you want to add the
+For example, if you want to add the
 label `my.namespace.org/my-label=value`, your hook output or file must contains
 `my.namespace.org/my-label=value` and you must add
 `-extra-label-ns=my.namespace.org` on the master command line.
@@ -604,48 +599,40 @@ you have created a shared area for delivering hooks and feature files to NFD.
 #### A hook example
 
 User has a shell script
-`/etc/kubernetes/node-feature-discovery/source.d/my-source` which has the
+`/etc/kubernetes/node-feature-discovery/source.d/my-hook.sh` which has the
 following `stdout` output:
 
 ```plaintext
-MY_FEATURE_1
-MY_FEATURE_2=myvalue
-/override_source-OVERRIDE_BOOL
-/override_source-OVERRIDE_VALUE=123
-override.namespace/value=456
+my-feature.1
+my-feature.2=myvalue
+my.namespace/my-feature.3=456
 ```
 
 which, in turn, will translate into the following node labels:
 
 ```plaintext
-feature.node.kubernetes.io/my-source-MY_FEATURE_1=true
-feature.node.kubernetes.io/my-source-MY_FEATURE_2=myvalue
-feature.node.kubernetes.io/override_source-OVERRIDE_BOOL=true
-feature.node.kubernetes.io/override_source-OVERRIDE_VALUE=123
-override.namespace/value=456
+feature.node.kubernetes.io/my-feature.1=true
+feature.node.kubernetes.io/my-feature.2=myvalue
+my.namespace/my-feature.3=456
 ```
 
 #### A file example
 
-User has a file `/etc/kubernetes/node-feature-discovery/features.d/my-source`
+User has a file `/etc/kubernetes/node-feature-discovery/features.d/my-features`
 which contains the following lines:
 
 ```plaintext
-MY_FEATURE_1
-MY_FEATURE_2=myvalue
-/override_source-OVERRIDE_BOOL
-/override_source-OVERRIDE_VALUE=123
-override.namespace/value=456
+my-feature.4
+my-feature.5=myvalue
+my.namespace/my-feature.6=456
 ```
 
 which, in turn, will translate into the following node labels:
 
 ```plaintext
-feature.node.kubernetes.io/my-source-MY_FEATURE_1=true
-feature.node.kubernetes.io/my-source-MY_FEATURE_2=myvalue
-feature.node.kubernetes.io/override_source-OVERRIDE_BOOL=true
-feature.node.kubernetes.io/override_source-OVERRIDE_VALUE=123
-override.namespace/value=456
+feature.node.kubernetes.io/my-feature.4=true
+feature.node.kubernetes.io/my-feature.5=myvalue
+my.namespace/my-feature.6=456
 ```
 
 NFD tries to run any regular files found from the hooks directory. Any

--- a/source/local/local.go
+++ b/source/local/local.go
@@ -108,24 +108,14 @@ func (s *localSource) GetFeatures() *feature.DomainFeatures {
 	return s.features
 }
 
-func parseFeatures(lines [][]byte, prefix string) map[string]string {
+func parseFeatures(lines [][]byte) map[string]string {
 	features := make(map[string]string)
 
 	for _, line := range lines {
 		if len(line) > 0 {
 			lineSplit := strings.SplitN(string(line), "=", 2)
 
-			// Check if we need to add prefix
-			var key string
-			if strings.Contains(lineSplit[0], "/") {
-				if lineSplit[0][0] == '/' {
-					key = lineSplit[0][1:]
-				} else {
-					key = lineSplit[0]
-				}
-			} else {
-				key = prefix + "-" + lineSplit[0]
-			}
+			key := lineSplit[0]
 
 			// Check if it's a boolean value
 			if len(lineSplit) == 1 {
@@ -161,7 +151,7 @@ func getFeaturesFromHooks() (map[string]string, error) {
 		}
 
 		// Append features
-		fileFeatures := parseFeatures(lines, fileName)
+		fileFeatures := parseFeatures(lines)
 		utils.KlogDump(4, fmt.Sprintf("features from hook %q:", fileName), "  ", fileFeatures)
 		for k, v := range fileFeatures {
 			if old, ok := features[k]; ok {
@@ -238,7 +228,7 @@ func getFeaturesFromFiles() (map[string]string, error) {
 		}
 
 		// Append features
-		fileFeatures := parseFeatures(lines, fileName)
+		fileFeatures := parseFeatures(lines)
 		utils.KlogDump(4, fmt.Sprintf("features from feature file %q:", fileName), "  ", fileFeatures)
 		for k, v := range fileFeatures {
 			if old, ok := features[k]; ok {


### PR DESCRIPTION
Implicitly injecting the filename of the hook/featurefile into the name
of the label is usually confusing, counter-intuitive and unnecessarily
complex to understand. It's much clearer to advertise features and
labels as presented in the feature file / output of the hook.

NOTE: this breaks backwards compatibility with usage scenarios that rely
on prefixing the label with the filename.