### PR TITLE
Fix templates for NodeFeatureRule with MatchAny

### DIFF
--- a/pkg/apis/nfd/v1alpha1/rule.go
+++ b/pkg/apis/nfd/v1alpha1/rule.go
@@ -50,11 +50,13 @@ func (r *Rule) Execute(features feature.Features) (RuleOutput, error) {
 				matched = true
 				utils.KlogDump(4, "matches for matchAny "+r.Name, "  ", matches)
 
-				if r.labelsTemplate == nil {
-					// No templating so we stop here (further matches would just
-					// produce the same labels)
+				if r.LabelsTemplate == "" && r.VarsTemplate == "" {
+					// there's no need to evaluate other matchers in MatchAny
+					// if there are no templates to be executed on them - so
+					// short-circuit and stop on first match here
 					break
 				}
+
 				if err := r.executeLabelsTemplate(matches, labels); err != nil {
 					return RuleOutput{}, err
 				}

--- a/pkg/apis/nfd/v1alpha1/rule_test.go
+++ b/pkg/apis/nfd/v1alpha1/rule_test.go
@@ -297,6 +297,11 @@ var-2=
 		},
 	}
 
+	// test with empty MatchFeatures, but with MatchAny
+	r3 := r1.DeepCopy()
+	r3.MatchAny = []MatchAnyElem{{MatchFeatures: r3.MatchFeatures}}
+	r3.MatchFeatures = nil
+
 	expectedLabels := map[string]string{
 		"label-1": "label-val-1",
 		"label-2": "",
@@ -321,6 +326,11 @@ var-2=
 	}
 
 	m, err := r1.Execute(f)
+	assert.Nilf(t, err, "unexpected error: %v", err)
+	assert.Equal(t, expectedLabels, m.Labels, "instances should have matched")
+	assert.Equal(t, expectedVars, m.Vars, "instances should have matched")
+
+	m, err = r3.Execute(f)
 	assert.Nilf(t, err, "unexpected error: %v", err)
 	assert.Equal(t, expectedLabels, m.Labels, "instances should have matched")
 	assert.Equal(t, expectedVars, m.Vars, "instances should have matched")


### PR DESCRIPTION
When `MatchAny` is matched, template existence is checked with `r.labelsTemplate == nil`, and if it's nil - templating is skipped.

This is wrong because:
- there are `vars` templates too, not only `labels` templates
- `labelsTemplate` is initialized from `LabelsTemplate` when `executeLabelsTemplate` is called first time, so it would always be nil unless Rule has `MatchFeatures` in addition to `MatchAny`, and was executed already.

`LabelsTemplate` should be checked instead of `labelsTemplate` (same for vars) to see if there's template – but `executeLabelsTemplate` already does that.

So the check should be removed completely.

I've also added a test case which catches this issue.

Fixes #864.