### PR TITLE
Fix kustomization template to work with cert-manager

### DIFF
--- a/deployment/overlays/samples/cert-manager/issuer.yaml
+++ b/deployment/overlays/samples/cert-manager/issuer.yaml
@@ -1,3 +1,35 @@
+# See https://cert-manager.io/docs/configuration/selfsigned/#bootstrapping-ca-issuers
+# - Create a self signed issuer
+# - Use this to create a CA cert
+# - Use this to now create a CA issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: nfd-ca-bootstrap
+  namespace: node-feature-discovery
+spec:
+  selfSigned: {}
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: nfd-ca-cert
+  namespace: node-feature-discovery
+spec:
+  isCA: true
+  secretName: nfd-ca-cert
+  subject:
+    organizations:
+    - node-feature-discovery
+  commonName: nfd-ca-cert
+  issuerRef:
+    name: nfd-ca-bootstrap
+    kind: Issuer
+    group: cert-manager.io
+
+---
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -5,4 +37,5 @@ metadata:
   namespace: node-feature-discovery
 spec:
   ca:
-    secretName: nfd-ca-key-pair
+    secretName: nfd-ca-cert
+

--- a/deployment/overlays/samples/cert-manager/kustomization.yaml
+++ b/deployment/overlays/samples/cert-manager/kustomization.yaml
@@ -12,13 +12,6 @@ resources:
 generatorOptions:
   disableNameSuffixHash: true
 
-secretGenerator:
-- files:
-  - tls.crt
-  - tls.key
-  name: nfd-ca-key-pair
-  type: kubernetes.io/tls
-
 patches:
 - path: args.yaml
   target:
@@ -32,3 +25,8 @@ patches:
   target:
     labelSelector: app=nfd
     name: nfd-worker
+- path: probes.yaml
+  target:
+    labelSelector: app=nfd
+    name: nfd-master
+

--- a/deployment/overlays/samples/cert-manager/master-cert.yaml
+++ b/deployment/overlays/samples/cert-manager/master-cert.yaml
@@ -13,6 +13,7 @@ spec:
   - nfd-master.node-feature-discovery.svc
   - nfd-master.node-feature-discovery.svc.cluster.local
   - nfd-master
+  - localhost    # needed for grpc_health_probe
   issuerRef:
     name: nfd-ca-issuer
     kind: Issuer

--- a/deployment/overlays/samples/cert-manager/probes.yaml
+++ b/deployment/overlays/samples/cert-manager/probes.yaml
@@ -1,0 +1,26 @@
+- op: add
+  path: /spec/template/spec/containers/0/livenessProbe/exec/command/-
+  value: "-tls"
+- op: add
+  path: /spec/template/spec/containers/0/livenessProbe/exec/command/-
+  value: "-tls-ca-cert=/etc/kubernetes/node-feature-discovery/certs/ca.crt"
+- op: add
+  path: /spec/template/spec/containers/0/livenessProbe/exec/command/-
+  value: "-tls-client-key=/etc/kubernetes/node-feature-discovery/certs/tls.key"
+- op: add
+  path: /spec/template/spec/containers/0/livenessProbe/exec/command/-
+  value: "-tls-client-cert=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
+
+- op: add
+  path: /spec/template/spec/containers/0/readinessProbe/exec/command/-
+  value: "-tls"
+- op: add
+  path: /spec/template/spec/containers/0/readinessProbe/exec/command/-
+  value: "-tls-ca-cert=/etc/kubernetes/node-feature-discovery/certs/ca.crt"
+- op: add
+  path: /spec/template/spec/containers/0/readinessProbe/exec/command/-
+  value: "-tls-client-key=/etc/kubernetes/node-feature-discovery/certs/tls.key"
+- op: add
+  path: /spec/template/spec/containers/0/readinessProbe/exec/command/-
+  value: "-tls-client-cert=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
+

--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -436,17 +436,14 @@ management between nfd-master and the nfd-worker pods.
 
 NFD source code repository contains an example kustomize overlay that can be
 used to deploy NFD with cert-manager supplied certificates enabled. The
-instructions below describe steps how to generate a self-signed CA certificate
+instructions below will install cert-manager and generate a self-signed CA certificate
 and set up cert-manager's
 [CA Issuer](https://cert-manager.io/docs/configuration/ca/) to sign
 `Certificate` requests for NFD components in `node-feature-discovery`
 namespace.
 
 ```bash
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.1/cert-manager.yaml
-openssl genrsa -out deployment/overlays/samples/cert-manager/tls.key 2048
-openssl req -x509 -new -nodes -key deployment/overlays/samples/cert-manager/tls.key -subj "/CN=nfd-ca" \
-        -days 10000 -out deployment/overlays/samples/cert-manager/tls.crt
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
 kubectl apply -k deployment/overlays/samples/cert-manager
 ```
 


### PR DESCRIPTION
A few changes in this PR:
1/ Make use of cert-manager's selfSigned{} to bootstrap the actual CA creation (removes the need for a manual openssl step)
2/ Update grpc_health_check to use TLS (without this, the master pod won't start)
3/ Update the certs to include "localhost" in the SAN list, so grpc_health_check can work
4/ Update docs (and bump cert-manager referenced to 1.6.1)

Note - this is partly in response to #563 