### PR TITLE
nfd-worker: drop 'custom-' prefix from matchFeatures custom rules

### DIFF
--- a/pkg/nfd-client/worker/nfd-worker.go
+++ b/pkg/nfd-client/worker/nfd-worker.go
@@ -498,8 +498,8 @@ func getFeatureLabels(source source.LabelSource, labelWhiteList regexp.Regexp) (
 	// Prefix for labels in the default namespace
 	prefix := source.Name() + "-"
 	switch source.Name() {
-	case "local":
-		// Do not prefix labels from the hooks
+	case "local", "custom":
+		// Do not prefix labels from the custom rules, hooks or feature files
 		prefix = ""
 	}
 

--- a/source/custom/custom.go
+++ b/source/custom/custom.go
@@ -171,11 +171,18 @@ func (r *LegacyRule) execute(features map[string]*feature.DomainFeatures) (map[s
 		}
 	}
 
+	// Prefix non-namespaced labels with "custom-"
+	name := r.Name
+	if !strings.Contains(name, "/") {
+		name = "custom-" + name
+	}
+
 	value := "true"
 	if r.Value != nil {
 		value = *r.Value
 	}
-	return map[string]string{r.Name: value}, nil
+
+	return map[string]string{name: value}, nil
 }
 
 func (m *LegacyMatcher) match() (bool, error) {


### PR DESCRIPTION
Do not prefix label names from the new matchFeatures/matchAny custom
rules with "custom-". We want to have the same result (set of labels)
from a rule independent of whether it has been specified in worker
config or in a NodeFeatureRule CRs. Legacy matchOn rules (not available
in NodeFeatureRule CRs) are intact, i.e. still prefixed, in order to
retain backwards compatibility.