### PR TITLE
dockerfile: update builder image to golang v1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
+ARG BUILDER_IMAGE
 ARG BASE_IMAGE_FULL
 ARG BASE_IMAGE_MINIMAL
 
 # Build node feature discovery
-FROM golang:1.18.1-buster as builder
+FROM ${BUILDER_IMAGE} as builder
 
 # Build and install the grpc-health-probe binary
 RUN GRPC_HEALTH_PROBE_VERSION=v0.4.6 && \

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ IMAGE_BUILD_CMD ?= docker build
 IMAGE_BUILD_EXTRA_OPTS ?=
 IMAGE_PUSH_CMD ?= docker push
 CONTAINER_RUN_CMD ?= docker run
+BUILDER_IMAGE ?= golang:1.18-buster
 BASE_IMAGE_FULL ?= debian:buster-slim
 BASE_IMAGE_MINIMAL ?= gcr.io/distroless/base
 
@@ -69,9 +70,10 @@ ensure-buildx:
 IMAGE_BUILDX_CMD ?= DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --platform=${IMAGE_ALL_PLATFORMS} --progress=auto --pull
 
 IMAGE_BUILD_ARGS = --build-arg VERSION=$(VERSION) \
-	    	   --build-arg HOSTMOUNT_PREFIX=$(CONTAINER_HOSTMOUNT_PREFIX) \
-	    	   --build-arg BASE_IMAGE_FULL=$(BASE_IMAGE_FULL) \
-	    	   --build-arg BASE_IMAGE_MINIMAL=$(BASE_IMAGE_MINIMAL)
+                --build-arg HOSTMOUNT_PREFIX=$(CONTAINER_HOSTMOUNT_PREFIX) \
+                --build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \
+                --build-arg BASE_IMAGE_FULL=$(BASE_IMAGE_FULL) \
+                --build-arg BASE_IMAGE_MINIMAL=$(BASE_IMAGE_MINIMAL)
 
 IMAGE_BUILD_ARGS_FULL = --target full \
                 	-t $(IMAGE_TAG) \


### PR DESCRIPTION
Switch over to the "non-point-release" version of the image. Now we
always use the latest patch version of golang with latest security
fixes, for example, without the need to manually bump the version after
every point release.

This patch also makes the builder image configurable through a Makefile
variable.

For reproducible builds we should used fixed point-release versions in
release-brances.