### PR TITLE
docs: fix operator deployment instructions

### DIFF
--- a/docs/get-started/deployment-and-usage.md
+++ b/docs/get-started/deployment-and-usage.md
@@ -73,7 +73,6 @@ is recommended to be done via
      namespace: nfd
    spec:
      operand:
-       namespace: nfd
        image: {{ site.container_image }}
        imagePullPolicy: IfNotPresent
    EOF


### PR DESCRIPTION
Namespace parameter was dropped in operator v0.4.0.