### PR TITLE
cpu: Discover IBM Secure Execution

### DIFF
--- a/docs/advanced/customization-guide.md
+++ b/docs/advanced/customization-guide.md
@@ -492,6 +492,8 @@ The following features are available for matching:
 |                  |              | **`enabled`** | bool  | `true` if Intel SGX has been enabled, otherwise does not exist
 | **`cpu.sst`**    | attribute    |          |            | Intel SST (Speed Select Technology) capabilities
 |                  |              | **`bf.enabled`** | bool | `true` if Intel SST-BF (Intel Speed Select Technology - Base frequency) has been enabled, otherwise does not exist
+| **`cpu.se`**     | attribute    |          |            | IBM Secure Execution for Linux (IBM Z & LinuxONE)
+|                  |              | **`enabled`** | bool  | `true` if IBM Secure Execution for Linux is available and has been enabled, otherwise does not exist
 | **`cpu.topology`** | attribute  |          |            | CPU topology related features
 | | |          **`hardware_multithreading`** | bool       | Hardware multithreading, such as Intel HTT, is enabled
 | **`kernel.config`** | attribute |          |            | Kernel configuration options

--- a/docs/get-started/features.md
+++ b/docs/get-started/features.md
@@ -51,6 +51,7 @@ such as restricting discovered features with the -label-whitelist option.*
 | **`cpu-cstate.enabled`**          | bool   | Set to 'true' if cstates are set in the intel_idle driver, otherwise set to 'false'. Unset if intel_idle cpuidle driver is not active.
 | **`cpu-rdt.<rdt-flag>`**          | true   | [Intel RDT][intel-rdt] capability is supported. See [RDT flags](#intel-rdt-flags) for details.
 | **`cpu-sgx.enabled`**             | true   | Set to 'true' if Intel SGX is enabled in BIOS (based a non-zero sum value of SGX EPC section sizes).
+| **`cpu-se.enabled`**              | true   | Set to 'true' if IBM Secure Execution for Linux (IBM Z & LinuxONE) is available and enabled (requires `/sys/firmware/uv/prot_virt_host` facility)
 | **`cpu-model.vendor_id`**         | string | Comparable CPU vendor ID.
 | **`cpu-model.family`**            | int    | CPU family.
 | **`cpu-model.id`**                | int    | CPU model number.

--- a/source/cpu/cpu.go
+++ b/source/cpu/cpu.go
@@ -38,6 +38,7 @@ const (
 	CstateFeature   = "cstate"
 	PstateFeature   = "pstate"
 	RdtFeature      = "rdt"
+	SeFeature       = "se"
 	SgxFeature      = "sgx"
 	SstFeature      = "sst"
 	TopologyFeature = "topology"
@@ -169,6 +170,11 @@ func (s *cpuSource) GetLabels() (source.FeatureLabels, error) {
 		labels["sgx."+k] = v
 	}
 
+	// Secure Execution
+	for k, v := range features.Values[SeFeature].Elements {
+		labels["se."+k] = v
+	}
+
 	// SST
 	for k, v := range features.Values[SstFeature].Elements {
 		labels["power.sst_"+k] = v
@@ -212,6 +218,9 @@ func (s *cpuSource) Discover() error {
 
 	// Detect SGX features
 	s.features.Values[SgxFeature] = feature.NewValueFeatures(discoverSGX())
+
+	// Detect Secure Execution features
+	s.features.Values[SeFeature] = feature.NewValueFeatures(discoverSE())
 
 	// Detect SST features
 	s.features.Values[SstFeature] = feature.NewValueFeatures(discoverSST())

--- a/source/cpu/se_s390x.go
+++ b/source/cpu/se_s390x.go
@@ -1,0 +1,40 @@
+//go:build s390x
+// +build s390x
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpu
+
+import (
+	"os"
+
+	"sigs.k8s.io/node-feature-discovery/source"
+)
+
+func discoverSE() map[string]string {
+	se := make(map[string]string)
+	// This file is available in kernels >=5.12 + backports. Skip specifically
+	// checking facilities and kernel command lines and just assume Secure
+	// Execution to be unavailable or disabled if the file is not present.
+	protVirtHost := source.SysfsDir.Path("firmware/uv/prot_virt_host")
+	if content, err := os.ReadFile(protVirtHost); err == nil {
+		if string(content) == "1\n" {
+			se["enabled"] = "true"
+		}
+	}
+	return se
+}

--- a/source/cpu/se_stub.go
+++ b/source/cpu/se_stub.go
@@ -1,0 +1,25 @@
+//go:build !s390x
+// +build !s390x
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpu
+
+// Secure Execution is exclusive to s390x
+func discoverSE() map[string]string {
+	return nil
+}


### PR DESCRIPTION
Set `cpu.se-enabled` to `true` when IBM Secure Execution for Linux (IBM Z & LinuxONE) is available and has been enabled.

Uses `/sys/firmware/uv/prot_virt_host`, which is available in kernels >=5.12 + backports. For simplicity, skip more complicated facility & kernel cmdline lookups.