### PR TITLE
scripts: configure docker auth in push-image.sh

### DIFF
--- a/scripts/test-infra/push-image.sh
+++ b/scripts/test-infra/push-image.sh
@@ -5,4 +5,8 @@
 # container image tag
 VERSION_OVERRIDE=${_GIT_TAG+VERSION=${_GIT_TAG:10}}
 
+# Authenticate in order to be able to push images
+gcloud auth configure-docker
+
+# Build and push images
 make push-all $VERSION_OVERRIDE


### PR DESCRIPTION
Re-introduce docker authentication that was dropped in
bac690813ae5416387c9a4ace2ab4b65b040f4ee. Should fix issues with
building multi-arch buildx buildx.