### PR TITLE
docs: re-fix operator deployment instructions

### DIFF
--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -54,7 +54,7 @@ is recommended to be done via
 1. Install the operator:
 
    ```bash
-   kubectl create -f https://operatorhub.io/install/stable/nfd-operator.yaml
+   kubectl create -f https://operatorhub.io/install/nfd-operator.yaml
    ```
 
 1. Create `NodeFeatureDiscovery` object (in `nfd` namespace here):


### PR DESCRIPTION
Back to how it was - the 'stable' channel went away in the latest NFD
update on community-opetors (operatorhub.io).