### PR TITLE
Dockerfile: build grpc_health-probe from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,8 @@ ARG BASE_IMAGE_MINIMAL
 FROM golang:1.17.2-buster as builder
 
 # Download the grpc_health_probe bin
-RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x /bin/grpc_health_probe
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.6 && \
+	go install github.com/grpc-ecosystem/grpc-health-probe@${GRPC_HEALTH_PROBE_VERSION}
 
 # Get (cache) deps in a separate layer
 COPY go.mod go.sum /go/node-feature-discovery/
@@ -37,7 +36,6 @@ ENV GRPC_GO_LOG_SEVERITY_LEVEL="INFO"
 
 COPY --from=builder /go/node-feature-discovery/deployment/components/worker-config/nfd-worker.conf.example /etc/kubernetes/node-feature-discovery/nfd-worker.conf
 COPY --from=builder /go/bin/* /usr/bin/
-COPY --from=builder /bin/grpc_health_probe /usr/bin/grpc_health_probe
 
 # Create minimal variant of the production image
 FROM ${BASE_IMAGE_MINIMAL} as minimal
@@ -50,4 +48,3 @@ ENV GRPC_GO_LOG_SEVERITY_LEVEL="INFO"
 
 COPY --from=builder /go/node-feature-discovery/deployment/components/worker-config/nfd-worker.conf.example /etc/kubernetes/node-feature-discovery/nfd-worker.conf
 COPY --from=builder /go/bin/* /usr/bin/
-COPY --from=builder /bin/grpc_health_probe /usr/bin/grpc_health_probe


### PR DESCRIPTION
Current grpc-health-probe functionality is pulling a binary, hard coded
to amd64, both unsecure and only works for 1 arch, preparing to build
NFD for multiple Arch's require we build the health probe from source,
that way we get rid of the unsecure binary pull, and guarantee a proper
arch build for the grpc-health-probe

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>