### PR TITLE
helm: add namespace override for multi-namespace deployments

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/_helpers.tpl
+++ b/deployment/helm/node-feature-discovery/templates/_helpers.tpl
@@ -25,6 +25,17 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "node-feature-discovery.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "node-feature-discovery.chart" -}}

--- a/deployment/helm/node-feature-discovery/templates/cert-manager-certs.yaml
+++ b/deployment/helm/node-feature-discovery/templates/cert-manager-certs.yaml
@@ -4,6 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: nfd-master-cert
+  namespace: {{ include "node-feature-discovery.namespace" . }}
 spec:
   secretName: nfd-master-cert
   subject:
@@ -14,8 +15,8 @@ spec:
   # must match the service name
   - {{ include "node-feature-discovery.fullname" . }}-master
   # first one is configured for use by the worker; below are for completeness
-  - {{ include "node-feature-discovery.fullname" . }}-master.{{ $.Release.Namespace }}.svc
-  - {{ include "node-feature-discovery.fullname" . }}-master.{{ $.Release.Namespace }}.svc.cluster.local
+  - {{ include "node-feature-discovery.fullname" . }}-master.{{ include "node-feature-discovery.namespace" .  }}.svc
+  - {{ include "node-feature-discovery.fullname" . }}-master.{{ include "node-feature-discovery.namespace" .  }}.svc.cluster.local
   # localhost needed for grpc_health_probe
   - localhost
   issuerRef:
@@ -28,6 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: nfd-worker-cert
+  namespace: {{ include "node-feature-discovery.namespace" . }}
 spec:
   secretName: nfd-worker-cert
   subject:
@@ -35,7 +37,7 @@ spec:
     - node-feature-discovery
   commonName: nfd-worker
   dnsNames:
-  - {{ include "node-feature-discovery.fullname" . }}-worker.{{ $.Release.Namespace }}.svc.cluster.local
+  - {{ include "node-feature-discovery.fullname" . }}-worker.{{ include "node-feature-discovery.namespace" .  }}.svc.cluster.local
   issuerRef:
     name: nfd-ca-issuer
     kind: Issuer
@@ -47,6 +49,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: nfd-topology-updater-cert
+  namespace: {{ include "node-feature-discovery.namespace" . }}
 spec:
   secretName: nfd-topology-updater-cert
   subject:
@@ -54,7 +57,7 @@ spec:
     - node-feature-discovery
   commonName: nfd-topology-updater
   dnsNames:
-  - {{ include "node-feature-discovery.fullname" . }}-topology-updater.{{ $.Release.Namespace }}.svc.cluster.local
+  - {{ include "node-feature-discovery.fullname" . }}-topology-updater.{{ include "node-feature-discovery.namespace" .  }}.svc.cluster.local
   issuerRef:
     name: nfd-ca-issuer
     kind: Issuer

--- a/deployment/helm/node-feature-discovery/templates/cert-manager-issuer.yaml
+++ b/deployment/helm/node-feature-discovery/templates/cert-manager-issuer.yaml
@@ -8,6 +8,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: nfd-ca-bootstrap
+  namespace: {{ include "node-feature-discovery.namespace" . }}
 spec:
   selfSigned: {}
 
@@ -16,6 +17,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: nfd-ca-cert
+  namespace: {{ include "node-feature-discovery.namespace" . }}
 spec:
   isCA: true
   secretName: nfd-ca-cert
@@ -33,6 +35,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: nfd-ca-issuer
+  namespace: {{ include "node-feature-discovery.namespace" . }}
 spec:
   ca:
     secretName: nfd-ca-cert

--- a/deployment/helm/node-feature-discovery/templates/clusterrolebinding.yaml
+++ b/deployment/helm/node-feature-discovery/templates/clusterrolebinding.yaml
@@ -12,7 +12,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "node-feature-discovery.master.serviceAccountName" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "node-feature-discovery.namespace" .  }}
 {{- end }}
 
 ---
@@ -30,5 +30,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "node-feature-discovery.topologyUpdater.serviceAccountName" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "node-feature-discovery.namespace" .  }}
 {{- end }}

--- a/deployment/helm/node-feature-discovery/templates/master.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name:  {{ include "node-feature-discovery.fullname" . }}-master
+  namespace: {{ include "node-feature-discovery.namespace" . }}
   labels:
     {{- include "node-feature-discovery.labels" . | nindent 4 }}
     role: master

--- a/deployment/helm/node-feature-discovery/templates/nfd-worker-conf.yaml
+++ b/deployment/helm/node-feature-discovery/templates/nfd-worker-conf.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "node-feature-discovery.fullname" . }}-worker-conf
+  namespace: {{ include "node-feature-discovery.namespace" . }}
   labels:
   {{- include "node-feature-discovery.labels" . | nindent 4 }}
 data:

--- a/deployment/helm/node-feature-discovery/templates/service.yaml
+++ b/deployment/helm/node-feature-discovery/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "node-feature-discovery.fullname" . }}-master
+  namespace: {{ include "node-feature-discovery.namespace" . }}
   labels:
     {{- include "node-feature-discovery.labels" . | nindent 4 }}
     role: master

--- a/deployment/helm/node-feature-discovery/templates/serviceaccount.yaml
+++ b/deployment/helm/node-feature-discovery/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "node-feature-discovery.master.serviceAccountName" . }}
+  namespace: {{ include "node-feature-discovery.namespace" . }}
   labels:
     {{- include "node-feature-discovery.labels" . | nindent 4 }}
   {{- with .Values.master.serviceAccount.annotations }}
@@ -17,6 +18,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "node-feature-discovery.topologyUpdater.serviceAccountName" . }}
+  namespace: {{ include "node-feature-discovery.namespace" . }}
   labels:
     {{- include "node-feature-discovery.labels" . | nindent 4 }}
   {{- with .Values.topologyUpdater.serviceAccount.annotations }}
@@ -31,6 +33,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "node-feature-discovery.worker.serviceAccountName" . }}
+  namespace: {{ include "node-feature-discovery.namespace" . }}
   labels:
     {{- include "node-feature-discovery.labels" . | nindent 4 }}
   {{- with .Values.worker.serviceAccount.annotations }}

--- a/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
+++ b/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "node-feature-discovery.fullname" . }}-topology-updater
+  namespace: {{ include "node-feature-discovery.namespace" . }}
   labels:
     {{- include "node-feature-discovery.labels" . | nindent 4 }}
     role: topology-updater

--- a/deployment/helm/node-feature-discovery/templates/worker.yaml
+++ b/deployment/helm/node-feature-discovery/templates/worker.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name:  {{ include "node-feature-discovery.fullname" . }}-worker
+  namespace: {{ include "node-feature-discovery.namespace" . }}
   labels:
     {{- include "node-feature-discovery.labels" . | nindent 4 }}
     role: worker

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -8,6 +8,7 @@ imagePullSecrets: []
 
 nameOverride: ""
 fullnameOverride: ""
+namespaceOverride: ""
 
 nodeFeatureRule:
   createCRD: true


### PR DESCRIPTION
when use this helm chart as other charts' dependency([Helm Dependency](https://helm.sh/docs/helm/helm_dependency/)), helm will install manifests of this chart to parent chart's  namespace, because .Release.Namespace is parent chart's namespace. so, if we want this chart installed to a separated namespace, community of helm project recommend add namespaceOverride (https://github.com/helm/charts/pull/15202), and namespaceOverride is in helm template chart by default now.

many helm charts support namespaceOverride, such as [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/blob/ae0085979db2de39611b60b1c9ddbcf35c3baa91/charts/kube-prometheus-stack/values.yaml#L11)