### PR TITLE
docs: use new custom rule format in worker config reference

### DIFF
--- a/docs/advanced/worker-configuration-reference.md
+++ b/docs/advanced/worker-configuration-reference.md
@@ -408,20 +408,25 @@ With the example config above NFD would publish labels like:
 
 List of rules to process in the custom feature source to create user-specific
 labels. Refer to the documentation of the
-[custom feature source](../get-started/features.html#custom) for details of
-the available rules and their configuration.
+[custom feature source](customization-guide.html#custom-feature-source) for
+details of the available rules and their configuration.
 
 Default: *empty*
 
 Example:
 
 ```yaml
-source:
+sources:
   custom:
-  - name: "my.custom.feature"
-    matchOn:
-    - loadedKMod: ["e1000e"]
-    - pciId:
-        class: ["0200"]
-        vendor: ["8086"]
+    - name: "my custom rule"
+      labels:
+        my-custom-feature: "true"
+      matchFeatures:
+        - feature: kernel.loadedmodule
+          matchExpressions:
+            e1000e: {op: Exists}
+        - feature: pci.device
+          matchExpressions:
+            class: {op: In, value: ["0200"]}
+            vendor: {op: In, value: ["8086"]}
 ```


### PR DESCRIPTION
Also, update the reference linking to the documentation of the custom
source to point to the customization guide.