### PR TITLE
scripts/prepare-release: fix upating of readme

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -93,7 +93,9 @@ if [ -z "$assets_only" ]; then
 
     # Patch README
     echo Patching README.md to refer to $release
-    sed s"!node-feature-discovery/v.*/!node-feature-discovery/$release/!" -i README.md
+    sed -e s"!\(node-feature-discovery/deployment/.*\)=v.*!\1=$release!" \
+        -e s"!^\[documentation\]:.*![documentation]: https://kubernetes-sigs.github.io/node-feature-discovery/$docs_version!" \
+        -i README.md
 
     # Patch deployment templates
     echo Patching kustomize templates to use $container_image


### PR DESCRIPTION
Fix the sed script to update the version of kustomize overlay.

Also, add a sed script to update the documentation link to point to the
correct version in gh-pages.