### PR TITLE
[release-0.9] Revert "scripts: disable gofmt check in ci"

### DIFF
--- a/scripts/test-infra/verify.sh
+++ b/scripts/test-infra/verify.sh
@@ -7,6 +7,7 @@ export PATH=$PATH:$(go env GOPATH)/bin
 curl -sfL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash -s -- --version v3.5.2
 
 # Run verify steps
+make gofmt-verify
 make ci-lint
 make helm-lint
 


### PR DESCRIPTION
This reverts commit 24425ed16f2162eb6d4ff9149de5b7e7f76577f0.

Tests if https://github.com/kubernetes/test-infra/pull/25023 works as expected