### PR TITLE
source/network: add iommu_group/type attribute

### DIFF
--- a/docs/advanced/customization-guide.md
+++ b/docs/advanced/customization-guide.md
@@ -514,7 +514,7 @@ The following features are available for matching:
 |                  |              | **`node_count`** | int | Number of NUMA nodes
 | **`network.device`** | instance |          |            | Physical (non-virtual) network interfaces present in the system
 |                  |              | **`name`** | string   | Name of the network interface
-|                  |              | **`<sysfs-attribute>`** | string | Sysfs network interface attribute, available attributes: `operstate`, `speed`, `sriov_numvfs`, `sriov_totalvfs`
+|                  |              | **`<sysfs-attribute>`** | string | Sysfs network interface attribute, available attributes: `operstate`, `speed`, `sriov_numvfs`, `sriov_totalvfs`, `iommu_group/type`
 | **`pci.device`** | instance     |          |            | PCI devices present in the system
 |                  |              | **`<sysfs-attribute>`** | string | Value of the sysfs device attribute, available attributes: `class`, `vendor`, `device`, `subsystem_vendor`, `subsystem_device`, `sriov_totalvfs`, `iommu_group/type`
 | **`storage.device`** | instance |          |            | Block storage devices present in the system

--- a/source/network/network.go
+++ b/source/network/network.go
@@ -54,7 +54,7 @@ var (
 	// ifaceAttrs is the list of files under /sys/class/net/<iface> that we're trying to read
 	ifaceAttrs = []string{"operstate", "speed"}
 	// devAttrs is the list of files under /sys/class/net/<iface>/device that we're trying to read
-	devAttrs = []string{"sriov_numvfs", "sriov_totalvfs"}
+	devAttrs = []string{"sriov_numvfs", "sriov_totalvfs", "iommu_group/type"}
 )
 
 // Name returns an identifier string for this feature source.


### PR DESCRIPTION
Detect "iommu_group/type" sysfs attribute for network devices. It is
available for custom label rules. The value is the raw value from sysfs
(i.e DMA, DMA-FQ or identity).

An example rule:

  - name: "nic iommu passthrough rule"
    labels:
      network-iommu.passthrough: "true"
    matchFeatures:
      - feature: network.device
        matchExpressions:
          "iommu_group/type": {op: In, value: ["identity"]}