### PR TITLE
Enable TLS and cert-manager created certs for helm chart

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/cert-manager-certs.yaml
+++ b/deployment/helm/node-feature-discovery/templates/cert-manager-certs.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.tls.certManager }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: nfd-master-cert
+spec:
+  secretName: nfd-master-cert
+  subject:
+    organizations:
+    - node-feature-discovery
+  commonName: nfd-master
+  dnsNames:
+  # must match the service name
+  - {{ include "node-feature-discovery.fullname" . }}-master
+  # first one is configured for use by the worker; below are for completeness
+  - {{ include "node-feature-discovery.fullname" . }}-master.{{ $.Release.Namespace }}.svc
+  - {{ include "node-feature-discovery.fullname" . }}-master.{{ $.Release.Namespace }}.svc.cluster.local
+  # localhost needed for grpc_health_probe
+  - localhost
+  issuerRef:
+    name: nfd-ca-issuer
+    kind: Issuer
+    group: cert-manager.io
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: nfd-worker-cert
+spec:
+  secretName: nfd-worker-cert
+  subject:
+    organizations:
+    - node-feature-discovery
+  commonName: nfd-worker
+  dnsNames:
+  - {{ include "node-feature-discovery.fullname" . }}-worker.{{ $.Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    name: nfd-ca-issuer
+    kind: Issuer
+    group: cert-manager.io
+
+{{- if .Values.topologyUpdater.enable }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: nfd-topology-updater-cert
+spec:
+  secretName: nfd-topology-updater-cert
+  subject:
+    organizations:
+    - node-feature-discovery
+  commonName: nfd-topology-updater
+  dnsNames:
+  - {{ include "node-feature-discovery.fullname" . }}-topology-updater.{{ $.Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    name: nfd-ca-issuer
+    kind: Issuer
+    group: cert-manager.io
+{{- end }}
+
+{{- end }}

--- a/deployment/helm/node-feature-discovery/templates/cert-manager-issuer.yaml
+++ b/deployment/helm/node-feature-discovery/templates/cert-manager-issuer.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.tls.certManager }}
+# See https://cert-manager.io/docs/configuration/selfsigned/#bootstrapping-ca-issuers
+# - Create a self signed issuer
+# - Use this to create a CA cert
+# - Use this to now create a CA issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: nfd-ca-bootstrap
+spec:
+  selfSigned: {}
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: nfd-ca-cert
+spec:
+  isCA: true
+  secretName: nfd-ca-cert
+  subject:
+    organizations:
+    - node-feature-discovery
+  commonName: nfd-ca-cert
+  issuerRef:
+    name: nfd-ca-bootstrap
+    kind: Issuer
+    group: cert-manager.io
+
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: nfd-ca-issuer
+spec:
+  ca:
+    secretName: nfd-ca-cert
+{{- end }}

--- a/deployment/helm/node-feature-discovery/templates/master.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master.yaml
@@ -34,12 +34,28 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             exec:
-              command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+              command:
+              - "/usr/bin/grpc_health_probe"
+              - "-addr=:8080"
+              {{- if .Values.tls.enable }}
+              - "-tls"
+              - "-tls-ca-cert=/etc/kubernetes/node-feature-discovery/certs/ca.crt"
+              - "-tls-client-key=/etc/kubernetes/node-feature-discovery/certs/tls.key"
+              - "-tls-client-cert=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
+              {{- end }}
             initialDelaySeconds: 10
             periodSeconds: 10
           readinessProbe:
             exec:
-              command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+              command:
+              - "/usr/bin/grpc_health_probe"
+              - "-addr=:8080"
+              {{- if .Values.tls.enable }}
+              - "-tls"
+              - "-tls-ca-cert=/etc/kubernetes/node-feature-discovery/certs/ca.crt"
+              - "-tls-client-key=/etc/kubernetes/node-feature-discovery/certs/tls.key"
+              - "-tls-client-cert=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
+              {{- end }}
             initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 10
@@ -63,30 +79,20 @@ spec:
             - "--extra-label-ns={{- join "," .Values.master.extraLabelNs }}"
             {{- end }}
             - "-featurerules-controller={{ .Values.master.featureRulesController }}"
-## Enable TLS authentication
-## The example below assumes having the root certificate named ca.crt stored in
-## a ConfigMap named nfd-ca-cert, and, the TLS authentication credentials stored
-## in a TLS Secret named nfd-master-cert.
-## Additional hardening can be enabled by specifying --verify-node-name in
-## args, in which case node name will be checked against the worker's
-## TLS certificate.
-#            - "--ca-file=/etc/kubernetes/node-feature-discovery/trust/ca.crt"
-#            - "--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
-#            - "--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
-#          volumeMounts:
-#            - name: nfd-ca-cert
-#              mountPath: "/etc/kubernetes/node-feature-discovery/trust"
-#              readOnly: true
-#            - name: nfd-master-cert
-#              mountPath: "/etc/kubernetes/node-feature-discovery/certs"
-#              readOnly: true
-#      volumes:
-#        - name: nfd-ca-cert
-#          configMap:
-#            name: nfd-ca-cert
-#        - name: nfd-master-cert
-#          secret:
-#            secretName: nfd-master-cert
+    {{- if .Values.tls.enable }}
+            - "--ca-file=/etc/kubernetes/node-feature-discovery/certs/ca.crt"
+            - "--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
+            - "--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
+          volumeMounts:
+            - name: nfd-master-cert
+              mountPath: "/etc/kubernetes/node-feature-discovery/certs"
+              readOnly: true
+      volumes:
+        - name: nfd-master-cert
+          secret:
+            secretName: nfd-master-cert
+    ## /TLS ##
+    {{- end }}
     {{- with .Values.master.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
+++ b/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
@@ -50,6 +50,11 @@ spec:
           {{- else }}
           - "--watch-namespace=*"
           {{- end }}
+          {{- if .Values.tls.enable }}
+          - "--ca-file=/etc/kubernetes/node-feature-discovery/certs/ca.crt"
+          - "--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
+          - "--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
+          {{- end }}
         volumeMounts:
         - name: kubelet-config
           mountPath: /host-var/lib/kubelet/config.yaml
@@ -57,6 +62,12 @@ spec:
           mountPath: /host-var/lib/kubelet/pod-resources/kubelet.sock
         - name: host-sys
           mountPath: /host-sys
+        {{- if .Values.tls.enable }}
+        - name: nfd-topology-updater-cert
+          mountPath: "/etc/kubernetes/node-feature-discovery/certs"
+          readOnly: true
+        {{- end }}
+
         resources:
       {{- toYaml .Values.topologyUpdater.resources | nindent 12 }}
         securityContext:
@@ -79,6 +90,12 @@ spec:
           {{- else }}
           path: /var/lib/kubelet/pod-resources/kubelet.sock
           {{- end }}
+      {{- if .Values.tls.enable }}
+      - name: nfd-topology-updater-cert
+        secret:
+          secretName: nfd-topology-updater-cert
+      {{- end }}
+
     {{- with .Values.topologyUpdater.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deployment/helm/node-feature-discovery/templates/worker.yaml
+++ b/deployment/helm/node-feature-discovery/templates/worker.yaml
@@ -42,13 +42,11 @@ spec:
         - "nfd-worker"
         args:
         - "--server={{ include "node-feature-discovery.fullname" . }}-master:{{ .Values.master.service.port }}"
-## Enable TLS authentication (1/3)
-## The example below assumes having the root certificate named ca.crt stored in
-## a ConfigMap named nfd-ca-cert, and, the TLS authentication credentials stored
-## in a TLS Secret named nfd-worker-cert
-#          - "--ca-file=/etc/kubernetes/node-feature-discovery/trust/ca.crt"
-#          - "--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
-#          - "--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
+{{- if .Values.tls.enable }}
+        - "--ca-file=/etc/kubernetes/node-feature-discovery/certs/ca.crt"
+        - "--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
+        - "--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
+{{- end }}
         volumeMounts:
         - name: host-boot
           mountPath: "/host-boot"
@@ -76,13 +74,11 @@ spec:
         - name: nfd-worker-conf
           mountPath: "/etc/kubernetes/node-feature-discovery"
           readOnly: true
-## Enable TLS authentication (2/3)
-#        - name: nfd-ca-cert
-#          mountPath: "/etc/kubernetes/node-feature-discovery/trust"
-#          readOnly: true
-#        - name: nfd-worker-cert
-#          mountPath: "/etc/kubernetes/node-feature-discovery/certs"
-#          readOnly: true
+{{- if .Values.tls.enable }}
+        - name: nfd-worker-cert
+          mountPath: "/etc/kubernetes/node-feature-discovery/certs"
+          readOnly: true
+{{- end }}
       volumes:
         - name: host-boot
           hostPath:
@@ -113,13 +109,11 @@ spec:
             items:
               - key: nfd-worker.conf
                 path: nfd-worker.conf
-## Enable TLS authentication (3/3)
-#        - name: nfd-ca-cert
-#          configMap:
-#            name: nfd-ca-cert
-#        - name: nfd-worker-cert
-#          secret:
-#            secretName: nfd-worker-cert
+{{- if .Values.tls.enable }}
+        - name: nfd-worker-cert
+          secret:
+            secretName: nfd-worker-cert
+{{- end }}
     {{- with .Values.worker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -429,3 +429,13 @@ rbac:
   ## Annotations for the Service Account
   ##
   serviceAccountAnnotations: {}
+
+# Optionally use encryption for worker <--> master comms
+# TODO: verify hostname is not yet supported
+#
+# If you do not enable certManager (and have it installed) you will
+# need to manually, or otherwise, provision the TLS certs as secrets
+tls:
+  enable: false
+  certManager: false
+

--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -291,6 +291,8 @@ We have introduced the following Chart parameters.
 | `nameOverride` | string |  | Override the name of the chart |
 | `fullnameOverride` | string |  | Override a default fully qualified app name |
 | `nodeFeatureRule.createCRD` | bool | true | Specifies whether to create the NodeFeatureRule CRD |
+| `tls.enable` | bool | false | Specifies whether to use TLS for communications between components |
+| `tls.certManager` | bool | false | If enabled, requires [cert-manager](https://cert-manager.io/docs/) to be installed and will automatically create the required TLS certificates |
 
 ##### Master pod parameters
 
@@ -436,17 +438,14 @@ management between nfd-master and the nfd-worker pods.
 
 NFD source code repository contains an example kustomize overlay that can be
 used to deploy NFD with cert-manager supplied certificates enabled. The
-instructions below describe steps how to generate a self-signed CA certificate
+instructions below will install cert-manager and generate a self-signed CA certificate
 and set up cert-manager's
 [CA Issuer](https://cert-manager.io/docs/configuration/ca/) to sign
 `Certificate` requests for NFD components in `node-feature-discovery`
 namespace.
 
 ```bash
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.1/cert-manager.yaml
-openssl genrsa -out deployment/overlays/samples/cert-manager/tls.key 2048
-openssl req -x509 -new -nodes -key deployment/overlays/samples/cert-manager/tls.key -subj "/CN=nfd-ca" \
-        -days 10000 -out deployment/overlays/samples/cert-manager/tls.crt
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
 kubectl apply -k deployment/overlays/samples/cert-manager
 ```
 


### PR DESCRIPTION
See also #710 -- this is a similar change to the helm chart:
1/ Enable TLS for worker/master communications
2/ Optionally use cert-manager to bootstrap CA, and then create secrets
3/ Update grpc_health_check call to use the TLS certs if enabled