### PR TITLE
scripts/test-e2e: install kubectl

### DIFF
--- a/scripts/test-infra/test-e2e.sh
+++ b/scripts/test-infra/test-e2e.sh
@@ -1,9 +1,11 @@
 #!/bin/bash -e
 
 # Install deps
-curl -o $HOME/bin/aws-iam-authenticator --create-dirs -L https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.7/aws-iam-authenticator_0.5.7_linux_amd64
-chmod a+x $HOME/bin/aws-iam-authenticator
-export PATH=$PATH:$HOME/bin
+curl -o /usr/local/bin/aws-iam-authenticator -L https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.7/aws-iam-authenticator_0.5.7_linux_amd64
+chmod a+x /usr/local/bin/aws-iam-authenticator
+
+curl -o /usr/local/bin/kubectl -L https://dl.k8s.io/release/v1.24.0/bin/linux/amd64/kubectl
+chmod a+x /usr/local/bin/kubectl
 
 
 # Configure environment


### PR DESCRIPTION
Kubectl is required bu the topologu-updater end-to-end tests.