### PR TITLE
Add cpu-model feature detection

### DIFF
--- a/docs/advanced/customization-guide.md
+++ b/docs/advanced/customization-guide.md
@@ -482,6 +482,10 @@ The following features are available for matching:
 |                  |              | **`<cpuid-flag>`** |  | CPUID flag is present
 | **`cpu.cstate`** | attribute    |          |            | Status of cstates in the intel_idle cpuidle driver
 |                  |              | **`enabled`** | bool  | 'true' if cstates are set, otherwise 'false'. Does not exist of intel_idle driver is not active.
+| **`cpu.model`**  | attribute    |          |            | CPU model related attributes
+|                  |              | **`family`** | string | CPU family
+|                  |              | **`vendor_id`** | string | CPU vendor ID
+|                  |              | **`id`** | string     | CPU model ID
 | **`cpu.pstate`** | attribute    |          |            | State of the Intel pstate driver. Does not exist if the driver is not enabled.
 |                  |              | **`status`** | string | Status of the driver, possible values are 'active' and 'passive'
 |                  |              | **`turbo`**  | bool   | 'true' if turbo frequencies are enabled, otherwise 'false'

--- a/docs/advanced/customization-guide.md
+++ b/docs/advanced/customization-guide.md
@@ -483,9 +483,9 @@ The following features are available for matching:
 | **`cpu.cstate`** | attribute    |          |            | Status of cstates in the intel_idle cpuidle driver
 |                  |              | **`enabled`** | bool  | 'true' if cstates are set, otherwise 'false'. Does not exist of intel_idle driver is not active.
 | **`cpu.model`**  | attribute    |          |            | CPU model related attributes
-|                  |              | **`family`** | string | CPU family
+|                  |              | **`family`** | int    | CPU family
 |                  |              | **`vendor_id`** | string | CPU vendor ID
-|                  |              | **`id`** | string     | CPU model ID
+|                  |              | **`id`** | int        | CPU model ID
 | **`cpu.pstate`** | attribute    |          |            | State of the Intel pstate driver. Does not exist if the driver is not enabled.
 |                  |              | **`status`** | string | Status of the driver, possible values are 'active' and 'passive'
 |                  |              | **`turbo`**  | bool   | 'true' if turbo frequencies are enabled, otherwise 'false'

--- a/docs/get-started/features.md
+++ b/docs/get-started/features.md
@@ -51,6 +51,9 @@ such as restricting discovered features with the -label-whitelist option.*
 | **`cpu-cstate.enabled`**          | bool   | Set to 'true' if cstates are set in the intel_idle driver, otherwise set to 'false'. Unset if intel_idle cpuidle driver is not active.
 | **`cpu-rdt.<rdt-flag>`**          | true   | [Intel RDT][intel-rdt] capability is supported. See [RDT flags](#intel-rdt-flags) for details.
 | **`cpu-sgx.enabled`**             | true   | Set to 'true' if Intel SGX is enabled in BIOS (based a non-zero sum value of SGX EPC section sizes).
+| **`cpu-model.vendor_id`**         | string | Comparable CPU vendor ID.
+| **`cpu-model.family`**            | int    | CPU family.
+| **`cpu-model.id`**                | int    | CPU model number.
 
 The CPU label source is configurable, see
 [worker configuration](deployment-and-usage#worker-configuration) and

--- a/source/cpu/cpu.go
+++ b/source/cpu/cpu.go
@@ -144,7 +144,7 @@ func (s *cpuSource) GetLabels() (source.FeatureLabels, error) {
 		}
 	}
 
-	// CPUMODEL
+	// CPU model
 	for k, v := range features.Values[Cpumodel].Elements {
 		labels["model."+k] = v
 	}


### PR DESCRIPTION
Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>
First pass on enhancing the discovered model of the CPU
example:
```bash
                    feature.node.kubernetes.io/cpu-model.ID=113
                    feature.node.kubernetes.io/cpu-model.family=23
                    feature.node.kubernetes.io/cpu-model.vendorID=AMD
```