### PR TITLE
cloudbuild.yaml: increase timeout to 1 hour

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 2400s
+timeout: 3600s
 steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90
     entrypoint: scripts/test-infra/push-image.sh

--- a/scripts/test-infra/test-e2e.sh
+++ b/scripts/test-infra/test-e2e.sh
@@ -19,7 +19,7 @@ i=1
 while true; do
     if make poll-images; then
         break
-    elif [ $i -ge 12 ]; then
+    elif [ $i -ge 62 ]; then
         echo "ERROR: too many tries when polling for image"
         exit 1
     fi


### PR DESCRIPTION
Even 40 minutes failed us for multi-arch builds.

Also, increase the e2e-test image polling timeout correspondingly.