### PR TITLE
source/pci: add iommu_group/type attribute

### DIFF
--- a/docs/advanced/customization-guide.md
+++ b/docs/advanced/customization-guide.md
@@ -515,7 +515,7 @@ The following features are available for matching:
 | **`network.device`** | instance |          |            | Physical (non-virtual) network interfaces present in the system
 |                  |              | **`<sysfs-attribute>`** | string | Sysfs network interface attribute, available attributes: `name`, `operstate`, `speed`, `sriov_numvfs`, `sriov_totalvfs`
 | **`pci.device`** | instance     |          |            | PCI devices present in the system
-|                  |              | **`<sysfs-attribute>`** | string | Value of the sysfs device attribute, available attributes: `class`, `vendor`, `device`, `subsystem_vendor`, `subsystem_device`, `sriov_totalvfs`
+|                  |              | **`<sysfs-attribute>`** | string | Value of the sysfs device attribute, available attributes: `class`, `vendor`, `device`, `subsystem_vendor`, `subsystem_device`, `sriov_totalvfs`, `iommu_group/type`
 | **`storage.device`** | instance |          |            | Block storage devices present in the system
 |                  |              | **`<sysfs-attribute>`** | string | Sysfs network interface attribute, available attributes: `name`, `dax`, `rotational`, `nr_zones`, `zoned`
 | **`system.osrelease`** | attribute |          |            | System identification data from `/etc/os-release`

--- a/source/pci/utils.go
+++ b/source/pci/utils.go
@@ -29,7 +29,7 @@ import (
 )
 
 var mandatoryDevAttrs = []string{"class", "vendor", "device", "subsystem_vendor", "subsystem_device"}
-var optionalDevAttrs = []string{"sriov_totalvfs"}
+var optionalDevAttrs = []string{"sriov_totalvfs", "iommu_group/type"}
 
 // Read a single PCI device attribute
 // A PCI attribute in this context, maps to the corresponding sysfs file


### PR DESCRIPTION
Add `iommu_group/type` to the list of PCI device attributes that are
discovered. The value is the raw value from sysfs (i.e DMA, DMA-FQ or
identity).

No built-in (automatic) labels are generated based on this, but, the
attribute is available for custom label rules to use. Examples of custom
rules:

```
  - name: "iommu enabled rule"
    labels:
      iommu.enabled: "true"
    matchFeatures:
      - feature: pci.device
        matchExpressions:
          "iommu_group/type": {op: NotIn, value: ["unknown"]}
```

```
  - name: "iommu passthrough rule"
    labels:
      iommu.passthrough: "true"
    matchFeatures:
      - feature: pci.device
        matchExpressions:
          "iommu_group/type": {op: In, value: ["identity"]}
```