### PR TITLE
docs: remove fixed release tag in developer guide

### DIFF
--- a/docs/advanced/developer-guide.md
+++ b/docs/advanced/developer-guide.md
@@ -66,8 +66,9 @@ make push-all
 ```
 
 The resulting container image can be used in the same way on each arch by pulling
-e.g. `node-feature-discovery:v0.10.0` without specifying the architecture. The
-manifest-list will take care of providing the right architecture image.
+e.g. `node-feature-discovery:{{ site.release }}` without specifying the
+architecture. The manifest-list will take care of providing the right
+architecture image.
 
 #### Change the job spec to use your custom image (optional)
 


### PR DESCRIPTION
Let the documentation follow the latest release name. Even if it's just
referential here it would look odd in the future if we refer to some
ancient version.