### PR TITLE
cpu: add cpuid stub for non-linux platforms

### DIFF
--- a/source/cpu/cpuid_stub.go
+++ b/source/cpu/cpuid_stub.go
@@ -1,0 +1,22 @@
+//go:build !linux
+// +build !linux
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpu
+
+func getCpuidFlags() []string { return nil }


### PR DESCRIPTION
Make it possible to do non-linux builds. Code compiles, at least, even
if the feature detection functionality is virtually Linux-only.