### PR TITLE
Add ServiceAccount for nfd-worker

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/_helpers.tpl
+++ b/deployment/helm/node-feature-discovery/templates/_helpers.tpl
@@ -52,13 +52,24 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
-Create the name of the service account to use
+Create the name of the service account which the nfd master will use
 */}}
-{{- define "node-feature-discovery.serviceAccountName" -}}
+{{- define "node-feature-discovery.master.serviceAccountName" -}}
 {{- if .Values.master.serviceAccount.create -}}
     {{ default (include "node-feature-discovery.fullname" .) .Values.master.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.master.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account which the nfd worker will use
+*/}}
+{{- define "node-feature-discovery.worker.serviceAccountName" -}}
+{{- if .Values.worker.serviceAccount.create -}}
+    {{ default (printf "%s-worker" (include "node-feature-discovery.fullname" .)) .Values.worker.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.worker.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 

--- a/deployment/helm/node-feature-discovery/templates/clusterrolebinding.yaml
+++ b/deployment/helm/node-feature-discovery/templates/clusterrolebinding.yaml
@@ -11,7 +11,7 @@ roleRef:
   name: {{ include "node-feature-discovery.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "node-feature-discovery.serviceAccountName" . }}
+  name: {{ include "node-feature-discovery.master.serviceAccountName" . }}
   namespace: {{ $.Release.Namespace }}
 {{- end }}
 

--- a/deployment/helm/node-feature-discovery/templates/master.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master.yaml
@@ -23,7 +23,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      serviceAccountName: {{ include "node-feature-discovery.serviceAccountName" . }}
+      serviceAccountName: {{ include "node-feature-discovery.master.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.master.podSecurityContext | nindent 8 }}
       containers:

--- a/deployment/helm/node-feature-discovery/templates/serviceaccount.yaml
+++ b/deployment/helm/node-feature-discovery/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "node-feature-discovery.serviceAccountName" . }}
+  name: {{ include "node-feature-discovery.master.serviceAccountName" . }}
   labels:
     {{- include "node-feature-discovery.labels" . | nindent 4 }}
   {{- with .Values.master.serviceAccount.annotations }}
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 
 ---
-{{- if .Values.topologyUpdater.serviceAccount.create -}}
+{{- if .Values.topologyUpdater.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -20,6 +20,20 @@ metadata:
   labels:
     {{- include "node-feature-discovery.labels" . | nindent 4 }}
   {{- with .Values.topologyUpdater.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+
+---
+{{- if .Values.worker.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "node-feature-discovery.worker.serviceAccountName" . }}
+  labels:
+    {{- include "node-feature-discovery.labels" . | nindent 4 }}
+  {{- with .Values.worker.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/deployment/helm/node-feature-discovery/templates/worker.yaml
+++ b/deployment/helm/node-feature-discovery/templates/worker.yaml
@@ -23,6 +23,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      serviceAccountName: {{ include "node-feature-discovery.worker.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.worker.podSecurityContext | nindent 8 }}
       containers:

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -326,6 +326,16 @@ worker:
     runAsNonRoot: true
     # runAsUser: 1000
 
+  serviceAccount:
+    # Specifies whether a service account should be created.
+    # We create this by default to make it easier for downstream users to apply PodSecurityPolicies.
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name:
+
   # Allow users to mount the hostPath /usr/src, useful for RHCOS on s390x
   # Does not work on systems without /usr/src AND a read-only /usr, such as Talos
   mountUsrSrc: false


### PR DESCRIPTION
This PR creates a separate ServiceAccount for the nfd-worker like the other components.

Even though the nfd-worker doesn't need any special RBAC permissions, this feature is useful for nvidia/gpu-operator which supports PodSecurityPolicies. But since nfd-worker doesn't have its own ServiceAccount, they've bolted on this feature into their fork, which is giving them issues: https://github.com/NVIDIA/gpu-operator/issues/314 https://gitlab.com/nvidia/kubernetes/gpu-operator/-/merge_requests/414#note_854845708

 PodSecurityPolicies are used to grant special permission to nfd-worker to create hostPath volumes.