### PR TITLE
fix probe check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE_MINIMAL
 # Build node feature discovery
 FROM golang:1.17.2-buster as builder
 
-# Download the grpc_health_probe bin
+# Download the grpc-health-probe bin
 RUN GRPC_HEALTH_PROBE_VERSION=v0.4.6 && \
 	go install github.com/grpc-ecosystem/grpc-health-probe@${GRPC_HEALTH_PROBE_VERSION}
 

--- a/deployment/base/master-worker-combined/master-worker-daemonset.yaml
+++ b/deployment/base/master-worker-combined/master-worker-daemonset.yaml
@@ -21,12 +21,12 @@ spec:
         imagePullPolicy: Always
         livenessProbe:
           exec:
-            command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+            command: ["/usr/bin/grpc-health-probe", "-addr=:8080"]
           initialDelaySeconds: 10
           periodSeconds: 10
         readinessProbe:
           exec:
-            command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+            command: ["/usr/bin/grpc-health-probe", "-addr=:8080"]
           initialDelaySeconds: 5
           periodSeconds: 10
           failureThreshold: 10

--- a/deployment/base/master/master-deployment.yaml
+++ b/deployment/base/master/master-deployment.yaml
@@ -22,12 +22,12 @@ spec:
           imagePullPolicy: Always
           livenessProbe:
             exec:
-              command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+              command: ["/usr/bin/grpc-health-probe", "-addr=:8080"]
             initialDelaySeconds: 10
             periodSeconds: 10
           readinessProbe:
             exec:
-              command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+              command: ["/usr/bin/grpc-health-probe", "-addr=:8080"]
             initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 10

--- a/deployment/helm/node-feature-discovery/templates/master.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master.yaml
@@ -34,12 +34,12 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             exec:
-              command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+              command: ["/usr/bin/grpc-health-probe", "-addr=:8080"]
             initialDelaySeconds: 10
             periodSeconds: 10
           readinessProbe:
             exec:
-              command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+              command: ["/usr/bin/grpc-health-probe", "-addr=:8080"]
             initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 10


### PR DESCRIPTION
Due to recently changed way of building health probe binary its
name changed from grpc_health_probe to grpc-health-probe.
It broke readiness check causing non-functional deployments.

Changing binary name should fix this issue.
