### PR TITLE
Increase timeout in test setups

### DIFF
--- a/pkg/nfd-client/topology-updater/nfd-topology-updater_test.go
+++ b/pkg/nfd-client/topology-updater/nfd-topology-updater_test.go
@@ -53,7 +53,7 @@ func setupTest(args *nfdmaster.Args) testContext {
 		ctx.errs <- ctx.master.Run()
 		close(ctx.errs)
 	}()
-	ready := ctx.master.WaitForReady(time.Second)
+	ready := ctx.master.WaitForReady(5 * time.Second)
 	if !ready {
 		fmt.Println("Test setup failed: timeout while waiting for nfd-master")
 		os.Exit(1)

--- a/pkg/nfd-client/worker/nfd-worker_test.go
+++ b/pkg/nfd-client/worker/nfd-worker_test.go
@@ -54,7 +54,7 @@ func setupTest(args *master.Args) testContext {
 		ctx.errs <- ctx.master.Run()
 		close(ctx.errs)
 	}()
-	ready := ctx.master.WaitForReady(time.Second)
+	ready := ctx.master.WaitForReady(5 * time.Second)
 	if !ready {
 		fmt.Println("Test setup failed: timeout while waiting for nfd-master")
 		os.Exit(1)


### PR DESCRIPTION
This patch increases the timeout when setting up the NFD master
to 5 seconds instead of 1 second to allow for running tests in
slow environments.

Closes: #737 