### PR TITLE
docs: drop topology-updater cmdline help from developer guide

### DIFF
--- a/docs/advanced/developer-guide.md
+++ b/docs/advanced/developer-guide.md
@@ -218,66 +218,6 @@ $ docker run --rm --network=container:nfd-test ${NFD_CONTAINER_IMAGE} nfd-topolo
 If you just want to try out feature discovery without connecting to nfd-master,
 pass the `-no-publish` flag to nfd-topology-updater.
 
-Command line flags of nfd-topology-updater:
-
-```bash
-$ docker run --rm ${NFD_CONTAINER_IMAGE} nfd-topology-updater -help
-docker run --rm  quay.io/swsehgal/node-feature-discovery:v0.10.0-devel-64-g93a0a9f-dirty nfd-topology-updater -help
-Usage of nfd-topology-updater:
-  -add_dir_header
-       If true, adds the file directory to the header of the log messages
-  -alsologtostderr
-       log to standard error as well as files
-  -ca-file string
-       Root certificate for verifying connections
-  -cert-file string
-       Certificate used for authenticating connections
-  -key-file string
-       Private key matching -cert-file
-  -kubeconfig string
-       Kube config file.
-  -kubelet-config-file string
-       Kubelet config file path. (default "/host-var/lib/kubelet/config.yaml")
-  -log_backtrace_at value
-       when logging hits line file:N, emit a stack trace
-  -log_dir string
-       If non-empty, write log files in this directory
-  -log_file string
-       If non-empty, use this log file
-  -log_file_max_size uint
-       Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-  -logtostderr
-       log to standard error instead of files (default true)
-  -no-publish
-       Do not publish discovered features to the cluster-local Kubernetes API server.
-  -one_output
-       If true, only write logs to their native severity level (vs also writing to each lower severity level)
-  -oneshot
-       Update once and exit
-  -podresources-socket string
-       Pod Resource Socket path to use. (default "/host-var/lib/kubelet/pod-resources/kubelet.sock")
-  -server string
-       NFD server address to connecto to. (default "localhost:8080")
-  -server-name-override string
-       Hostname expected from server certificate, useful in testing
-  -skip_headers
-       If true, avoid header prefixes in the log messages
-  -skip_log_headers
-       If true, avoid headers when opening log files
-  -sleep-interval duration
-       Time to sleep between CR updates. Non-positive value implies no CR updatation (i.e. infinite sleep). [Default: 60s] (default 1m0s)
-  -stderrthreshold value
-       logs at or above this threshold go to stderr (default 2)
-  -v value
-       number for the log level verbosity
-  -version
-       Print version and exit.
-  -vmodule value
-       comma-separated list of pattern=N settings for file-filtered logging
-  -watch-namespace string
-       Namespace to watch pods (for testing/debugging purpose). Use * for all namespaces. (default "*")
-```
-
 NOTE:
 
 NFD topology updater needs certain directories and/or files from the


### PR DESCRIPTION
Similar to what we did for nfd-master and nfd-worker in
0d21b3d7200272157438b76a62f7aad1361fe31e.