### PR TITLE
topologyupdater: Prevent crash with incorrect node id

### DIFF
--- a/pkg/resourcemonitor/noderesourcesaggregator.go
+++ b/pkg/resourcemonitor/noderesourcesaggregator.go
@@ -246,6 +246,11 @@ func (noderesourceData *nodeResources) updateAvailable(numaData map[int]map[v1.R
 			klog.Infof("unknown resource %q: %q", resName, resID)
 			continue
 		}
+		if _, ok := numaData[nodeID]; !ok {
+			klog.Infof("unknown node id: %q", nodeID)
+			continue
+		}
+
 		numaData[nodeID][ri.Name].available--
 	}
 }


### PR DESCRIPTION
It's possible for device plugins to advertise non-existent
numa node ids that cause topology updater to crash.

Signed-off-by: Tuomas Katila <tuomas.katila@intel.com>