### PR TITLE
apis/nfd: empty match expression set returns no features for templates

### DIFF
--- a/docs/advanced/customization-guide.md
+++ b/docs/advanced/customization-guide.md
@@ -420,10 +420,6 @@ element whose name matches the `<key>`. However, for *instance* features all
 MatchExpressions are evaluated against the attributes of each instance
 separately.
 
-A special case of an empty `matchExpressions` field matches everything, i.e.
-matches/returns all elements of the feature. This makes it possible to write
-[templates](#templating) that run over all discovered features.
-
 #### MatchAny
 
 The `.matchAny` field is a list of of [`matchFeatures`](#matchfeatures)
@@ -623,27 +619,6 @@ would be executed on matcher#1 as well as on matcher#2 and/or matcher#3
 (depending on whether both or only one of them match). All the labels from
 these separate expansions would be created, i.e. the end result would be a
 union of all the individual expansions.
-
-A special case of an empty `matchExpressions` field matches everything, i.e.
-matches/returns all elements of the feature. This makes it possible to write
-[templates](#templating) that run over all discovered features.
-
-Consider the following example:
-<!-- {% raw %} -->
-
-```yaml
-    labelsTemplate: |
-      {{ range .network.device }}net-{{ .name }}.speed-mbps={{ .speed }}
-      {{ end }}
-    matchFeatures:
-      - feature: network.device
-        matchExpressions: null
-```
-
-<!-- {% endraw %} -->
-This will create individual
-`feature.node.kubernetes.io/net-<if-name>.speed-mbpx=<speed-in-mbps>` label for
-each (physical) network device of the system.
 
 Rule templates use the Golang [text/template](https://pkg.go.dev/text/template)
 package and all its built-in functionality (e.g. pipelines and functions) can

--- a/pkg/apis/nfd/v1alpha1/expression_test.go
+++ b/pkg/apis/nfd/v1alpha1/expression_test.go
@@ -306,7 +306,7 @@ func TestMESMatchKeys(t *testing.T) {
 
 		{input: I{}, output: O{}, result: assert.Truef, err: assert.Nilf},
 
-		{input: I{"foo": {}}, output: O{MK{Name: "foo"}}, result: assert.Truef, err: assert.Nilf},
+		{input: I{"foo": {}}, output: O{}, result: assert.Truef, err: assert.Nilf},
 
 		{mes: `
 foo: { op: DoesNotExist }
@@ -339,11 +339,12 @@ bar: { op: Exists }
 			t.Fatalf("failed to parse data of test case #%d (%v): %v", i, tc, err)
 		}
 
-		out, err := mes.MatchGetKeys(tc.input)
+		res, out, err := mes.MatchGetKeys(tc.input)
+		tc.result(t, res, "test case #%d (%v) failed", i, tc)
 		assert.Equalf(t, tc.output, out, "test case #%d (%v) failed", i, tc)
 		tc.err(t, err, "test case #%d (%v) failed", i, tc)
 
-		res, err := mes.MatchKeys(tc.input)
+		res, err = mes.MatchKeys(tc.input)
 		tc.result(t, res, "test case #%d (%v) failed", i, tc)
 		tc.err(t, err, "test case #%d (%v) failed", i, tc)
 	}
@@ -366,7 +367,7 @@ func TestMESMatchValues(t *testing.T) {
 
 		{input: I{}, output: O{}, result: assert.Truef, err: assert.Nilf},
 
-		{input: I{"foo": "bar"}, output: O{MV{Name: "foo", Value: "bar"}}, result: assert.Truef, err: assert.Nilf},
+		{input: I{"foo": "bar"}, output: O{}, result: assert.Truef, err: assert.Nilf},
 
 		{mes: `
 foo: { op: Exists }
@@ -400,11 +401,12 @@ baz: { op: Gt, value: ["10"] }
 			t.Fatalf("failed to parse data of test case #%d (%v): %v", i, tc, err)
 		}
 
-		out, err := mes.MatchGetValues(tc.input)
+		res, out, err := mes.MatchGetValues(tc.input)
+		tc.result(t, res, "test case #%d (%v) failed", i, tc)
 		assert.Equalf(t, tc.output, out, "test case #%d (%v) failed", i, tc)
 		tc.err(t, err, "test case #%d (%v) failed", i, tc)
 
-		res, err := mes.MatchValues(tc.input)
+		res, err = mes.MatchValues(tc.input)
 		tc.result(t, res, "test case #%d (%v) failed", i, tc)
 		tc.err(t, err, "test case #%d (%v) failed", i, tc)
 	}

--- a/pkg/apis/nfd/v1alpha1/rule_test.go
+++ b/pkg/apis/nfd/v1alpha1/rule_test.go
@@ -82,6 +82,17 @@ func TestRule(t *testing.T) {
 	assert.Nilf(t, err, "unexpected error: %v", err)
 	assert.Equal(t, r1.Labels, m.Labels, "empty matcher should have matched empty features")
 
+	// Test empty MatchExpressions
+	r1.MatchFeatures = FeatureMatcher{
+		FeatureMatcherTerm{
+			Feature:          "domain-1.kf-1",
+			MatchExpressions: MatchExpressionSet{},
+		},
+	}
+	m, err = r1.Execute(f)
+	assert.Nilf(t, err, "unexpected error: %v", err)
+	assert.Equal(t, r1.Labels, m.Labels, "empty match expression set mathces anything")
+
 	// Match "key" features
 	m, err = r2.Execute(f)
 	assert.Nilf(t, err, "unexpected error: %v", err)
@@ -325,8 +336,11 @@ var-2=
 			// We need at least one matcher to match to execute the template.
 			// Use a simple empty matchexpression set to match anything.
 			FeatureMatcherTerm{
-				Feature:          "domain_1.kf_1",
-				MatchExpressions: MatchExpressionSet{},
+				Feature: "domain_1.kf_1",
+				MatchExpressions: MatchExpressionSet{Expressions: Expressions{
+					"key-a": MustCreateMatchExpression(MatchExists),
+				},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
This patch changes a rare corner case of custom label rules with an
empty set of matchexpressions. The patch removes a special case where an
empty match expression set matched everything and returned all feature
elements for templates to consume. With this patch the match expression
set logically evaluates all expressions in the set and returns all
matches - if there are no expressions there are no matches and no
matched features are returned. However, the overall match result
(determining if "non-template" labels will be created) in this special
case will be "true" as before as none of the zero match expressions
failed.

The former behavior was somewhat illogical and counterintuitive: having
1 to N expressions matched and returned 1 to N features (at most), but,
having 0 expressions always matched everything and returned all
features. This was some leftover proof-of-concept functionality (for
some possible future extensions) that should have been removed before
merging.