### PR TITLE
source/network: ignore interface operational state

### DIFF
--- a/source/network/network.go
+++ b/source/network/network.go
@@ -70,9 +70,6 @@ func (s *networkSource) GetLabels() (source.FeatureLabels, error) {
 
 	for _, dev := range features.Instances[DeviceFeature].Elements {
 		attrs := dev.Attributes
-		if attrs["operstate"] != "up" {
-			continue
-		}
 		for attr, feature := range map[string]string{
 			"sriov_totalvfs": "sriov.capable",
 			"sriov_numvfs":   "sriov.configured"} {


### PR DESCRIPTION
Ignore the operational state of network interface when creating the
network SR-IOV labels. Previously NFD only considered interfaces which
were "up".

Pre v0.9 we used to check the "administrative state" of interfaces
(managed by the sysadmin with e.g. with ip link set dev <dev> down/up).
In v0.10 we changed to checking the "operational state" of interfaces,
reflecting whether the it is actually able to transfer data. Both these
checks have caused confusion among users and it is more understandable
and more aligned with other HW discovery functions in NFD to just drop
the state check. Also, the documentation is aligned with this behavior.

Fixes #812 