### PR TITLE
source/pci: detect intel-iommu/version

### DIFF
--- a/docs/advanced/customization-guide.md
+++ b/docs/advanced/customization-guide.md
@@ -516,7 +516,7 @@ The following features are available for matching:
 |                  |              | **`name`** | string   | Name of the network interface
 |                  |              | **`<sysfs-attribute>`** | string | Sysfs network interface attribute, available attributes: `operstate`, `speed`, `sriov_numvfs`, `sriov_totalvfs`
 | **`pci.device`** | instance     |          |            | PCI devices present in the system
-|                  |              | **`<sysfs-attribute>`** | string | Value of the sysfs device attribute, available attributes: `class`, `vendor`, `device`, `subsystem_vendor`, `subsystem_device`, `sriov_totalvfs`, `iommu_group/type`
+|                  |              | **`<sysfs-attribute>`** | string | Value of the sysfs device attribute, available attributes: `class`, `vendor`, `device`, `subsystem_vendor`, `subsystem_device`, `sriov_totalvfs`, `iommu_group/type`, `iommu/intel-iommu/version`
 | **`storage.device`** | instance |          |            | Block storage devices present in the system
 |                  |              | **`name`** | string   | Name of the block device
 |                  |              | **`<sysfs-attribute>`** | string | Sysfs network interface attribute, available attributes: `dax`, `rotational`, `nr_zones`, `zoned`

--- a/source/pci/utils.go
+++ b/source/pci/utils.go
@@ -29,7 +29,7 @@ import (
 )
 
 var mandatoryDevAttrs = []string{"class", "vendor", "device", "subsystem_vendor", "subsystem_device"}
-var optionalDevAttrs = []string{"sriov_totalvfs", "iommu_group/type"}
+var optionalDevAttrs = []string{"sriov_totalvfs", "iommu_group/type", "iommu/intel-iommu/version"}
 
 // Read a single PCI device attribute
 // A PCI attribute in this context, maps to the corresponding sysfs file


### PR DESCRIPTION
Discover "iommu/intel-iommu/version" sysfs attribute for pci devices.
This information is available for custom label rules.

An example custom rule:

```
  - name: "iommu version rule"
    labels:
      iommu.version_1: "true"
    matchFeatures:
      - feature: pci.device
        matchExpressions:
          "iommu/intel-iommu/version": {op: In, value: ["1:0"]}
```
