### PR TITLE
release-0.10: enable multi arch builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ push:
 	$(IMAGE_PUSH_CMD) $(IMAGE_TAG)-minimal
 	for tag in $(IMAGE_EXTRA_TAGS); do $(IMAGE_PUSH_CMD) $$tag; $(IMAGE_PUSH_CMD) $$tag-minimal; done
 
-push-all:
+push-all: ensure-buildx yamls
 	$(IMAGE_BUILDX_CMD) --push $(IMAGE_BUILD_ARGS) $(IMAGE_BUILD_ARGS_FULL)
 	$(IMAGE_BUILDX_CMD) --push $(IMAGE_BUILD_ARGS) $(IMAGE_BUILD_ARGS_MINIMAL)
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,3 +1,4 @@
+timeout: 1500s
 steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90
     entrypoint: scripts/test-infra/push-image.sh

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,3 +11,4 @@ substitutions:
   _PULL_BASE_REF: 'master'
 options:
   substitution_option: ALLOW_LOOSE
+  machineType: 'N1_HIGHCPU_8'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,6 +5,7 @@ steps:
     - IMAGE_REGISTRY=gcr.io/$PROJECT_ID
     - _GIT_TAG=$_GIT_TAG
     - IMAGE_EXTRA_TAG_NAMES=$_PULL_BASE_REF
+    - HOME=/root
 substitutions:
   _GIT_TAG: '0.0.0'
   _PULL_BASE_REF: 'master'

--- a/docs/advanced/developer-guide.md
+++ b/docs/advanced/developer-guide.md
@@ -43,6 +43,32 @@ Optional, this example with Docker.
 docker push <IMAGE_TAG>
 ```
 
+### Docker multi-arch builds with buildx
+
+The default set of architectures enabled for mulit-arch builds are `linux/amd64`
+and `linux/arm64`. If more architectures are needed one can override the
+`IMAGE_ALL_PLATFORMS` variable with a comma separated list of `OS/ARCH` tuples.
+
+#### Build the manifest-list with a container image per arch
+
+```bash
+make image-all
+```
+
+Currently `docker` does not support loading of manifest-lists meaning the images
+are not shown when executing `docker images`, see:
+[buildx issue #59](https://github.com/docker/buildx/issues/59).
+
+#### Push the manifest-list with container image per arch
+
+```bash
+make push-all
+```
+
+The resulting container image can be used in the same way on each arch by pulling
+e.g. `node-feature-discovery:v0.10.0` without specifying the architechture. The
+manifest-list will take care of providing the right architecture image.
+
 #### Change the job spec to use your custom image (optional)
 
 To use your published image from the step above instead of the
@@ -88,6 +114,8 @@ makefile overrides.
 | HOSTMOUNT_PREFIX           | Prefix of system directories for feature discovery (local builds) | / (*local builds*) /host- (*container builds*)
 | IMAGE_BUILD_CMD            | Command to build the image                                        | docker build
 | IMAGE_BUILD_EXTRA_OPTS     | Extra options to pass to build command                            | *empty*
+| IMAGE_BUILDX_CMD           | Command to build and push multi-arch images with buildx           | DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --platform=${IMAGE_ALL_PLATFORMS} --progress=auto --pull
+| IMAGE_ALL_PLATFORMS        | Comma seperated list of OS/ARCH tuples for mulit-arch builds    | linux/amd64,linux/arm64
 | IMAGE_PUSH_CMD             | Command to push the image to remote registry                      | docker push
 | IMAGE_REGISTRY             | Container image registry to use                                   | k8s.gcr.io/nfd
 | IMAGE_TAG_NAME             | Container image tag name                                          | &lt;nfd version&gt;

--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -15,16 +15,11 @@ sort: 3
 
 ---
 
-## Requirements
-
-1. Linux (x86_64/Arm64/Arm)
-1. [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) v1.21 or
-   later (properly set up and configured to work with your Kubernetes cluster)
-
 ## Image variants
 
 NFD currently offers two variants of the container image. The "full" variant is
-currently deployed by default.
+currently deployed by default. Released container images are available for
+x86_64 and Arm64 architectures.
 
 ### Full
 
@@ -89,7 +84,9 @@ to the metadata of NodeFeatureDiscovery object above.
 
 ### Deployment with kustomize
 
-The kustomize overlays provided in the repo can be used directly:
+This requires [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl)
+v1.21 or later. The kustomize overlays provided in the repo can be used
+directly:
 
 ```bash
 kubectl apply -k https://github.com/kubernetes-sigs/node-feature-discovery/deployment/overlays/default?ref={{ site.release }}

--- a/hack/init-buildx.sh
+++ b/hack/init-buildx.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit -o nounset -o pipefail
+
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+# We can skip setup if the current builder already has multi-arch
+# AND if it isn't the docker driver, which doesn't work
+current_builder="$(docker buildx inspect)"
+# linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
+if ! grep -q "^Driver: docker$"  <<<"${current_builder}" && \
+     grep -q "linux/amd64" <<<"${current_builder}" && \
+     grep -q "linux/arm64" <<<"${current_builder}"; then
+  exit 0
+fi
+
+# Ensure qemu is in binfmt_misc
+# Docker desktop already has these in versions recent enough to have buildx
+# We only need to do this setup on linux hosts
+if [ "$(uname)" == 'Linux' ]; then
+  # NOTE: this is pinned to a digest for a reason!
+  docker run --rm --privileged tonistiigi/binfmt:qemu-v6.1.0@sha256:11128304bc582dc7dbaa35947ff3e52e2610d23cecb410ddfa381a6ce74fa763 --install all
+fi
+
+# Ensure we use a builder that can leverage it (the default on linux will not)
+docker buildx rm nfd-builder || true
+docker buildx create --use --name=nfd-builder                 \
+  ${http_proxy:+--driver-opt env.http_proxy="$http_proxy"}    \
+  ${HTTP_PROXY:+--driver-opt env.HTTP_PROXY="$HTTP_PROXY"}    \
+  ${https_proxy:+--driver-opt env.https_proxy="$https_proxy"} \
+  ${HTTPS_PROXY:+--driver-opt env.HTTPS_PROXY="$HTTPS_PROXY"} \
+  ${no_proxy:+--driver-opt '"env.no_proxy='$no_proxy'"'}      \
+  ${NO_PROXY:+--driver-opt '"env.NO_PROXY='$NO_PROXY'"'}

--- a/pkg/nfd-client/topology-updater/nfd-topology-updater_test.go
+++ b/pkg/nfd-client/topology-updater/nfd-topology-updater_test.go
@@ -53,7 +53,7 @@ func setupTest(args *nfdmaster.Args) testContext {
 		ctx.errs <- ctx.master.Run()
 		close(ctx.errs)
 	}()
-	ready := ctx.master.WaitForReady(time.Second)
+	ready := ctx.master.WaitForReady(5 * time.Second)
 	if !ready {
 		fmt.Println("Test setup failed: timeout while waiting for nfd-master")
 		os.Exit(1)

--- a/pkg/nfd-client/worker/nfd-worker_test.go
+++ b/pkg/nfd-client/worker/nfd-worker_test.go
@@ -54,7 +54,7 @@ func setupTest(args *master.Args) testContext {
 		ctx.errs <- ctx.master.Run()
 		close(ctx.errs)
 	}()
-	ready := ctx.master.WaitForReady(time.Second)
+	ready := ctx.master.WaitForReady(5 * time.Second)
 	if !ready {
 		fmt.Println("Test setup failed: timeout while waiting for nfd-master")
 		os.Exit(1)

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -241,8 +241,11 @@ func (m *nfdMaster) Run() error {
 				return err
 			}
 
-		case <-grpcErr:
-			return fmt.Errorf("gRPC server exited with an error: %v", err)
+		case err := <-grpcErr:
+			if err != nil {
+				return fmt.Errorf("gRPC server exited with an error: %v", err)
+			}
+			klog.Infof("gRPC server stopped")
 
 		case <-m.stop:
 			klog.Infof("shutting down nfd-master")

--- a/scripts/test-infra/build-image-cross.sh
+++ b/scripts/test-infra/build-image-cross.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+# cross build
+make image-all

--- a/scripts/test-infra/build-image.sh
+++ b/scripts/test-infra/build-image.sh
@@ -2,6 +2,3 @@
 
 # local build
 make image
-
-# cross build
-make image-all

--- a/scripts/test-infra/build-image.sh
+++ b/scripts/test-infra/build-image.sh
@@ -1,3 +1,7 @@
 #!/bin/bash -e
 
+# local build
 make image
+
+# cross build
+make image-all

--- a/scripts/test-infra/push-image.sh
+++ b/scripts/test-infra/push-image.sh
@@ -5,4 +5,8 @@
 # container image tag
 VERSION_OVERRIDE=${_GIT_TAG+VERSION=${_GIT_TAG:10}}
 
+# Authenticate in order to be able to push images
+gcloud auth configure-docker
+
+# Build and push images
 make push-all $VERSION_OVERRIDE

--- a/scripts/test-infra/push-image.sh
+++ b/scripts/test-infra/push-image.sh
@@ -5,5 +5,4 @@
 # container image tag
 VERSION_OVERRIDE=${_GIT_TAG+VERSION=${_GIT_TAG:10}}
 
-make image $VERSION_OVERRIDE
-make push $VERSION_OVERRIDE
+make push-all $VERSION_OVERRIDE

--- a/scripts/test-infra/test-e2e.sh
+++ b/scripts/test-infra/test-e2e.sh
@@ -19,7 +19,7 @@ i=1
 while true; do
     if make poll-images; then
         break
-    elif [ $i -ge 12 ]; then
+    elif [ $i -ge 27 ]; then
         echo "ERROR: too many tries when polling for image"
         exit 1
     fi


### PR DESCRIPTION
Enables multi arch (amd64 and arm64) builds on the `release-0.10` branch. Done by cherry-picking required commits from `master`.