### PR TITLE
docs: add customization guide

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -44,6 +44,14 @@ remote_theme: rundocs/jekyll-rtd-theme@v2.0.10
 version: master
 display_version_list: true
 
+# Customize page width (make it wider) for large screens
+scss: |
+  @media(min-width: 1280px){
+    .content-wrap{
+      max-width: 1200px
+    }
+  }
+
 # Release is the full released version number. Used to make external links to
 # point to the correct blobs in the Github repo. This is also the version shown
 # in the sidebar (top left corner of the page)

--- a/docs/advanced/customization-guide.md
+++ b/docs/advanced/customization-guide.md
@@ -2,7 +2,6 @@
 title: "Customization guide"
 layout: default
 sort: 5
-published: false
 ---
 
 # Customization guide
@@ -16,8 +15,1029 @@ published: false
 
 ---
 
-***WORK IN PROGRESS.***
+## Overview
 
-This document explains with examples how to use hooks, feature files and the
-custom feature source.
+NFD provides multiple extension points for vendor and application specific
+labeling:
+
+- [`NodeFeatureRule`](#nodefeaturerule-custom-resource) objects provide a way to
+  deploy custom labeling rules via the Kubernetes API
+- [`local`](#local-feature-source) feature source of nfd-worker creates
+  labels by executing hooks and reading files
+- [`custom`](#custom-feature-source) feature source of nfd-worker creates
+  labels based on user-specified rules
+
+## NodeFeatureRule custom resource
+
+`NodeFeatureRule` objects provide an easy way to create vendor or application
+specific labels. It uses a flexible rule-based mechanism for creating labels
+based on node feature.
+
+### A NodeFeatureRule example
+
+Consider the following referential example:
+
+```yaml
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: my-sample-rule-object
+spec:
+  rules:
+    - name: "my sample rule"
+      labels:
+        "my-sample-feature": "true"
+      matchFeatures:
+        - feature: kernel.loadedmodule
+          matchExpressions:
+            dummy: {op: Exists}
+        - feature: kernel.config
+          matchExpressions:
+            X86: {op: In, value: ["y"]}
+```
+
+It specifies one rule which creates node label
+`feature.node.kubenernetes.io/my-sample-feature=true` if both of the following
+conditions are true (`matchFeatures` implements a logical AND over the
+matchers):
+
+- The `dummy` network driver module has been loaded
+- X86 option in kernel config is set to `=y`
+
+Create a `NodeFeatureRule` with a yaml file:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/examples/nodefeaturerule.yaml
+```
+
+Now, on X86 platforms the feature label appears after doing `modprobe dummy` on
+a system and correspondingly the label is removed after `rmmod dummy`. Note a
+re-labeling delay up to the sleep-interval of nfd-worker (1 minute by default).
+
+### NodeFeatureRule controller
+
+NFD-Master acts as the controller for `NodeFeatureRule` objects. It applies these
+rules on raw feature data received from nfd-worker instances and creates node
+labels, accordingly.
+
+**NOTE** nfd-master is stateless and (re-)labelling only happens when a request
+is received from nfd-worker. That is, in practice rules are evaluated and
+labels for each node are created on intervals specified by the
+[`core.sleepInterval`](worker-configuration-reference#coresleepinterval)
+configuration option (or
+[`-sleep-interval`](worker-commandline-reference#-sleep-interval) command line
+flag) of nfd-worker instances. This means that modification or creation of
+`NodeFeatureRule` objects does not instantly cause the node labels to be updated.
+Instead, the changes only come visible in node labels as nfd-worker instances
+send their labelling requests.
+
+## Local feature source
+
+NFD-Worker has a special feature source named `local` which is an integration
+point for external feature detectors. It provides a mechanism for pluggable
+extensions, allowing the creation of new user-specific features and even
+overriding built-in labels.
+
+The `local` feature source has two methods for detecting features, hooks and
+feature files. The features discovered by the `local` source can further be
+used in label rules specified in
+[`NodeFeatureRule`](#nodefeaturerule-custom-resource) objects and the
+[`custom`](#custom-feature-source) feature source.
+
+**NOTE:** Be careful when creating and/or updating hook or feature files while
+NFD is running. In order to avoid race conditions you should write into a
+temporary file (outside the `source.d` and `features.d` directories), and,
+atomically create/update the original file by doing a filesystem move
+operation.
+
+### A hook example
+
+Consider a shell script
+`/etc/kubernetes/node-feature-discovery/source.d/my-hook.sh` having the
+following stdout output, or alternatively, a plaintext file
+`/etc/kubernetes/node-feature-discovery/features.d/my-features` having the
+following contents:
+
+```plaintext
+my-feature.1
+my-feature.2=myvalue
+my.namespace/my-feature.3=456
+```
+
+This will translate into the following node labels:
+
+```yaml
+feature.node.kubernetes.io/my-feature.1: "true"
+feature.node.kubernetes.io/my-feature.2: "myvalue"
+my.namespace/my-feature.3: "456"
+```
+
+Note that in the example above `-extra-label-ns=my.namespace` must be specified
+on the nfd-master command line.
+
+### Hooks
+
+The `local` source executes hooks found in
+`/etc/kubernetes/node-feature-discovery/source.d/`. The hook files must be
+executable and they are supposed to print all discovered features in `stdout`.
+With ELF binaries static linking is recommended as the selection of system
+libraries available in the NFD release image is very limited. Other runtimes
+currently supported by the NFD image are bash and perl.
+
+`stderr` output of hooks is propagated to NFD log so it can be used for
+debugging and logging.
+
+NFD tries to execute any regular files found from the hooks directory.
+Any additional data files the hook might need (e.g. a configuration file)
+should be placed in a separate directory in order to avoid NFD unnecessarily
+trying to execute them. A subdirectory under the hooks directory can be used,
+for example `/etc/kubernetes/node-feature-discovery/source.d/conf/`.
+
+**NOTE:** NFD will blindly run any executables placed/mounted in the hooks
+directory. It is the user's responsibility to review the hooks for e.g.
+possible security implications.
+
+**NOTE:** The [minimal](deployment-and-usage#minimal) image variant only
+supports running statically linked binaries.
+
+### Feature files
+
+The `local` source reads files found in
+`/etc/kubernetes/node-feature-discovery/features.d/`.
+
+### Input format
+
+The hook stdout and feature files are expected to contain features in simple
+key-value pairs, separated by newlines:
+
+```plaintext
+<name>[=<value>]
+```
+
+The label value defaults to `true`, if not specified.
+
+Label namespace may be specified with `<namespace>/<name>[=<value>]`. The
+namespace must be explicitly allowed with the `-extra-label-ns` command line
+flag of nfd-master if using something else than
+`[<sub-ns>.]feature.node.kubernetes.io` or
+`[<sub-ns>.]profile.node.kubernetes.io`.
+
+### Mounts
+
+The standard NFD deployments contain `hostPath` mounts for
+`/etc/kubernetes/node-feature-discovery/source.d/` and
+`/etc/kubernetes/node-feature-discovery/features.d/`, making these directories
+from the host available inside the nfd-worker container.
+
+#### Injecting labels from other pods
+
+One use case for the hooks and/or feature files is detecting features in other
+Pods outside NFD, e.g. in Kubernetes device plugins. By using the same
+`hostPath` mounts for `/etc/kubernetes/node-feature-discovery/source.d/` and
+`/etc/kubernetes/node-feature-discovery/features.d/` in the side-car (e.g.
+device plugin) creates a shared area for deploying hooks and feature files to
+NFD. NFD will periodically scan the directories and run any hooks and read any
+feature files it finds.
+
+## Custom feature source
+
+The `custom` feature source in nfd-worker provides a rule-based mechanism for
+label creation, similar to the
+[`NodeFeatureRule`](#nodefeaturerule-custom-resource) objects. The difference is
+that the rules are specified in the worker configuration instead of a
+Kubernetes API object.
+
+See [worker configuration](deployment-and-usage.md#worker-configuration) for
+instructions how to set-up and manage the worker configuration.
+
+### An example custom feature source configuration
+
+Consider the following referential configuration for nfd-worker:
+
+```yaml
+core:
+  labelSources: ["custom"]
+sources:
+  custom:
+    - name: "my sample rule"
+      labels:
+        "my-sample-feature": "true"
+      matchFeatures:
+        - feature: kernel.loadedmodule
+          matchExpressions:
+            dummy: {op: Exists}
+        - feature: kernel.config
+          matchExpressions:
+            X86: {op: In, value: ["y"]}
+```
+
+It specifies one rule which creates node label
+`feature.node.kubenernetes.io/my-sample-feature=true` if both of the following
+conditions are true (`matchFeatures` implements a logical AND over the
+matchers):
+
+- The `dummy` network driver module has been loaded
+- X86 option in kernel config is set to `=y`
+
+In addition, the configuration only enables the `custom` source, disabling all
+built-in labels.
+
+Now, on X86 platforms the feature label appears after doing `modprobe dummy` on
+a system and correspondingly the label is removed after `rmmod dummy`. Note a
+re-labeling delay up to the sleep-interval of nfd-worker (1 minute by default).
+
+### Additional configuration directory
+
+In addition to the rules defined in the nfd-worker configuration file, the
+`custom` feature source can read more configuration files located in the
+`/etc/kubernetes/node-feature-discovery/custom.d/` directory. This makes more
+dynamic and flexible configuration easier.
+
+As an example, consider having file
+`/etc/kubernetes/node-feature-discovery/custom.d/my-rule.yaml` with the
+following content:
+
+```yaml
+- name: "my e1000 rule"
+  labels:
+    "e1000.present": "true"
+  matchFeatures:
+    - feature: kernel.loadedmodule
+      matchExpressions:
+        e1000: {op: Exists}
+```
+
+This simple rule will create `feature.node.kubenernetes.io/e1000.present=true`
+label if the `e1000` kernel module has been loaded.
+
+The
+[`samples/custom-rules`](https://github.com/kubernetes-sigs/node-feature-discovery/blob/{{site.release}}/deployment/overlays/samples/custom-rules)
+kustomize overlay sample contains an example for deploying a custom rule from a
+ConfigMap.
+
+## Node labels
+
+Feature labels have the following format:
+
+```plaintext
+<namespace>/<name> = <value>
+```
+
+The namespace part (i.e. prefix) of the labels is controlled by nfd:
+
+- All built-in labels use `feature.node.kubernetes.io`. This is also
+  the default for user defined features that don't specify any namespace.
+- User-defined labels are allowed to use:
+  - `feature.node.kubernetes.io` and `profile.node.kubernetes.io` plus their
+    sub-namespaces (e.g. `vendor.profile.node.kubernetes.io` and
+    `sub.ns.profile.node.kubernetes.io`) by default
+  - Additional namespaces may be enabled with the
+    [`-extra-label-ns`](../advanced/master-commandline-reference#-extra-label-ns)
+    command line flag of nfd-master
+
+## Label rule format
+
+This section describes the rule format used  in
+[`NodeFeatureRule`](#nodefeaturerule-custom-resource) objects and in the
+configuration of the [`custom`](#custom-feature-source) feature source.
+
+It is based on a generic feature matcher that covers all features discovered by
+nfd-worker. The rules rely on a unified data model of the available features
+and a generic expression-based format. Features that can be used in the rules
+are described in detail in [available features](#available-features) below.
+
+Take this rule as a referential example:
+
+```yaml
+    - name: "my feature rule"
+      labels:
+        "my-special-feature": "my-value"
+      matchFeatures:
+        - feature: cpu.cpuid
+          matchExpressions:
+            AVX512F: {op: Exists}
+        - feature: kernel.version
+          matchExpressions:
+            major: {op: In, value: ["5"]}
+            minor: {op: Gt, value: ["1"]}
+        - feature: pci.device
+          matchExpressions:
+            vendor: {op: In, value: ["8086"]}
+            class: {op: In, value: ["0200"]}
+```
+
+This will yield `feature.node.kubenernetes.io/my-special-feature=my-value` node
+label if all of these are true (`matchFeatures` implements a logical AND over
+the matchers):
+
+- the CPU has AVX512F capability
+- kernel version is 5.2 or later (must be v5.x)
+- an Intel network controller is present
+
+### Fields
+
+#### Name
+
+The `.name` field is required and used as an identifier of the rule.
+
+#### Labels
+
+The `.labels` is a map of the node labels to create if the rule matches.
+
+#### Labels template
+
+The `.labelsTemplate` field specifies a text template for dynamically creating
+labels based on the matched features. See [templating](#templating) for
+details.
+
+**NOTE** The `labels` field has priority over `labelsTemplate`, i.e.
+labels specified in the `labels` field will override anything
+originating from `labelsTemplate`.
+
+#### Vars
+
+The `.vars` field is a map of values (key-value pairs) to store for subsequent
+rules to use. In other words, these are variables that are not advertised as
+node labels. See [backreferences](#backreferences) for more details on the
+usage of vars.
+
+#### Vars template
+
+The `.varsTemplate` field specifies a text template for dynamically creating
+vars based on the matched features. See [templating](#templating) for details
+on using templates and [backreferences](#backreferences) for more details on
+the usage of vars.
+
+**NOTE** The `vars` field has priority over `varsTemplate`, i.e.
+vars specified in the `vars` field will override anything originating from
+`varsTemplate`.
+
+#### MatchFeatures
+
+The `.matchFeatures` field specifies a feature matcher, consisting of a list of
+feature matcher terms. It implements a logical AND over the terms i.e. all
+of them must match in order for the rule to trigger.
+
+```yaml
+      matchFeatures:
+        - feature: <feature-name>
+          matchExpressions:
+            <key>:
+              op: <op>
+              value:
+                - <value-1>
+                - ...
+```
+
+The `.matchFeatures[].feature` field specifies the feature against which to
+match.
+
+The `.matchFeatures[].matchExpressions` field specifies a map of expressions
+which to evaluate against the elements of the feature.
+
+In each MatchExpression `op` specifies the operator to apply. Valid values are
+described below.
+
+| Operator        | Number of values | Matches when
+| --------------- | ---------------- | -----------
+|  `In`           | 1 or greater | Input is equal to one of the values
+|  `NotIn`        | 1 or greater | Input is not equal to any of the values
+|  `InRegexp`     | 1 or greater | Values of the MatchExpression are treated as regexps and input matches one or more of them
+|  `Exists`       | 0            | The key exists
+|  `DoesNotExist` | 0            | The key does not exists
+|  `Gt`           | 1            | Input is greater than the value. Both the input and value must be integer numbers.
+|  `Lt`           | 1            | Input is less than the value. Both the input and value must be integer numbers.
+|  `GtLt`         | 2            | Input is between two values. Both the input and value must be integer numbers.
+|  `IsTrue`       | 0            | Input is equal to "true"
+|  `IsFalse`      | 0            | Input is equal "false"
+
+The `value` field of MatchExpression is a list of string arguments to the
+operator.
+
+The behavior of MatchExpression depends on the [feature type](#feature-types):
+for *flag* and *attribute* features the MatchExpression operates on the feature
+element whose name matches the `<key>`. However, for *instance* features all
+MatchExpressions are evaluated against the attributes of each instance
+separately.
+
+A special case of an empty `matchExpressions` field matches everything, i.e.
+matches/returns all elements of the feature. This makes it possible to write
+[templates](#templating) that run over all discovered features.
+
+#### MatchAny
+
+The `.matchAny` field is a list of of [`matchFeatures`](#matchfeatures)
+matchers. A logical OR is applied over the matchers, i.e. at least one of them
+must match in order for the rule to trigger.
+
+Consider the following example:
+
+```yaml
+      matchAny:
+        - matchFeatures:
+            - feature: kernel.loadedmodule
+              matchExpressions:
+                kmod-1: {op: Exists}
+            - feature: pci.device
+              matchExpressions:
+                vendor: {op: In, value: ["0eee"]}
+                class: {op: In, value: ["0200"]}
+        - matchFeatures:
+            - feature: kernel.loadedmodule
+              matchExpressions:
+                kmod-2: {op: Exists}
+            - feature: pci.device
+              matchExpressions:
+                vendor: {op: In, value: ["0fff"]}
+                class: {op: In, value: ["0200"]}
+```
+
+This matches if kernel module kmod-1 is loaded and a network controller from
+vendor 0eee is present, OR, if kernel module kmod-2 has been loaded and a
+network controller from vendor 0fff is present (OR both of these conditions are
+true).
+
+### Available features
+
+#### Feature types
+
+Features are divided into three different types:
+
+- **flag** features: a set of names without any associated values, e.g. CPUID
+  flags or loaded kernel modules
+- **attribute** features: a set of names each of which has a single value
+  associated with it (essentially a map of key-value pairs), e.g. kernel config
+  flags or os release information
+- **instance** features: a list of instances, each of which has multiple
+  attributes (key-value pairs of their own) associated with it, e.g. PCI or USB
+  devices
+
+#### List of features
+
+The following features are available for matching:
+
+| Feature          | Feature type | Elements | Value type | Description
+| ---------------- | ------------ | -------- | ---------- | -----------
+| **`cpu.cpuid`**  | flag         |          |            | Supported CPU capabilities
+|                  |              | **`<cpuid-flag>`** |  | CPUID flag is present
+| **`cpu.cstate`** | attribute    |          |            | Status of cstates in the intel_idle cpuidle driver
+|                  |              | **`enabled`** | bool  | 'true' if cstates are set, otherwise 'false'. Does not exist of intel_idle driver is not active.
+| **`cpu.pstate`** | attribute    |          |            | State of the Intel pstate driver. Does not exist if the driver is not enabled.
+|                  |              | **`status`** | string | Status of the driver, possible values are 'active' and 'passive'
+|                  |              | **`turbo`**  | bool   | 'true' if turbo frequencies are enabled, otherwise 'false'
+|                  |              | **`scaling`** | string | Active scaling_governor, possible values are 'powersave' or 'performance'.
+| **`cpu.rdt`**    | flag         |          |            | Intel RDT capabilities supported by the system
+|                  |              | **`<rdt-flag>`** |    | RDT capability is supported, see [RDT flags](../get-started/features#intel-rdt-flags) for details
+| **`cpu.sgx`**    | attribute    |          |            | Intel SGX (Software Guard Extensions) capabilities
+|                  |              | **`enabled`** | bool  | `true` if Intel SGX has been enabled, otherwise does not exist
+| **`cpu.sst`**    | attribute    |          |            | Intel SST (Speed Select Technology) capabilities
+|                  |              | **`bf.enabled`** | bool | `true` if Intel SST-BF (Intel Speed Select Technology - Base frequency) has been enabled, otherwise does not exist
+| **`cpu.topology`** | attribute  |          |            | CPU topology related features
+| | |          **`hardware_multithreading`** | bool       | Hardware multithreading, such as Intel HTT, is enabled
+| **`kernel.config`** | attribute |          |            | Kernel configuration options
+|                  |              | **`<config-flag>`** | string | Value of the kconfig option
+| **`kernel.loadedmodule`** | flag |         |            | Loaded kernel modules
+|                  |              | **`mod-name`** |      | Kernel module `<mod-name>` is loaded
+| **`kernel.selinux`** | attribute |         |            | Kernel SELinux related features
+|                  |              | **`enabled`** | bool  | `true` if SELinux has been enabled and is in enforcing mode, otherwise `false`
+| **`kernel.version`** | attribute |          |           | Kernel version information
+|                  |              | **`full`** | string   | Full kernel version (e.g. ‘4.5.6-7-g123abcde')
+|                  |              | **`major`** | int     | First component of the kernel version (e.g. ‘4')
+|                  |              | **`minor`** | int     | Second component of the kernel version (e.g. ‘5')
+|                  |              | **`revision`** | int  | Third component of the kernel version (e.g. ‘6')
+| **`local.label`** | attribute   |           |           | Features from hooks and feature files, i.e. labels from the [*local* feature source](#local-feature-source)
+|                  |              | **`<label-name>`** | string | Label `<label-name>` created by the local feature source, value equals the value of the label
+| **`memory.nv`**  | instance     |          |            | NVDIMM devices present in the system
+|                  |              | **`<sysfs-attribute>`** | string | Value of the sysfs device attribute, available attributes: `devtype`, `mode`
+| **`memory.numa`**  | attribute  |          |            | NUMA nodes
+|                  |              | **`is_numa`** | bool  | `true` if NUMA architecture, `false` otherwise
+|                  |              | **`node_count`** | int | Number of NUMA nodes
+| **`network.device`** | instance |          |            | Physical (non-virtual) network interfaces present in the system
+|                  |              | **`<sysfs-attribute>`** | string | Sysfs network interface attribute, available attributes: `name`, `operstate`, `speed`, `sriov_numvfs`, `sriov_totalvfs`
+| **`pci.device`** | instance     |          |            | PCI devices present in the system
+|                  |              | **`<sysfs-attribute>`** | string | Value of the sysfs device attribute, available attributes: `class`, `vendor`, `device`, `subsystem_vendor`, `subsystem_device`, `sriov_totalvfs`
+| **`storage.device`** | instance |          |            | Block storage devices present in the system
+|                  |              | **`<sysfs-attribute>`** | string | Sysfs network interface attribute, available attributes: `name`, `dax`, `rotational`, `nr_zones`, `zoned`
+| **`system.osrelease`** | attribute |          |            | System identification data from `/etc/os-release`
+|                  |              | **`<parameter>`** | string | One parameter from `/etc/os-release`
+| **`system.name`** | attribute   |          |            | System name information
+|                  |              | **`nodename`** | string | Name of the kubernetes node object
+| **`usb.device`** | instance     |          |            | USB devices present in the system
+|                  |              | **`<sysfs-attribute>`** | string | Value of the sysfs device attribute, available attributes: `class`, `vendor`, `device`, `serial`
+| **`rule.matched`** | attribute  |          |            | Previously matched rules
+|                  |              | **`<label-or-var>`** | string | Label or var from a preceding rule that matched
+
+### Templating
+
+Rules support template-based creation of labels and vars with the
+`.labelsTemplate` and `.varsTemplate` fields. These makes it possible to
+dynamically generate labels and vars based on the features that matched.
+
+The template must expand into a simple format with `<key>=<value>` pairs
+separated by newline.
+
+Consider the following example:
+<!-- {% raw %} -->
+
+```yaml
+    labelsTemplate: |
+      {{ range .pci.device }}vendor-{{ .class }}-{{ .device }}.present=true
+      {{ end }}
+    matchFeatures:
+      - feature: pci.device
+        matchExpressions:
+          class: {op: InRegexp, value: ["^02"]}
+          vendor: ["0fff"]
+```
+
+<!-- {% endraw %} -->
+The rule above will create individual labels
+`feature.node.kubernetes.io/vendor-<class-id>-<device-id>.present=true` for
+each network controller device (device class starting with 02) from vendor
+0ffff.
+
+All the matched features of each feature matcher term under `matchFeatures`
+fields are available for the template engine. Matched features can be
+referenced with `{%raw%}{{ .<feature-name> }}{%endraw%}` in the template, and
+the available data could be described in yaml as follows:
+
+```yaml
+.
+  <key-feature>:
+    - Name: <matched-key>
+    - ...
+
+  <value-feature>:
+    - Name: <matched-key>
+      Value: <matched-value>
+    - ...
+
+  <instance-feature>:
+    - <attribute-1-name>: <attribute-1-value>
+      <attribute-2-name>: <attribute-2-value>
+      ...
+    - ...
+```
+
+That is, the per-feature data is a list of objects whose data fields depend on
+the type of the feature:
+
+- for *flag* features only 'Name' is available
+- for *value* features 'Name' and 'Value' are available
+- for *instance* features all attributes of the matched instance are available
+
+A simple example of a template utilizing name and value from an *attribute*
+feature:
+<!-- {% raw %} -->
+
+```yaml
+    labelsTemplate: |
+      {{ range .system.osrelease }}system-{{ .Name }}={{ .Value }}
+      {{ end }}
+    matchFeatures:
+      - feature: system.osRelease
+        matchExpressions:
+          ID: {op: Exists}
+          VERSION_ID.major: {op: Exists}
+```
+
+<!-- {% endraw %} -->
+**NOTE** In case of matchAny is specified, the template is executed separately
+against each individual `matchFeatures` field and the final set of labels will
+be superset of all these separate template expansions. E.g. consider the
+following:
+
+```yaml
+  - name: <name>
+    labelsTemplate: <template>
+    matchFeatures: <matcher#1>
+    matchAny:
+      - matchFeatures: <matcher#2>
+      - matchFeatures: <matcher#3>
+```
+
+In the example above (assuming the overall result is a match) the template
+would be executed on matcher#1 as well as on matcher#2 and/or matcher#3
+(depending on whether both or only one of them match). All the labels from
+these separate expansions would be created, i.e. the end result would be a
+union of all the individual expansions.
+
+A special case of an empty `matchExpressions` field matches everything, i.e.
+matches/returns all elements of the feature. This makes it possible to write
+[templates](#templating) that run over all discovered features.
+
+Consider the following example:
+<!-- {% raw %} -->
+
+```yaml
+    labelsTemplate: |
+      {{ range .network.device }}net-{{ .name }}.speed-mbps={{ .speed }}
+      {{ end }}
+    matchFeatures:
+      - feature: network.device
+        matchExpressions: null
+```
+
+<!-- {% endraw %} -->
+This will create individual
+`feature.node.kubernetes.io/net-<if-name>.speed-mbpx=<speed-in-mbps>` label for
+each (physical) network device of the system.
+
+Rule templates use the Golang [text/template](https://pkg.go.dev/text/template)
+package and all its built-in functionality (e.g. pipelines and functions) can
+be used. An example template taking use of the built-in `len` function,
+advertising the number of PCI network controllers from a specific vendor:
+<!-- {% raw %} -->
+
+```yaml
+    labelsTemplate: |
+      num-intel-network-controllers={{ .pci.device | len }}
+    matchFeatures:
+      - feature: pci.device
+        matchExpressions:
+          vendor: {op: In, value: ["8086"]}
+          class: {op: In, value: ["0200"]}
+
+```
+
+<!-- {% endraw %} -->
+Imaginative template pipelines are possible, but care must be taken in order to
+produce understandable and maintainable rule sets.
+
+### Backreferences
+
+Rules support referencing the output of preceding rules. This enables
+sophisticated scenarios where multiple rules are combined together
+to for more complex heuristics than a single rule can provide. The labels and
+vars created by the execution of preceding rules are available as a special
+`rule.matched` feature.
+
+Consider the following configuration:
+
+```yaml
+  - name: "my kernel label rule"
+    labels:
+      kernel-feature: "true"
+    matchFeatures:
+      - feature: kernel.version
+        matchExpressions:
+          major: {op: Gt, value: ["4"]}
+
+  - name: "my var rule"
+    vars:
+      nolabel-feature: "true"
+    matchFeatures:
+      - feature: cpu.cpuid
+        matchExpressions:
+          AVX512F: {op: Exists}
+      - feature: pci.device
+        matchExpressions:
+          vendor: {op: In, value: ["0fff"]}
+          device: {op: In, value: ["1234", "1235"]}
+
+  - name: "my high level feature rule"
+    labels:
+      high-level-feature: "true"
+    matchFeatures:
+      - feature: rule.matched
+        matchExpressions:
+          kernel-feature: {op: IsTrue}
+          nolabel-feature: {op: IsTrue}
+```
+
+The `feature.node.kubernetes.io/high-level-feature = true` label depends on thw
+two previous rules.
+
+Note that when referencing rules accross multiple
+[`NodeFeatureRule`](#nodefeaturerule-custom-resource) objects attention must be
+paid to the ordering. `NodeFeatureRule` objects are processed in alphabetical
+order (based on their `.metadata.name`).
+
+### Examples
+
+Some more configuration examples below.
+
+Match certain CPUID features:
+
+```yaml
+  - name: "example cpuid rule"
+    labels:
+      my-special-cpu-feature: "true"
+    matchFeatures:
+      - feature: cpu.cpuid
+        matchExpressions:
+          AESNI: {op: Exists}
+          AVX: {op: Exists}
+```
+
+Require a certain loaded kernel module and OS version:
+
+```yaml
+  - name: "my multi-feature rule"
+    labels:
+      my-special-multi-feature: "true"
+    matchFeatures:
+      - feature: kernel.loadedmodule
+        matchExpressions:
+          e1000: {op: Exists}
+      - feature: system.osrelease
+        matchExpressions:
+          NAME: {op: InRegexp, values: ["^openSUSE"]}
+          VERSION_ID.major: {op: Gt, values: ["14"]}
+```
+
+Require a loaded  kernel module and two specific PCI devices (both of which
+must be present):
+
+```yaml
+  - name: "my multi-device rule"
+    labels:
+      my-multi-device-feature: "true"
+    matchFeatures:
+      - feature: kernel.loadedmodule
+        matchExpressions:
+          my-driver-module: {op: Exists}
+      - pci.device:
+          vendor: "0fff"
+          device: "1234"
+      - pci.device:
+          vendor: "0fff"
+          device: "abcd"
+```
+
+## Legacy custom rule syntax
+
+**DEPRECATED**: use the new rule syntax instead.
+
+The `custom` source supports the legacy `matchOn` rule syntax for
+backwards-compatibility.
+
+To aid in making the legacy rule syntax clearer, we define a general and a per
+rule nomenclature, keeping things as consistent as possible.
+
+### General nomenclature and definitions
+
+```plaintext
+Rule        :Represents a matching logic that is used to match on a feature.
+Rule Input  :The input a Rule is provided. This determines how a Rule performs the match operation.
+Matcher     :A composition of Rules, each Matcher may be composed of at most one instance of each Rule.
+```
+
+### Custom features format (using the nomenclature defined above)
+
+Rules are specified under `sources.custom` in the nfd-worker configuration
+file.
+
+```yaml
+sources:
+  custom:
+  - name: <feature name>
+    value: <optional feature value, defaults to "true">
+    matchOn:
+    - <Rule-1>: <Rule-1 Input>
+      [<Rule-2>: <Rule-2 Input>]
+    - <Matcher-2>
+    - ...
+    - ...
+    - <Matcher-N>
+  - <custom feature 2>
+  - ...
+  - ...
+  - <custom feature M>
+```
+
+The label is constructed by adding `custom-` prefix to the name field, label
+value defaults to `true` if not specified in the rule spec:
+
+```plaintext
+feature.node.kubernetes.io/custom-<name> = <value>
+```
+
+### Matching process
+
+Specifying Rules to match on a feature is done by providing a list of Matchers.
+Each Matcher contains one or more Rules.
+
+Logical _OR_ is performed between Matchers and logical _AND_ is performed
+between Rules of a given Matcher.
+
+### Rules
+
+#### pciid rule
+
+##### Nomenclature
+
+```plaintext
+Attribute   :A PCI attribute.
+Element     :An identifier of the PCI attribute.
+```
+
+The PciId Rule allows matching the PCI devices in the system on the following
+Attributes: `class`,`vendor` and `device`. A list of Elements is provided for
+each Attribute.
+
+##### Format
+
+```yaml
+pciId :
+  class: [<class id>, ...]
+  vendor: [<vendor id>,  ...]
+  device: [<device id>, ...]
+```
+
+Matching is done by performing a logical _OR_ between Elements of an Attribute
+and logical _AND_ between the specified Attributes for each PCI device in the
+system.  At least one Attribute must be specified. Missing attributes will not
+partake in the matching process.
+
+#### UsbId rule
+
+##### Nomenclature
+
+```plaintext
+Attribute   :A USB attribute.
+Element     :An identifier of the USB attribute.
+```
+
+The UsbId Rule allows matching the USB devices in the system on the following
+Attributes: `class`,`vendor`, `device` and `serial`. A list of Elements is
+provided for each Attribute.
+
+##### Format
+
+```yaml
+usbId :
+  class: [<class id>, ...]
+  vendor: [<vendor id>,  ...]
+  device: [<device id>, ...]
+  serial: [<serial>, ...]
+```
+
+Matching is done by performing a logical _OR_ between Elements of an Attribute
+and logical _AND_ between the specified Attributes for each USB device in the
+system.  At least one Attribute must be specified. Missing attributes will not
+partake in the matching process.
+
+#### LoadedKMod rule
+
+##### Nomenclature
+
+```plaintext
+Element     :A kernel module
+```
+
+The LoadedKMod Rule allows matching the loaded kernel modules in the system
+against a provided list of Elements.
+
+##### Format
+
+```yaml
+loadedKMod : [<kernel module>, ...]
+```
+
+Matching is done by performing logical _AND_ for each provided Element, i.e
+the Rule will match if all provided Elements (kernel modules) are loaded in the
+system.
+
+#### CpuId rule
+
+##### Nomenclature
+
+```plaintext
+Element     :A CPUID flag
+```
+
+The Rule allows matching the available CPUID flags in the system against a
+provided list of Elements.
+
+##### Format
+
+```yaml
+cpuId : [<CPUID flag string>, ...]
+```
+
+Matching is done by performing logical _AND_ for each provided Element, i.e the
+Rule will match if all provided Elements (CPUID flag strings) are available in
+the system.
+
+#### Kconfig rule
+
+##### Nomenclature
+
+```plaintext
+Element     :A Kconfig option
+```
+
+The Rule allows matching the kconfig options in the system against a provided
+list of Elements.
+
+##### Format
+
+```yaml
+kConfig: [<kernel config option ('y' or 'm') or '=<value>'>, ...]
+```
+
+Matching is done by performing logical _AND_ for each provided Element, i.e the
+Rule will match if all provided Elements (kernel config options) are enabled
+(`y` or `m`) or matching `=<value>` in the kernel.
+
+#### Nodename rule
+
+##### Nomenclature
+
+```plaintext
+Element     :A nodename regexp pattern
+```
+
+The Rule allows matching the node's name against a provided list of Elements.
+
+##### Format
+
+```yaml
+nodename: [ <nodename regexp pattern>, ... ]
+```
+
+Matching is done by performing logical _OR_ for each provided Element, i.e the
+Rule will match if one of the provided Elements (nodename regexp pattern)
+matches the node's name.
+
+### Legacy custom rule example
+
+```yaml
+custom:
+  - name: "my.kernel.feature"
+    matchOn:
+      - loadedKMod: ["kmod1", "kmod2"]
+  - name: "my.pci.feature"
+    matchOn:
+      - pciId:
+          vendor: ["15b3"]
+          device: ["1014", "1017"]
+  - name: "my.usb.feature"
+    matchOn:
+      - usbId:
+          vendor: ["1d6b"]
+          device: ["0003"]
+          serial: ["090129a"]
+  - name: "my.combined.feature"
+    matchOn:
+      - loadedKMod : ["vendor_kmod1", "vendor_kmod2"]
+        pciId:
+          vendor: ["15b3"]
+          device: ["1014", "1017"]
+  - name: "vendor.feature.node.kubernetes.io/accumulated.feature"
+    matchOn:
+      - loadedKMod : ["some_kmod1", "some_kmod2"]
+      - pciId:
+          vendor: ["15b3"]
+          device: ["1014", "1017"]
+  - name: "my.kernel.featureneedscpu"
+    matchOn:
+      - kConfig: ["KVM_INTEL"]
+      - cpuId: ["VMX"]
+  - name: "my.kernel.modulecompiler"
+    matchOn:
+      - kConfig: ["GCC_VERSION=100101"]
+        loadedKMod: ["kmod1"]
+  - name: "profile.node.kubernetes.io/my-datacenter"
+    value: "datacenter-1"
+    matchOn:
+      - nodename: [ "node-datacenter1-rack.*-server.*" ]
+```
+
+__In the example above:__
+
+- A node would contain the label:
+  `feature.node.kubernetes.io/custom-my.kernel.feature=true` if the node has
+  `kmod1` _AND_ `kmod2` kernel modules loaded.
+- A node would contain the label:
+  `feature.node.kubernetes.io/custom-my.pci.feature=true` if the node contains
+  a PCI device with a PCI vendor ID of `15b3` _AND_ PCI device ID of `1014` _OR_
+  `1017`.
+- A node would contain the label:
+  `feature.node.kubernetes.io/custom-my.usb.feature=true` if the node contains
+  a USB device with a USB vendor ID of `1d6b` _AND_ USB device ID of `0003`.
+- A node would contain the label:
+  `feature.node.kubernetes.io/custom-my.combined.feature=true` if
+  `vendor_kmod1` _AND_ `vendor_kmod2` kernel modules are loaded __AND__ the node
+  contains a PCI device
+  with a PCI vendor ID of `15b3` _AND_ PCI device ID of `1014` _or_ `1017`.
+- A node would contain the label:
+  `vendor.feature.node.kubernetes.io/accumulated.feature=true` if
+  `some_kmod1` _AND_ `some_kmod2` kernel modules are loaded __OR__ the node
+  contains a PCI device
+  with a PCI vendor ID of `15b3` _AND_ PCI device ID of `1014` _OR_ `1017`.
+- A node would contain the label:
+  `feature.node.kubernetes.io/custom-my.kernel.featureneedscpu=true` if
+  `KVM_INTEL` kernel config is enabled __AND__ the node CPU supports `VMX`
+  virtual machine extensions
+- A node would contain the label:
+  `feature.node.kubernetes.io/custom-my.kernel.modulecompiler=true` if the
+  in-tree `kmod1` kernel module is loaded __AND__ it's built with
+  `GCC_VERSION=100101`.
+- A node would contain the label:
+  `profile.node.kubernetes.io/my-datacenter=datacenter-1` if the node's name
+  matches the `node-datacenter1-rack.*-server.*` pattern, e.g.
+  `node-datacenter1-rack2-server42`
+
 

--- a/docs/get-started/features.md
+++ b/docs/get-started/features.md
@@ -1,10 +1,10 @@
 ---
-title: "Feature discovery"
+title: "Feature labels"
 layout: default
 sort: 4
 ---
 
-# Feature discovery
+# Feature labels
 {: .no_toc}
 
 ## Table of contents
@@ -15,100 +15,68 @@ sort: 4
 
 ---
 
-Feature discovery in nfd-worker is performed by a set of separate modules
-called feature sources. Most of them are specifically responsible for certain
-domain of features (e.g. cpu). In addition there are two highly customizable
-feature sources that work accross the system.
+Features are advertised as labels in the Kubernetes Node object.
 
-## Feature labels
+## Built-in labels
 
-Each discovered feature is advertised a label in the Kubernetes Node object.
-The published node labels encode a few pieces of information:
+Label creation in nfd-worker is performed by a set of separate modules called
+label sources. The
+[`core.labelSources`](../advanced/worker-configuration-reference#corelabelsources)
+configuration option (or
+[`-label-sources`](../advanced/worker-commandline-reference#-label-sources)
+flag) of nfd-worker controls which sources to enable for label generation.
 
-- Namespace
-  - all built-in labels use `feature.node.kubernetes.io`
-  - user-specified custom labels ([custom](#custom) and
-    [local](#local--user-specific-features) feature sources)
-    - `feature.node.kubernetes.io` and `profile.node.kubernetes.io` plus their
-      sub-namespaces (e.g. `vendor.profile.node.kubernetes.io` and
-      `sub.ns.profile.node.kubernetes.io`) are allowed by default
-    - additional namespaces may be enabled with the
-      [`-extra-label-ns`](../advanced/master-commandline-reference#-extra-label-ns)
-      command line flag of nfd-master
-- The source for each label (e.g. `cpu`).
-- The name of the discovered feature as it appears in the underlying
-  source, (e.g. `cpuid.AESNI` from cpu).
-- The value of the discovered feature.
-
-Feature label names adhere to the following pattern:
+All built-in labels use the `feature.node.kubernetes.io` label namespace and
+have the following format.
 
 ```plaintext
-<namespace>/<source name>-<feature name>[.<attribute name>]
+feature.node.kubernetes.io/<feature> = <value>
 ```
-
-The last component (i.e. `attribute-name`) is optional, and only used if a
-feature logically has sub-hierarchy, e.g. `sriov.capable` and
-`sriov.configure` from the `network` source.
-
-The `-label-sources` flag controls which sources to enable for label
-generation.
 
 *Note: Consecutive runs of nfd-worker will update the labels on a
 given node. If features are not discovered on a consecutive run, the corresponding
 label will be removed. This includes any restrictions placed on the consecutive run,
 such as restricting discovered features with the -label-whitelist option.*
 
-## Feature sources
-
 ### CPU
 
-The **cpu** feature source supports the following labels:
+| Feature name            | Value        | Description
+| ----------------------- | ------------ | -----------
+| **`cpu-cpuid.<cpuid-flag>`**      | true   | CPU capability is supported. **NOTE:** the capability might be supported but not enabled.
+| **`cpu-hardware_multithreading`** | true   | Hardware multithreading, such as Intel HTT, enabled (number of logical CPUs is greater than physical CPUs)
+| **`cpu-power.sst_bf.enabled`**    | true   | Intel SST-BF ([Intel Speed Select Technology][intel-sst] - Base frequency) enabled
+| **`cpu-pstate.status`**           | string | The status of the [Intel pstate][intel-pstate] driver when in use and enabled, either 'active' or 'passive'.
+| **`cpu-pstate.turbo`**            | bool   | Set to 'true' if turbo frequencies are enabled in Intel pstate driver, set to 'false' if they have been disabled.
+| **`cpu-pstate.scaling_governor`** | string | The value of the Intel pstate scaling_governor when in use, either 'powersave' or 'performance'.
+| **`cpu-cstate.enabled`**          | bool   | Set to 'true' if cstates are set in the intel_idle driver, otherwise set to 'false'. Unset if intel_idle cpuidle driver is not active.
+| **`cpu-rdt.<rdt-flag>`**          | true   | [Intel RDT][intel-rdt] capability is supported. See [RDT flags](#intel-rdt-flags) for details.
+| **`cpu-sgx.enabled`**             | true   | Set to 'true' if Intel SGX is enabled in BIOS (based a non-zero sum value of SGX EPC section sizes).
 
-| Feature name            | Attribute          | Description                   |
-| ----------------------- | ------------------ | ----------------------------- |
-| cpuid                   | &lt;cpuid flag&gt; | CPU capability is supported
-| hardware_multithreading |                    | Hardware multithreading, such as Intel HTT, enabled (number of logical CPUs is greater than physical CPUs)
-| power                   | sst_bf.enabled     | Intel SST-BF ([Intel Speed Select Technology][intel-sst] - Base frequency) enabled
-| [pstate][intel-pstate]  | status             | The status of the Intel pstate driver when in use and enabled, either 'active' or 'passive'.
-|                         | turbo              | Set to 'true' if turbo frequencies are enabled in Intel pstate driver, set to 'false' if they have been disabled.
-|                         | scaling_governor   | The value of the Intel pstate scaling_governor when in use, either 'powersave' or 'performance'.
-| cstate                  | enabled            | Set to 'true' if cstates are set in the intel_idle driver, otherwise set to 'false'. Unset if intel_idle cpuidle driver is not active.
-| [rdt][intel-rdt]        | RDTMON             | Intel RDT Monitoring Technology
-|                         | RDTCMT             | Intel Cache Monitoring (CMT)
-|                         | RDTMBM             | Intel Memory Bandwidth Monitoring (MBM)
-|                         | RDTL3CA            | Intel L3 Cache Allocation Technology
-|                         | RDTL2CA            | Intel L2 Cache Allocation Technology
-|                         | RDTMBA             | Intel Memory Bandwidth Allocation (MBA) Technology
-| sgx                     | enabled            | Set to 'true' if Intel SGX is enabled in BIOS (based a non-zero sum value of SGX EPC section sizes).
+The CPU label source is configurable, see
+[worker configuration](deployment-and-usage#worker-configuration) and
+[`sources.cpu`](../advanced/worker-configuration-reference#sourcescpu)
+configuration options for details.
 
-The (sub-)set of CPUID attributes to publish is configurable via the
-`attributeBlacklist` and `attributeWhitelist` cpuid options of the cpu source.
-If whitelist is specified, only whitelisted attributes will be published. With
-blacklist, only blacklisted attributes are filtered out. `attributeWhitelist`
-has priority over `attributeBlacklist`.  For examples and more information
-about configurability, see
-[configuration](deployment-and-usage#worker-configuration).
-By default, the following CPUID flags have been blacklisted:
-BMI1, BMI2, CLMUL, CMOV, CX16, ERMS, F16C, HTT, LZCNT, MMX, MMXEXT, NX, POPCNT,
-RDRAND, RDSEED, RDTSCP, SGX, SSE, SSE2, SSE3, SSE4, SSE42 and SSSE3.
+#### X86 CPUID flags (partial list)
 
-**NOTE** The cpuid features advertise *supported* CPU capabilities, that is, a
-capability might be supported but not enabled.
-
-#### X86 CPUID attributes (partial list)
-
-| Attribute | Description                                                      |
+| Flag      | Description                                                      |
 | --------- | ---------------------------------------------------------------- |
 | ADX       | Multi-Precision Add-Carry Instruction Extensions (ADX)
 | AESNI     | Advanced Encryption Standard (AES) New Instructions (AES-NI)
 | AVX       | Advanced Vector Extensions (AVX)
 | AVX2      | Advanced Vector Extensions 2 (AVX2)
 
+By default, the following CPUID flags have been blacklisted: BMI1, BMI2, CLMUL,
+CMOV, CX16, ERMS, F16C, HTT, LZCNT, MMX, MMXEXT, NX, POPCNT, RDRAND, RDSEED,
+RDTSCP, SGX, SSE, SSE2, SSE3, SSE4, SSE42 and SSSE3. See
+[`sources.cpu`](../advanced/worker-configuration-reference#sourcescpu)
+configuration options to change the behavior.
+
 See the full list in [github.com/klauspost/cpuid][klauspost-cpuid].
 
-#### Arm CPUID attribute (partial list)
+#### Arm CPUID flags (partial list)
 
-| Attribute | Description                                                      |
+| Flag      | Description                                                      |
 | --------- | ---------------------------------------------------------------- |
 | IDIVA     | Integer divide instructions available in ARM mode
 | IDIVT     | Integer divide instructions available in Thumb mode
@@ -123,9 +91,9 @@ See the full list in [github.com/klauspost/cpuid][klauspost-cpuid].
 | NEON      | NEON SIMD instructions
 | LPAE      | Large Physical Address Extensions
 
-#### Arm64 CPUID attribute (partial list)
+#### Arm64 CPUID flags (partial list)
 
-| Attribute | Description                                                      |
+| Flag      | Description                                                      |
 | --------- | ---------------------------------------------------------------- |
 | AES       | Announcing the Advanced Encryption Standard
 | EVSTRM    | Event Stream Frequency Features
@@ -137,521 +105,113 @@ See the full list in [github.com/klauspost/cpuid][klauspost-cpuid].
 | JSCVT     | Perform Conversion to Match Javascript
 | DCPOP     | Persistent Memory Support
 
-### Custom
+#### Intel RDT flags
 
-The Custom feature source allows the user to define features based on a mix of
-predefined rules.  A rule is provided input witch affects its process of
-matching for a defined feature. The rules are specified in the
-nfd-worker configuration file. See
-[configuration](deployment-and-usage.md#worker-configuration) for instructions
-and examples how to set-up and manage the worker configuration.
-
-To aid in making Custom Features clearer, we define a general and a per rule
-nomenclature, keeping things as consistent as possible.
-
-#### Additional configuration directory
-
-Additionally to the rules defined in the nfd-worker configuration file, the
-Custom feature can read more configuration files located in the
-`/etc/kubernetes/node-feature-discovery/custom.d/` directory. This makes more
-dynamic and flexible configuration easier. This directory must be available
-inside the NFD worker container, so Volumes and VolumeMounts must be used for
-mounting e.g. ConfigMap(s). The example deployment manifests provide an example
-(commented out) for providing Custom configuration with an additional
-ConfigMap, mounted into the `custom.d` directory.
-
-#### General nomenclature & definitions
-
-```plaintext
-Rule        :Represents a matching logic that is used to match on a feature.
-Rule Input  :The input a Rule is provided. This determines how a Rule performs the match operation.
-Matcher     :A composition of Rules, each Matcher may be composed of at most one instance of each Rule.
-```
-
-#### Custom features format (using the nomenclature defined above)
-
-Rules are specified under `sources.custom` in the nfd-worker configuration
-file.
-
-```yaml
-sources:
-  custom:
-  - name: <feature name>
-    value: <optional feature value, defaults to "true">
-    matchOn:
-    - <Rule-1>: <Rule-1 Input>
-      [<Rule-2>: <Rule-2 Input>]
-    - <Matcher-2>
-    - ...
-    - ...
-    - <Matcher-N>
-  - <custom feature 2>
-  - ...
-  - ...
-  - <custom feature M>
-```
-
-#### Matching process
-
-Specifying Rules to match on a feature is done by providing a list of Matchers.
-Each Matcher contains one or more Rules.
-
-Logical _OR_ is performed between Matchers and logical _AND_ is performed
-between Rules of a given Matcher.
-
-#### Rules
-
-##### pciid rule
-
-###### Nomenclature
-
-```plaintext
-Attribute   :A PCI attribute.
-Element     :An identifier of the PCI attribute.
-```
-
-The PciId Rule allows matching the PCI devices in the system on the following
-Attributes: `class`,`vendor` and `device`. A list of Elements is provided for
-each Attribute.
-
-###### Format
-
-```yaml
-pciId :
-  class: [<class id>, ...]
-  vendor: [<vendor id>,  ...]
-  device: [<device id>, ...]
-```
-
-Matching is done by performing a logical _OR_ between Elements of an Attribute
-and logical _AND_ between the specified Attributes for each PCI device in the
-system.  At least one Attribute must be specified. Missing attributes will not
-partake in the matching process.
-
-##### UsbId rule
-
-###### Nomenclature
-
-```plaintext
-Attribute   :A USB attribute.
-Element     :An identifier of the USB attribute.
-```
-
-The UsbId Rule allows matching the USB devices in the system on the following
-Attributes: `class`,`vendor`, `device` and `serial`. A list of Elements is
-provided for each Attribute.
-
-###### Format
-
-```yaml
-usbId :
-  class: [<class id>, ...]
-  vendor: [<vendor id>,  ...]
-  device: [<device id>, ...]
-  serial: [<serial>, ...]
-```
-
-Matching is done by performing a logical _OR_ between Elements of an Attribute
-and logical _AND_ between the specified Attributes for each USB device in the
-system.  At least one Attribute must be specified. Missing attributes will not
-partake in the matching process.
-
-##### LoadedKMod rule
-
-###### Nomenclature
-
-```plaintext
-Element     :A kernel module
-```
-
-The LoadedKMod Rule allows matching the loaded kernel modules in the system
-against a provided list of Elements.
-
-###### Format
-
-```yaml
-loadedKMod : [<kernel module>, ...]
-```
-
-Matching is done by performing logical _AND_ for each provided Element, i.e
-the Rule will match if all provided Elements (kernel modules) are loaded in the
-system.
-
-##### CpuId rule
-
-###### Nomenclature
-
-```plaintext
-Element     :A CPUID flag
-```
-
-The Rule allows matching the available CPUID flags in the system against a
-provided list of Elements.
-
-###### Format
-
-```yaml
-cpuId : [<CPUID flag string>, ...]
-```
-
-Matching is done by performing logical _AND_ for each provided Element, i.e the
-Rule will match if all provided Elements (CPUID flag strings) are available in
-the system.
-
-##### Kconfig rule
-
-###### Nomenclature
-
-```plaintext
-Element     :A Kconfig option
-```
-
-The Rule allows matching the kconfig options in the system against a provided
-list of Elements.
-
-###### Format
-
-```yaml
-kConfig: [<kernel config option ('y' or 'm') or '=<value>'>, ...]
-```
-
-Matching is done by performing logical _AND_ for each provided Element, i.e the
-Rule will match if all provided Elements (kernel config options) are enabled
-(`y` or `m`) or matching `=<value>` in the kernel.
-
-##### Nodename rule
-
-###### Nomenclature
-
-```plaintext
-Element     :A nodename regexp pattern
-```
-
-The Rule allows matching the node's name against a provided list of Elements.
-
-###### Format
-
-```yaml
-nodename: [ <nodename regexp pattern>, ... ]
-```
-
-Matching is done by performing logical _OR_ for each provided Element, i.e the
-Rule will match if one of the provided Elements (nodename regexp pattern)
-matches the node's name.
-
-#### Example
-
-```yaml
-custom:
-  - name: "my.kernel.feature"
-    matchOn:
-      - loadedKMod: ["kmod1", "kmod2"]
-  - name: "my.pci.feature"
-    matchOn:
-      - pciId:
-          vendor: ["15b3"]
-          device: ["1014", "1017"]
-  - name: "my.usb.feature"
-    matchOn:
-      - usbId:
-          vendor: ["1d6b"]
-          device: ["0003"]
-          serial: ["090129a"]
-  - name: "my.combined.feature"
-    matchOn:
-      - loadedKMod : ["vendor_kmod1", "vendor_kmod2"]
-        pciId:
-          vendor: ["15b3"]
-          device: ["1014", "1017"]
-  - name: "vendor.feature.node.kubernetes.io/accumulated.feature"
-    matchOn:
-      - loadedKMod : ["some_kmod1", "some_kmod2"]
-      - pciId:
-          vendor: ["15b3"]
-          device: ["1014", "1017"]
-  - name: "my.kernel.featureneedscpu"
-    matchOn:
-      - kConfig: ["KVM_INTEL"]
-      - cpuId: ["VMX"]
-  - name: "my.kernel.modulecompiler"
-    matchOn:
-      - kConfig: ["GCC_VERSION=100101"]
-        loadedKMod: ["kmod1"]
-  - name: "profile.node.kubernetes.io/my-datacenter"
-    value: "datacenter-1"
-    matchOn:
-      - nodename: [ "node-datacenter1-rack.*-server.*" ]
-```
-
-__In the example above:__
-
-- A node would contain the label:
-  `feature.node.kubernetes.io/custom-my.kernel.feature=true` if the node has
-  `kmod1` _AND_ `kmod2` kernel modules loaded.
-- A node would contain the label:
-  `feature.node.kubernetes.io/custom-my.pci.feature=true` if the node contains
-  a PCI device with a PCI vendor ID of `15b3` _AND_ PCI device ID of `1014` _OR_
-  `1017`.
-- A node would contain the label:
-  `feature.node.kubernetes.io/custom-my.usb.feature=true` if the node contains
-  a USB device with a USB vendor ID of `1d6b` _AND_ USB device ID of `0003`.
-- A node would contain the label:
-  `feature.node.kubernetes.io/custom-my.combined.feature=true` if
-  `vendor_kmod1` _AND_ `vendor_kmod2` kernel modules are loaded __AND__ the node
-  contains a PCI device
-  with a PCI vendor ID of `15b3` _AND_ PCI device ID of `1014` _or_ `1017`.
-- A node would contain the label:
-  `vendor.feature.node.kubernetes.io/accumulated.feature=true` if
-  `some_kmod1` _AND_ `some_kmod2` kernel modules are loaded __OR__ the node
-  contains a PCI device
-  with a PCI vendor ID of `15b3` _AND_ PCI device ID of `1014` _OR_ `1017`.
-- A node would contain the label:
-  `feature.node.kubernetes.io/custom-my.kernel.featureneedscpu=true` if
-  `KVM_INTEL` kernel config is enabled __AND__ the node CPU supports `VMX`
-  virtual machine extensions
-- A node would contain the label:
-  `feature.node.kubernetes.io/custom-my.kernel.modulecompiler=true` if the
-  in-tree `kmod1` kernel module is loaded __AND__ it's built with
-  `GCC_VERSION=100101`.
-- A node would contain the label:
-  `profile.node.kubernetes.io/my-datacenter=datacenter-1` if the node's name
-  matches the `node-datacenter1-rack.*-server.*` pattern, e.g.
-  `node-datacenter1-rack2-server42`
-
-#### Statically defined features
-
-Some feature labels which are common and generic are defined statically in the
-`custom` feature source.  A user may add additional Matchers to these feature
-labels by defining them in the `nfd-worker` configuration file.
-
-| Feature | Attribute | Description |
-| ------- | --------- | -----------|
-| rdma  | capable | The node has an RDMA capable Network adapter |
-| rdma | enabled | The node has the needed RDMA modules loaded to run RDMA traffic |
+| Flag      | Description                                                      |
+| --------- | ---------------------------------------------------------------- |
+| RDTMON    | Intel RDT Monitoring Technology
+| RDTCMT    | Intel Cache Monitoring (CMT)
+| RDTMBM    | Intel Memory Bandwidth Monitoring (MBM)
+| RDTL3CA   | Intel L3 Cache Allocation Technology
+| RDTl2CA   | Intel L2 Cache Allocation Technology
+| RDTMBA    | Intel Memory Bandwidth Allocation (MBA) Technology
 
 ### IOMMU (deprecated)
 
-The **iommu** feature source supports the following labels:
-
-| Feature name   | Description                                                 |
-| :------------: | :---------------------------------------------------------: |
-| enabled        | IOMMU is present and enabled in the kernel
+| Feature             | Value | Description
+| ------------------- | ----- | -----------
+| **`iommu.enabled`** | true  | IOMMU is present and enabled in the kernel
 
 **DEPRECATED**: The **iommu** source is deprecated and not enabled by default.
 
 ### Kernel
 
-The **kernel** feature source supports the following labels:
+| Feature | Value  | Description
+| ------- | ------ | -----------
+| **`kernel-config.<option>`**  | true   | Kernel config option is enabled (set 'y' or 'm'). Default options are `NO_HZ`, `NO_HZ_IDLE`, `NO_HZ_FULL` and `PREEMPT`
+| **`kernel-selinux.enabled`**  | true   | Selinux is enabled on the node
+| **`kernel-version.full`**     | string | Full kernel version as reported by `/proc/sys/kernel/osrelease` (e.g. '4.5.6-7-g123abcde')
+| **`kernel-version.major`**    | string | First component of the kernel version (e.g. '4')
+| **`kernel-version.minor`**    | string | Second component of the kernel version (e.g. '5')
+| **`kernel-version.revision`** | string | Third component of the kernel version (e.g. '6')
 
-| Feature | Attribute           | Description                                  |
-| ------- | ------------------- | -------------------------------------------- |
-| config  | &lt;option name&gt; | Kernel config option is enabled (set 'y' or 'm'). Default options are `NO_HZ`, `NO_HZ_IDLE`, `NO_HZ_FULL` and `PREEMPT`
-| selinux | enabled             | Selinux is enabled on the node
-| version | full                | Full kernel version as reported by `/proc/sys/kernel/osrelease` (e.g. '4.5.6-7-g123abcde')
-|         | major               | First component of the kernel version (e.g. '4')
-|         | minor               | Second component of the kernel version (e.g. '5')
-|         | revision            | Third component of the kernel version (e.g. '6')
-
-Kernel config file to use, and, the set of config options to be detected are
-configurable. See [configuration](deployment-and-usage#worker-configuration)
-for more information.
+The kernel label source is configurable, see
+[worker configuration](deployment-and-usage#worker-configuration) and
+[`sources.kernel`](../advanced/worker-configuration-reference#sourceskernel)
+configuration options for details.
 
 ### Memory
 
-The **memory** feature source supports the following labels:
-
-| Feature | Attribute | Description                                            |
-| ------- | --------- | ------------------------------------------------------ |
-| numa    |           | Multiple memory nodes i.e. NUMA architecture detected
-| nv      | present   | NVDIMM device(s) are present
-| nv      | dax       | NVDIMM region(s) configured in DAX mode are present
+| Feature     | Value | Description
+| ----------- | ----- | -----------
+| **`memory-numa`**       | true | Multiple memory nodes i.e. NUMA architecture detected
+| **`memory-nv.present`** | true | NVDIMM device(s) are present
+| **`memory-nv.dax`**     | true | NVDIMM region(s) configured in DAX mode are present
 
 ### Network
 
-The **network** feature source supports the following labels:
-
-| Feature | Attribute  | Description                                           |
-| ------- | ---------- | ----------------------------------------------------- |
-| sriov   | capable    | [Single Root Input/Output Virtualization][sriov] (SR-IOV) enabled Network Interface Card(s) present
-|         | configured | SR-IOV virtual functions have been configured
+| Feature     | Value | Description
+| ----------- | ----- | -----------
+| **`network-sriov.capable`**    | true | [Single Root Input/Output Virtualization][sriov] (SR-IOV) enabled Network Interface Card(s) present
+| **`network-sriov.configured`** | true | SR-IOV virtual functions have been configured
 
 ### PCI
 
-The **pci** feature source supports the following labels:
+| Feature     | Value | Description
+| ----------- | ----- | -----------
+| **`pci-<device label>.present`**       | true | PCI device is detected
+| **`pci-<device label>.sriov.capable`** | true | [Single Root Input/Output Virtualization][sriov] (SR-IOV) enabled PCI device present
 
-| Feature              | Attribute     | Description                           |
-| -------------------- | ------------- | ------------------------------------- |
-| &lt;device label&gt; | present       | PCI device is detected
-| &lt;device label&gt; | sriov.capable | [Single Root Input/Output Virtualization][sriov] (SR-IOV) enabled PCI device present
-
-`<device label>` is composed of raw PCI IDs, separated by underscores.  The set
-of fields used in `<device label>` is configurable, valid fields being `class`,
-`vendor`, `device`, `subsystem_vendor` and `subsystem_device`.  Defaults are
-`class` and `vendor`. An example label using the default label fields:
-
-```plaintext
-feature.node.kubernetes.io/pci-1200_8086.present=true
-```
-
-Also  the set of PCI device classes that the feature source detects is
-configurable. By default, device classes (0x)03, (0x)0b40 and (0x)12, i.e.
-GPUs, co-processors and accelerator cards are detected.
+`<device label>` is format is configurable and set to `<class>_<vendor>` by
+default. For more more details about configuration of the pci labels, see
+[`sources.pci`](../advanced/worker-configuration-reference#sourcespci) options
+and [worker configuration](deployment-and-usage#worker-configuration)
+instructions.
 
 ### USB
 
-The **usb** feature source supports the following labels:
+| Feature     | Value | Description
+| ----------- | ----- | -----------
+| **`usb-<device label>.present`** | true | USB device is detected
 
-| Feature              | Attribute     | Description                           |
-| -------------------- | ------------- | ------------------------------------- |
-| &lt;device label&gt; | present       | USB device is detected
-
-`<device label>` is composed of raw USB IDs, separated by underscores.  The set
-of fields used in `<device label>` is configurable, valid fields being `class`,
-`vendor`, `device` and `serial`.  Defaults are `class`, `vendor` and `device`.
-An example label using the default label fields:
-
-```plaintext
-feature.node.kubernetes.io/usb-fe_1a6e_089a.present=true
-```
-
-See [configuration](deployment-and-usage#worker-configuration) for more
-information on NFD config.
+`<device label>` is format is configurable and set to
+`<class>_<vendor>_<device>` by default. For more more details about
+configuration of the usb labels, see
+[`sources.usb`](../advanced/worker-configuration-reference#sourcesusb) options
+and [worker configuration](deployment-and-usage#worker-configuration)
+instructions.
 
 ### Storage
 
-The **storage** feature source supports the following labels:
-
-| Feature name       | Description                                             |
-| ------------------ | ------------------------------------------------------- |
-| nonrotationaldisk  | Non-rotational disk, like SSD, is present in the node
+| Feature     | Value | Description
+| ----------- | ----- | -----------
+| **`storage-nonrotationaldisk`** | true | Non-rotational disk, like SSD, is present in the node
 
 ### System
 
-The **system** feature source supports the following labels:
+| Feature     | Value | Description
+| ----------- | ----- | -----------
+| **`system-os_release.ID`**               | string | Operating system identifier
+| **`system-os_release.VERSION_ID`**       | string |Operating system version identifier (e.g. '6.7')
+| **`system-os_release.VERSION_ID.major`** | string |First component of the OS version id (e.g. '6')
+| **`system-os_release.VERSION_ID.minor`** | string | Second component of the OS version id (e.g. '7')
 
-| Feature     | Attribute        | Description                                 |
-| ----------- | ---------------- | --------------------------------------------|
-| os_release  | ID               | Operating system identifier
-|             | VERSION_ID       | Operating system version identifier (e.g. '6.7')
-|             | VERSION_ID.major | First component of the OS version id (e.g. '6')
-|             | VERSION_ID.minor | Second component of the OS version id (e.g. '7')
+### Custom
 
-### Local -- user-specific features
+The custom label source is designed for creating
+[user defined labels](#user-defined-labels). However, it has a few statically
+defined built-in labels:
 
-NFD has a special feature source named *local* which is designed for getting
-the labels from user-specific feature detector. It provides a mechanism for
-users to implement custom feature sources in a pluggable way, without modifying
-nfd source code or Docker images. The local feature source can be used to
-advertise new user-specific features, and, for overriding labels created by the
-other feature sources.
+| Feature     | Value | Description
+| ----------- | ----- | -----------
+| **`custom-rdma.capable`** | true | The node has an RDMA capable Network adapter |
+| **`custom-rdma.enabled`** | true | The node has the needed RDMA modules loaded to run RDMA traffic |
 
-The *local* feature source gets its labels by two different ways:
+## User defined labels
 
-- It tries to execute files found under
-  `/etc/kubernetes/node-feature-discovery/source.d/` directory. The hook files
-  must be executable and they are supposed to print all discovered features in
-  `stdout`, one per line. With ELF binaries static linking is recommended as
-  the selection of system libraries available in the NFD release image is very
-  limited. Other runtimes currently supported by the NFD stock image are bash
-  and perl.
-- It reads files found under
-  `/etc/kubernetes/node-feature-discovery/features.d/` directory. The file
-  content is expected to be similar to the hook output (described above).
-
-**NOTE:** The [minimal](deployment-and-usage#minimal) image variant only
-supports running statically linked binaries.
-
-These directories must be available inside the Docker image so Volumes and
-VolumeMounts must be used if standard NFD images are used. The given template
-files mount by default the `source.d` and the `features.d` directories
-respectively from `/etc/kubernetes/node-feature-discovery/source.d/` and
-`/etc/kubernetes/node-feature-discovery/features.d/` from the host. You should
-update them to match your needs.
-
-In both cases, the labels can be binary or non binary, using either `<name>` or
-`<name>=<value>` format.
-
-`local` has precedence over other label sources which makes it possible to
-override labels created by them.
-
-You can also override the default namespace of your labels using this format:
-`<namespace>/<name>[=<value>]`. If using something else than
-`[<sub-ns>.]feature.node.kubernetes.io` or
-`[<sub-ns>.]profile.node.kubernetes.io`, you must whitelist your namespace
-using the `-extra-label-ns` option on the master.
-For example, if you want to add the
-label `my.namespace.org/my-label=value`, your hook output or file must contains
-`my.namespace.org/my-label=value` and you must add
-`-extra-label-ns=my.namespace.org` on the master command line.
-
-`stderr` output of the hooks is propagated to NFD log so it can be used for
-debugging and logging.
-
-#### Injecting labels from other pods
-
-One use case for the hooks and/or feature files is detecting features in other
-Pods outside NFD, e.g. in Kubernetes device plugins. It is possible to mount
-the `source.d` and/or `features.d` directories common with the NFD Pod and
-deploy the custom hooks/features there. NFD will periodically scan the
-directories and run any hooks and read any feature files it finds. The
-default deployments contain `hostPath` mounts for `sources.d` and `features.d`
-directories. By using the same mounts in the secondary Pod (e.g. device plugin)
-you have created a shared area for delivering hooks and feature files to NFD.
-
-#### A hook example
-
-User has a shell script
-`/etc/kubernetes/node-feature-discovery/source.d/my-hook.sh` which has the
-following `stdout` output:
-
-```plaintext
-my-feature.1
-my-feature.2=myvalue
-my.namespace/my-feature.3=456
-```
-
-which, in turn, will translate into the following node labels:
-
-```plaintext
-feature.node.kubernetes.io/my-feature.1=true
-feature.node.kubernetes.io/my-feature.2=myvalue
-my.namespace/my-feature.3=456
-```
-
-#### A file example
-
-User has a file `/etc/kubernetes/node-feature-discovery/features.d/my-features`
-which contains the following lines:
-
-```plaintext
-my-feature.4
-my-feature.5=myvalue
-my.namespace/my-feature.6=456
-```
-
-which, in turn, will translate into the following node labels:
-
-```plaintext
-feature.node.kubernetes.io/my-feature.4=true
-feature.node.kubernetes.io/my-feature.5=myvalue
-my.namespace/my-feature.6=456
-```
-
-NFD tries to run any regular files found from the hooks directory. Any
-additional data files your hook might need (e.g. a configuration file) should
-be placed in a separate directory in order to avoid NFD unnecessarily trying to
-execute these. You can use a subdirectory under the hooks directory, for
-example `/etc/kubernetes/node-feature-discovery/source.d/conf/`.
-
-**NOTE!** NFD will blindly run any executables placed/mounted in the hooks
-directory. It is the user's responsibility to review the hooks for e.g.
-possible security implications.
-
-**NOTE!** Be careful when creating and/or updating hook or feature files while
-NFD is running. In order to avoid race conditions you should write into a
-temporary file (outside the `source.d` and `features.d` directories), and,
-atomically create/update the original file by doing a filesystem move
-operation.
+NFD has many extension points for creating vendor and application specific
+labels. See the [customization guide](../advanced/customization-guide.md) for
+detailed documentation.
 
 ## Extended resources
 

--- a/examples/nodefeaturerule.yaml
+++ b/examples/nodefeaturerule.yaml
@@ -1,0 +1,16 @@
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: my-sample-rule-object
+spec:
+  rules:
+    - name: "my sample rule"
+      labels:
+        "my-sample-feature": "true"
+      matchFeatures:
+        - feature: kernel.loadedmodule
+          matchExpressions:
+            dummy: {op: Exists}
+        - feature: kernel.config
+          matchExpressions:
+            X86: {op: In, value: ["y"]}


### PR DESCRIPTION
Add a separate customization guide. Move documentation of the custom and
local sources there. Also, cover the new NodeFeatureRules custom
resource and the new expression-based label rule format.

This patch also simplifies the "Feature labels" page, describing
built-in labels. Reformat the tables describing feature labels.