### PR TITLE
deployment/helm: refactor nfd-master rbac parameters

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/_helpers.tpl
+++ b/deployment/helm/node-feature-discovery/templates/_helpers.tpl
@@ -55,10 +55,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "node-feature-discovery.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "node-feature-discovery.fullname" .) .Values.serviceAccount.name }}
+{{- if .Values.master.serviceAccount.create -}}
+    {{ default (include "node-feature-discovery.fullname" .) .Values.master.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
+    {{ default "default" .Values.master.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 

--- a/deployment/helm/node-feature-discovery/templates/clusterrole.yaml
+++ b/deployment/helm/node-feature-discovery/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if .Values.master.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/deployment/helm/node-feature-discovery/templates/clusterrolebinding.yaml
+++ b/deployment/helm/node-feature-discovery/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if .Values.master.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/deployment/helm/node-feature-discovery/templates/serviceaccount.yaml
+++ b/deployment/helm/node-feature-discovery/templates/serviceaccount.yaml
@@ -1,11 +1,11 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.master.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "node-feature-discovery.serviceAccountName" . }}
   labels:
     {{- include "node-feature-discovery.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with .Values.master.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -6,15 +6,6 @@ image:
   # tag
 imagePullSecrets: []
 
-serviceAccount:
-  # Specifies whether a service account should be created
-  create: true
-  # Annotations to add to the service account
-  annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name:
-
 nameOverride: ""
 fullnameOverride: ""
 
@@ -38,6 +29,18 @@ master:
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     # runAsUser: 1000
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name:
+
+  rbac:
+    create: true
 
   service:
     type: ClusterIP
@@ -420,16 +423,6 @@ topologyUpdater:
   annotations: {}
   affinity: {}
 
-## RBAC parameteres
-## https://kubernetes.io/docs/reference/access-authn-authz/rbac/
-##
-rbac:
-  create: true
-  serviceAccountName:
-  ## Annotations for the Service Account
-  ##
-  serviceAccountAnnotations: {}
-
 # Optionally use encryption for worker <--> master comms
 # TODO: verify hostname is not yet supported
 #
@@ -438,4 +431,3 @@ rbac:
 tls:
   enable: false
   certManager: false
-

--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -284,10 +284,6 @@ We have introduced the following Chart parameters.
 | `image.tag` | string | `{{ site.release }}` | NFD image tag |
 | `image.pullPolicy` | string | `Always` | Image pull policy |
 | `imagePullSecrets` | list | [] | ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. [More info](https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod) |
-| `serviceAccount.create` | bool | true | Specifies whether a service account should be created |
-| `serviceAccount.annotations` | dict | {} | Annotations to add to the service account |
-| `serviceAccount.name` | string |  | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
-| `rbac` | dict |  | RBAC [parameteres](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) |
 | `nameOverride` | string |  | Override the name of the chart |
 | `fullnameOverride` | string |  | Override a default fully qualified app name |
 | `nodeFeatureRule.createCRD` | bool | true | Specifies whether to create the NodeFeatureRule CRD |
@@ -304,6 +300,10 @@ We have introduced the following Chart parameters.
 | `master.featureRulesController` | bool | True                                   | Specifies whether the controller for  processing of NodeFeatureRule objects is enable.                                                   |
 | `master.replicaCount`       | integer | 1                                       | Number of desired pods. This is a pointer to distinguish between explicit zero and not specified                                         |
 | `master.podSecurityContext` | dict    | {}                                      | SecurityContext holds pod-level security attributes and common container settings                                                        |
+| `master.serviceAccount.create` | bool | true                                    | Specifies whether a service account should be created
+| `master.serviceAccount.annotations` | dict | {}                                 | Annotations to add to the service account
+| `master.serviceAccount.name` | string |                                         | The name of the service account to use. If not set and create is true, a name is generated using the fullname template
+| `master.rbac.create`        | bool    | true                                    | Specifies whether to create [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) configuration for nfd-master
 | `master.service.type`       | string  | ClusterIP                               | NFD master service type                                                                                                                  |
 | `master.service.port`       | integer | port                                    | NFD master service port                                                                                                                  |
 | `master.resources`          | dict    | {}                                      | NFD master pod [resources management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)                    |


### PR DESCRIPTION
Move top-level serviceAccount and rbac fields under master, making the
Helm chart more coherent.

Also, drop unused rbac.serviceAccountName and
rbac.serviceAccountAnnotations from values.yaml.

Add `-master` suffix to the nfd-master ClusterRole and
ClusterRoleBinding, and, to default name of the ServiceAccount. This
makes the naming consistent with the topology-updater and pave way for
the possibility of adding a separate worker-specific RBAC configuration.
Fixes #630 