### PR TITLE
README: reconfigure prow badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/kubernetes-sigs/node-feature-discovery)](https://goreportcard.com/report/github.com/kubernetes-sigs/node-feature-discovery)
 [![Prow Build](https://prow.k8s.io/badge.svg?jobs=post-node-feature-discovery-push-images)](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/post-node-feature-discovery-push-images)
+[![Prow E2E-Test](https://prow.k8s.io/badge.svg?jobs=postsubmit-node-feature-discovery-e2e-test)](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/postsubmit-node-feature-discovery-e2e-test)
 
 Welcome to Node Feature Discovery – a Kubernetes add-on for detecting hardware
 features and system configuration!

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Node Feature Discovery
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/kubernetes-sigs/node-feature-discovery)](https://goreportcard.com/report/github.com/kubernetes-sigs/node-feature-discovery)
-[![Prow Build](https://prow.k8s.io/badge.svg?jobs=pull-node-feature-discovery-build-image)](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-node-feature-discovery-build-image)
+[![Prow Build](https://prow.k8s.io/badge.svg?jobs=post-node-feature-discovery-push-images)](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/post-node-feature-discovery-push-images)
 
 Welcome to Node Feature Discovery – a Kubernetes add-on for detecting hardware
 features and system configuration!


### PR DESCRIPTION
-  change prow badge to display status of image-build
Change the prow badge on top of the readme file to show the status of
image building (push-image job). We're not interested in the status of
the PR builds, merely on how the tip of the master branch (or occasional
releases) are doing.
- add a prow badge for e2e-test status