### PR TITLE
scripts/test-infra: bump golangci-lint to v1.45.2

### DIFF
--- a/cmd/nfd-worker/main.go
+++ b/cmd/nfd-worker/main.go
@@ -167,7 +167,7 @@ func initKlogFlags(flagset *flag.FlagSet, args *worker.Args) {
 func klogConfigOptName(flagName string) string {
 	split := strings.Split(flagName, "_")
 	for i, v := range split[1:] {
-		split[i+1] = strings.Title(v)
+		split[i+1] = strings.ToUpper(v[0:1]) + v[1:]
 	}
 	return strings.Join(split, "")
 }

--- a/scripts/test-infra/verify.sh
+++ b/scripts/test-infra/verify.sh
@@ -2,7 +2,7 @@
 
 # Install deps
 gobinpath="$(go env GOPATH)/bin"
-curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b "$gobinpath" v1.42.1
+curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b "$gobinpath" v1.45.2
 export PATH=$PATH:$(go env GOPATH)/bin
 
 curl -sfL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash -s -- --version v3.7.1


### PR DESCRIPTION
Adds support for golang v1.18.