### PR TITLE
tls: require min TLS version 1.3

### DIFF
--- a/pkg/nfd-client/base.go
+++ b/pkg/nfd-client/base.go
@@ -118,6 +118,7 @@ func (w *NfdBaseClient) Connect() error {
 			Certificates: []tls.Certificate{cert},
 			RootCAs:      caPool,
 			ServerName:   w.args.ServerNameOverride,
+			MinVersion:   tls.VersionTLS13,
 		}
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	} else {

--- a/pkg/utils/tls.go
+++ b/pkg/utils/tls.go
@@ -65,6 +65,7 @@ func (c *TlsConfig) UpdateConfig(certFile, keyFile, caFile string) error {
 		ClientCAs:          caPool,
 		ClientAuth:         tls.RequireAndVerifyClientCert,
 		GetConfigForClient: c.GetConfig,
+		MinVersion:         tls.VersionTLS13,
 	}
 	return nil
 }


### PR DESCRIPTION
Deny deprecated TLS versions (1.0 and 1.1). We don't really excpect
other clients than NFD itself so we can just request the latest version.

Fixes #780