### PR TITLE
cloudbuild.yaml: increase timeout to 2400s

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 1200s
+timeout: 2400s
 steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90
     entrypoint: scripts/test-infra/push-image.sh


### PR DESCRIPTION
20 minutes was not clearly enough for multiarch buildx build.