### PR TITLE
cloudbuild.yaml: set HOME to /root

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,6 +5,7 @@ steps:
     - IMAGE_REGISTRY=gcr.io/$PROJECT_ID
     - _GIT_TAG=$_GIT_TAG
     - IMAGE_EXTRA_TAG_NAMES=$_PULL_BASE_REF
+    - HOME=/root
 substitutions:
   _GIT_TAG: '0.0.0'
   _PULL_BASE_REF: 'master'


### PR DESCRIPTION
As per
https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md
we need that for buildx.