### PR TITLE
cloudbuild.yaml: double the timeout

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,3 +1,4 @@
+timeout: 1200s
 steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90
     entrypoint: scripts/test-infra/push-image.sh


### PR DESCRIPTION
We hit the timeout with default 600s with multiarch builds enabled.