### PR TITLE
Only reload config when files change (according to modtime)

### DIFF
--- a/pkg/utils/fswatcher.go
+++ b/pkg/utils/fswatcher.go
@@ -149,7 +149,7 @@ func (w *FsWatcher) watch() {
 			// If any of our paths change
 			name := filepath.Clean(e.Name)
 			if _, ok := w.paths[name]; ok {
-				klog.Infof("fsnotify %s event in %q detected", e, name)
+				klog.V(2).Infof("fsnotify %s event in %q detected", e, name)
 				// Creation and deletion events should always trigger reloads since stat may fail
 				if e.Op&fsnotify.Create == fsnotify.Create || e.Op&fsnotify.Remove == fsnotify.Remove {
 					ratelimiter = time.After(w.ratelimit)


### PR DESCRIPTION
Fixes #805 by updating `utils.FsWatcher` to only return events to the caller if the file actually changed, according to the modification time of the file.

We still use `fsnotify` so we don't poll the filesystem for updates, but now when `FsWatcher` detects an fsnotify event, it will check the modification time of the file. If the modification time didn't change, the event is ignored.

Using modification times allows us to support mounting the config file via a k8s ConfigMap, since ConfigMaps get re-synced every minute which triggers a lot of fsnotify events, but doesn't actually change the modtime.