### PR TITLE
source/network: detect intel-iommu/version

### DIFF
--- a/docs/advanced/customization-guide.md
+++ b/docs/advanced/customization-guide.md
@@ -513,7 +513,7 @@ The following features are available for matching:
 |                  |              | **`is_numa`** | bool  | `true` if NUMA architecture, `false` otherwise
 |                  |              | **`node_count`** | int | Number of NUMA nodes
 | **`network.device`** | instance |          |            | Physical (non-virtual) network interfaces present in the system
-|                  |              | **`<sysfs-attribute>`** | string | Sysfs network interface attribute, available attributes: `name`, `operstate`, `speed`, `sriov_numvfs`, `sriov_totalvfs`
+|                  |              | **`<sysfs-attribute>`** | string | Sysfs network interface attribute, available attributes: `name`, `operstate`, `speed`, `sriov_numvfs`, `sriov_totalvfs`, `iommu_group/type`
 | **`pci.device`** | instance     |          |            | PCI devices present in the system
 |                  |              | **`<sysfs-attribute>`** | string | Value of the sysfs device attribute, available attributes: `class`, `vendor`, `device`, `subsystem_vendor`, `subsystem_device`, `sriov_totalvfs`
 | **`storage.device`** | instance |          |            | Block storage devices present in the system

--- a/docs/advanced/customization-guide.md
+++ b/docs/advanced/customization-guide.md
@@ -513,7 +513,7 @@ The following features are available for matching:
 |                  |              | **`is_numa`** | bool  | `true` if NUMA architecture, `false` otherwise
 |                  |              | **`node_count`** | int | Number of NUMA nodes
 | **`network.device`** | instance |          |            | Physical (non-virtual) network interfaces present in the system
-|                  |              | **`<sysfs-attribute>`** | string | Sysfs network interface attribute, available attributes: `name`, `operstate`, `speed`, `sriov_numvfs`, `sriov_totalvfs`, `iommu_group/type`
+|                  |              | **`<sysfs-attribute>`** | string | Sysfs network interface attribute, available attributes: `name`, `operstate`, `speed`, `sriov_numvfs`, `sriov_totalvfs`, `iommu_group/type`, `iommu/intel-iommu/version`
 | **`pci.device`** | instance     |          |            | PCI devices present in the system
 |                  |              | **`<sysfs-attribute>`** | string | Value of the sysfs device attribute, available attributes: `class`, `vendor`, `device`, `subsystem_vendor`, `subsystem_device`, `sriov_totalvfs`
 | **`storage.device`** | instance |          |            | Block storage devices present in the system

--- a/source/network/network.go
+++ b/source/network/network.go
@@ -53,7 +53,7 @@ var (
 	// ifaceAttrs is the list of files under /sys/class/net/<iface> that we're trying to read
 	ifaceAttrs = []string{"operstate", "speed"}
 	// devAttrs is the list of files under /sys/class/net/<iface>/device that we're trying to read
-	devAttrs = []string{"sriov_numvfs", "sriov_totalvfs"}
+	devAttrs = []string{"sriov_numvfs", "sriov_totalvfs", "iommu_group/type"}
 )
 
 // Name returns an identifier string for this feature source.

--- a/source/network/network.go
+++ b/source/network/network.go
@@ -53,7 +53,7 @@ var (
 	// ifaceAttrs is the list of files under /sys/class/net/<iface> that we're trying to read
 	ifaceAttrs = []string{"operstate", "speed"}
 	// devAttrs is the list of files under /sys/class/net/<iface>/device that we're trying to read
-	devAttrs = []string{"sriov_numvfs", "sriov_totalvfs", "iommu_group/type"}
+	devAttrs = []string{"sriov_numvfs", "sriov_totalvfs", "iommu_group/type", "iommu/intel-iommu/version"}
 )
 
 // Name returns an identifier string for this feature source.


### PR DESCRIPTION
Discover "iommu/intel-iommu/version" sysfs attribute forc network
devices. This information is available for custom label rules.

An example custom rule:

```
  - name: "nic iommu version rule"
    labels:
      network-iommu.version_1: "true"
    matchFeatures:
      - feature: network.device
        matchExpressions:
          "iommu/intel-iommu/version": {op: In, value: ["1:0"]}
```

Builds on #717 