### PR TITLE
test/e2e: change node-specific config to a list

### DIFF
--- a/test/e2e/e2e-test-config.example.yaml
+++ b/test/e2e/e2e-test-config.example.yaml
@@ -78,8 +78,8 @@ defaultFeatures:
     - "nfd.node.kubernetes.io/worker.version"
     - "nfd.node.kubernetes.io/feature-labels"
   nodes:
-    # NOTE: keys here are interpreted as regexps
-    my-node-regexp-1:
+    - name: name-of-this-item  # name is purely informational
+      nodeNameRegexp: my-node-regexp-1
       expectedLabelValues:
         "feature.node.kubernetes.io/cpu-cpuid.ADX": "true"
         "feature.node.kubernetes.io/cpu-cpuid.AESNI": "true"


### PR DESCRIPTION
Change the part of the e2e-test configuration that contains
node-specific expected labels and annotations to a list, instead of a
map. This makes the parsing order deterministic and makes it possible to
e.g. have a default at the end of the list that captures "all the rest".