### PR TITLE
Discover Node Features as annotations based on NodeFeatureRules

### DIFF
--- a/cmd/nfd-master/main.go
+++ b/cmd/nfd-master/main.go
@@ -85,6 +85,8 @@ func initFlags(flagset *flag.FlagSet) *master.Args {
 		"Certificate used for authenticating connections")
 	flagset.Var(&args.ExtraLabelNs, "extra-label-ns",
 		"Comma separated list of allowed extra label namespaces")
+	flagset.Var(&args.ExtraAnnotationNs, "extra-annotation-ns",
+		"Comma separated list of allowed extra annotaion namespaces")
 	flagset.StringVar(&args.Instance, "instance", "",
 		"Instance name. Used to separate annotation namespaces for multiple parallel deployments.")
 	flagset.StringVar(&args.KeyFile, "key-file", "",
@@ -93,6 +95,9 @@ func initFlags(flagset *flag.FlagSet) *master.Args {
 		"Kubeconfig to use")
 	flagset.Var(&args.LabelWhiteList, "label-whitelist",
 		"Regular expression to filter label names to publish to the Kubernetes API server. "+
+			"NB: the label namespace is omitted i.e. the filter is only applied to the name part after '/'.")
+	flagset.Var(&args.AnnotationsWhiteList, "annotation-whitelist",
+		"Regular expression to filter annotation names to publish to the Kubernetes API server. "+
 			"NB: the label namespace is omitted i.e. the filter is only applied to the name part after '/'.")
 	flagset.BoolVar(&args.NoPublish, "no-publish", false,
 		"Do not publish feature labels")

--- a/deployment/base/nfd-crds/nodefeaturerule-crd.yaml
+++ b/deployment/base/nfd-crds/nodefeaturerule-crd.yaml
@@ -42,6 +42,17 @@ spec:
                   description: Rule defines a rule for node customization such as
                     labeling.
                   properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations to create if the rule matches.
+                      type: object
+                    annotationsTemplate:
+                      description: AnnotationsTemplate specifies a template to expand
+                        for dynamically generating multiple annotations. Data (after
+                        template expansion) must be keys with an optional value (<key>[=<value>])
+                        separated by newlines.
+                      type: string
                     labels:
                       additionalProperties:
                         type: string

--- a/deployment/helm/node-feature-discovery/manifests/nodefeaturerule-crd.yaml
+++ b/deployment/helm/node-feature-discovery/manifests/nodefeaturerule-crd.yaml
@@ -42,6 +42,17 @@ spec:
                   description: Rule defines a rule for node customization such as
                     labeling.
                   properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations to create if the rule matches.
+                      type: object
+                    annotationsTemplate:
+                      description: AnnotationsTemplate specifies a template to expand
+                        for dynamically generating multiple annotations. Data (after
+                        template expansion) must be keys with an optional value (<key>[=<value>])
+                        separated by newlines.
+                      type: string
                     labels:
                       additionalProperties:
                         type: string

--- a/pkg/apis/nfd/v1alpha1/rule.go
+++ b/pkg/apis/nfd/v1alpha1/rule.go
@@ -50,11 +50,6 @@ func (r *Rule) Execute(features feature.Features) (RuleOutput, error) {
 				matched = true
 				utils.KlogDump(4, "matches for matchAny "+r.Name, "  ", matches)
 
-				if r.labelsTemplate == nil {
-					// No templating so we stop here (further matches would just
-					// produce the same labels)
-					break
-				}
 				if err := r.executeLabelsTemplate(matches, labels); err != nil {
 					return RuleOutput{}, err
 				}

--- a/pkg/apis/nfd/v1alpha1/rule_test.go
+++ b/pkg/apis/nfd/v1alpha1/rule_test.go
@@ -297,6 +297,11 @@ var-2=
 		},
 	}
 
+	// test with empty MatchFeatures, but with MatchAny
+	r3 := r1.DeepCopy()
+	r3.MatchAny = []MatchAnyElem{{MatchFeatures: r3.MatchFeatures}}
+	r3.MatchFeatures = nil
+
 	expectedLabels := map[string]string{
 		"label-1": "label-val-1",
 		"label-2": "",
@@ -321,6 +326,11 @@ var-2=
 	}
 
 	m, err := r1.Execute(f)
+	assert.Nilf(t, err, "unexpected error: %v", err)
+	assert.Equal(t, expectedLabels, m.Labels, "instances should have matched")
+	assert.Equal(t, expectedVars, m.Vars, "instances should have matched")
+
+	m, err = r3.Execute(f)
 	assert.Nilf(t, err, "unexpected error: %v", err)
 	assert.Equal(t, expectedLabels, m.Labels, "instances should have matched")
 	assert.Equal(t, expectedVars, m.Vars, "instances should have matched")

--- a/pkg/apis/nfd/v1alpha1/types.go
+++ b/pkg/apis/nfd/v1alpha1/types.go
@@ -65,6 +65,16 @@ type Rule struct {
 	// +optional
 	LabelsTemplate string `json:"labelsTemplate"`
 
+	// Annotations to create if the rule matches.
+	// +optional
+	Annotations map[string]string `json:"annotations"`
+
+	// AnnotationsTemplate specifies a template to expand for dynamically generating
+	// multiple annotations. Data (after template expansion) must be keys with an
+	// optional value (<key>[=<value>]) separated by newlines.
+	// +optional
+	AnnotationsTemplate string `json:"annotationsTemplate"`
+
 	// Vars is the variables to store if the rule matches. Variables do not
 	// directly inflict any changes in the node object. However, they can be
 	// referenced from other rules enabling more complex rule hierarchies,
@@ -87,8 +97,9 @@ type Rule struct {
 	MatchAny []MatchAnyElem `json:"matchAny"`
 
 	// private helpers/cache for handling golang templates
-	labelsTemplate *templateHelper `json:"-"`
-	varsTemplate   *templateHelper `json:"-"`
+	labelsTemplate      *templateHelper `json:"-"`
+	annotationsTemplate *templateHelper `json:"-"`
+	varsTemplate        *templateHelper `json:"-"`
 }
 
 // MatchAnyElem specifies one sub-matcher of MatchAny.

--- a/pkg/apis/nfd/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/nfd/v1alpha1/zz_generated.deepcopy.go
@@ -292,6 +292,13 @@ func (in *Rule) DeepCopyInto(out *Rule) {
 			(*out)[key] = val
 		}
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Vars != nil {
 		in, out := &in.Vars, &out.Vars
 		*out = make(map[string]string, len(*in))
@@ -315,6 +322,10 @@ func (in *Rule) DeepCopyInto(out *Rule) {
 	}
 	if in.labelsTemplate != nil {
 		in, out := &in.labelsTemplate, &out.labelsTemplate
+		*out = (*in).DeepCopy()
+	}
+	if in.annotationsTemplate != nil {
+		in, out := &in.annotationsTemplate, &out.annotationsTemplate
 		*out = (*in).DeepCopy()
 	}
 	if in.varsTemplate != nil {

--- a/pkg/nfd-master/nfd-master-internal_test.go
+++ b/pkg/nfd-master/nfd-master-internal_test.go
@@ -77,6 +77,12 @@ func TestUpdateNodeFeatures(t *testing.T) {
 		}
 		sort.Strings(fakeFeatureLabelNames)
 
+		fakeFeatureAnnotationNames := make([]string, 0, len(fakeAnnotations))
+		for k := range fakeAnnotations {
+			fakeFeatureAnnotationNames = append(fakeFeatureAnnotationNames, strings.TrimPrefix(k, FeatureAnnotationNs+"/"))
+		}
+		sort.Strings(fakeFeatureAnnotationNames)
+
 		fakeExtResourceNames := make([]string, 0, len(fakeExtResources))
 		for k := range fakeExtResources {
 			fakeExtResourceNames = append(fakeExtResourceNames, strings.TrimPrefix(k, FeatureLabelNs+"/"))
@@ -89,14 +95,18 @@ func TestUpdateNodeFeatures(t *testing.T) {
 		// Mock node with old features
 		mockNode := newMockNode()
 		mockNode.Labels[FeatureLabelNs+"/old-feature"] = "old-value"
-		mockNode.Annotations[AnnotationNsBase+"/feature-labels"] = "old-feature"
+		mockNode.Annotations[AnnotationNsBase+"/"+featureLabelAnnotation] = "old-feature"
+		mockNode.Annotations[AnnotationNsBase+"/"+featureAnnotationsAnnotation] = "old-annotation"
+		mockNode.Annotations[FeatureAnnotationNs+"/old-annotation"] = "old-value"
 
 		Convey("When I successfully update the node with feature labels", func() {
 			// Create a list of expected node metadata patches
 			metadataPatches := []apihelper.JsonPatch{
-				apihelper.NewJsonPatch("replace", "/metadata/annotations", AnnotationNsBase+"/feature-labels", strings.Join(fakeFeatureLabelNames, ",")),
-				apihelper.NewJsonPatch("add", "/metadata/annotations", AnnotationNsBase+"/extended-resources", strings.Join(fakeExtResourceNames, ",")),
+				apihelper.NewJsonPatch("replace", "/metadata/annotations", AnnotationNsBase+"/"+featureLabelAnnotation, strings.Join(fakeFeatureLabelNames, ",")),
+				apihelper.NewJsonPatch("replace", "/metadata/annotations", AnnotationNsBase+"/"+featureAnnotationsAnnotation, strings.Join(fakeFeatureAnnotationNames, ",")),
+				apihelper.NewJsonPatch("add", "/metadata/annotations", AnnotationNsBase+"/"+extendedResourceAnnotation, strings.Join(fakeExtResourceNames, ",")),
 				apihelper.NewJsonPatch("remove", "/metadata/labels", FeatureLabelNs+"/old-feature", ""),
+				apihelper.NewJsonPatch("remove", "/metadata/annotations", FeatureAnnotationNs+"/old-annotation", ""),
 			}
 			for k, v := range fakeFeatureLabels {
 				metadataPatches = append(metadataPatches, apihelper.NewJsonPatch("add", "/metadata/labels", k, v))


### PR DESCRIPTION
This PR fixes #863, it's still WIP, but is ready for review.

Design:
- NFR now has two more properties: annotations and annotationsTemplate, which allow setting Node Features as annotations
- Default NS for such annotations is same as labels – `feature.node.kubernetes.io`, and more can be allowed with `extra-annotation-ns`
- Unlike labels, `profile.node.kubernetes.io` is not allowed by default
- Unlike labels, there's a "restricted" ns – feature annotations can't be in `nfd.node.kubernetes.io`, to avoid conflicts with nfd's internal annotations
- These annotations are tracked in new annotation - `feature-annotations`, just like `feature-labels` or `extended-resources`
- Unlike labels, Annotations can only be set with NodeFeatureRule, and aren't supported on worker side

Docs are yet to be updated, and e2e tests don't cover this new feature at all – partially because there are no e2e tests with NodeFeatureRules in them

It's also written on top of #865, to avoid having to fix conflicts later on, since I'm assuming #865 would be merged before this PR.