### PR TITLE
Update registry to registry.k8s.io

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -32,8 +32,8 @@ Please do not remove items from the checklist
       `gcr.io/k8s-staging-nfd/node-feature-discovery:$VERSION`
   - Triggers build of the documentation and publish it at
         https://kubernetes-sigs.github.io/node-feature-discovery/0.$MAJ/
-- [ ] Submit a PR against [k8s.io](https://github.com/kubernetes/k8s.io), updating `k8s.gcr.io/images/k8s-staging-nfd/images.yaml` to promote the container images (both "full" and "minimal" variants) to production
-- [ ] Wait for the PR to be merged and verify that the image (`k8s.gcr.io/nfd/node-feature-discovery:$VERSION`) is available.
+- [ ] Submit a PR against [k8s.io](https://github.com/kubernetes/k8s.io), updating `registry.k8s.io/images/k8s-staging-nfd/images.yaml` to promote the container images (both "full" and "minimal" variants) to production
+- [ ] Wait for the PR to be merged and verify that the image (`registry.k8s.io/nfd/node-feature-discovery:$VERSION`) is available.
 - [ ] Publish the draft release prepared at the [Github releases page](https://github.com/kubernetes-sigs/node-feature-discovery/releases)
       which will also trigger a Helm repo index update to add the latest release
 - [ ] Add a link to the tagged release in this issue.

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ JEKYLL_OPTS := -d '$(SITE_DESTDIR)' $(if $(SITE_BASEURL),-b '$(SITE_BASEURL)',)
 
 VERSION := $(shell git describe --tags --dirty --always)
 
-IMAGE_REGISTRY ?= k8s.gcr.io/nfd
+IMAGE_REGISTRY ?= registry.k8s.io/nfd
 IMAGE_TAG_NAME ?= $(VERSION)
 IMAGE_EXTRA_TAG_NAMES ?=
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -9,7 +9,7 @@ IMAGE_REGISTRY = os.getenv('IMAGE_REGISTRY', "gcr.io/k8s-staging-nfd")
 IMAGE_NAME = os.getenv('IMAGE_NAME', "node-feature-discovery")
 
 # Get the image name in the following format
-# k8s.gcr.io/nfd/node-feature-discovery:master
+# registry.k8s.io/nfd/node-feature-discovery:master
 IMAGE = "/".join([IMAGE_REGISTRY, IMAGE_NAME])
 TAGGED_IMAGE = ":".join([IMAGE, IMAGE_TAG_NAME])
 

--- a/docs/advanced/developer-guide.md
+++ b/docs/advanced/developer-guide.md
@@ -73,7 +73,7 @@ architecture image.
 #### Change the job spec to use your custom image (optional)
 
 To use your published image from the step above instead of the
-`k8s.gcr.io/nfd/node-feature-discovery` image, edit `image`
+`registry.k8s.io/nfd/node-feature-discovery` image, edit `image`
 attribute in the spec template(s) to the new location
 (`<registry-name>/<image-name>[:<version>]`).
 
@@ -118,7 +118,7 @@ makefile overrides.
 | IMAGE_BUILDX_CMD           | Command to build and push multi-arch images with buildx           | DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --platform=${IMAGE_ALL_PLATFORMS} --progress=auto --pull
 | IMAGE_ALL_PLATFORMS        | Comma seperated list of OS/ARCH tuples for mulit-arch builds    | linux/amd64,linux/arm64
 | IMAGE_PUSH_CMD             | Command to push the image to remote registry                      | docker push
-| IMAGE_REGISTRY             | Container image registry to use                                   | k8s.gcr.io/nfd
+| IMAGE_REGISTRY             | Container image registry to use                                   | registry.k8s.io/nfd
 | IMAGE_TAG_NAME             | Container image tag name                                          | &lt;nfd version&gt;
 | IMAGE_EXTRA_TAG_NAMES      | Additional container image tag(s) to create when building image   | *empty*
 | K8S_NAMESPACE              | nfd-master and nfd-worker namespace                               | node-feature-discovery

--- a/docs/get-started/quick-start.md
+++ b/docs/get-started/quick-start.md
@@ -57,7 +57,7 @@ metadata:
   name: feature-dependent-pod
 spec:
   containers:
-  - image: k8s.gcr.io/pause
+  - image: registry.k8s.io/pause
     name: pause
   nodeSelector:
     # Select a valid feature

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -81,7 +81,7 @@ fi
 release=$1
 shift 1
 
-container_image=k8s.gcr.io/nfd/node-feature-discovery:$release
+container_image=registry.k8s.io/nfd/node-feature-discovery:$release
 
 #
 # Check/parse release number
@@ -113,7 +113,7 @@ if [ -z "$no_patching" ]; then
     echo Patching docs/_config.yml
     sed -e s"/release:.*/release: $release/"  \
         -e s"/version:.*/version: $docs_version/" \
-        -e s"!container_image:.*!container_image: k8s.gcr.io/nfd/node-feature-discovery:$release!" \
+        -e s"!container_image:.*!container_image: registry.k8s.io/nfd/node-feature-discovery:$release!" \
         -i docs/_config.yml
 
     # Patch README
@@ -133,14 +133,14 @@ if [ -z "$no_patching" ]; then
     echo "Patching Helm chart"
     sed -e s"/appVersion:.*/appVersion: $release/" -i deployment/helm/node-feature-discovery/Chart.yaml
     sed -e s"/pullPolicy:.*/pullPolicy: IfNotPresent/" \
-        -e s"!gcr.io/k8s-staging-nfd/node-feature-discovery!k8s.gcr.io/nfd/node-feature-discovery!" \
+        -e s"!gcr.io/k8s-staging-nfd/node-feature-discovery!registry.k8s.io/nfd/node-feature-discovery!" \
         -i deployment/helm/node-feature-discovery/values.yaml
     sed -e s"!kubernetes-sigs.github.io/node-feature-discovery/master!kubernetes-sigs.github.io/node-feature-discovery/$docs_version!" \
         -i deployment/helm/node-feature-discovery/README.md
 
     # Patch e2e test
-    echo Patching test/e2e/node_feature_discovery.go flag defaults to k8s.gcr.io/nfd/node-feature-discovery and $release
-    sed -e s'!"nfd\.repo",.*,!"nfd.repo", "k8s.gcr.io/nfd/node-feature-discovery",!' \
+    echo Patching test/e2e/node_feature_discovery.go flag defaults to registry.k8s.io/nfd/node-feature-discovery and $release
+    sed -e s'!"nfd\.repo",.*,!"nfd.repo", "registry.k8s.io/nfd/node-feature-discovery",!' \
         -e s"!\"nfd\.tag\",.*,!\"nfd.tag\", \"$release\",!" \
       -i test/e2e/node_feature_discovery.go
 fi

--- a/test/e2e/utils/pod.go
+++ b/test/e2e/utils/pod.go
@@ -40,7 +40,7 @@ import (
 var pullIfNotPresent = flag.Bool("nfd.pull-if-not-present", false, "Pull Images if not present - not always")
 
 const (
-	PauseImage = "k8s.gcr.io/pause"
+	PauseImage = "registry.k8s.io/pause"
 )
 
 // GuarenteedSleeperPod makes a Guaranteed QoS class Pod object which long enough forever but requires `cpuLimit` exclusive CPUs.


### PR DESCRIPTION
Kubernetes has moved to a new container image registry:
https://groups.google.com/a/kubernetes.io/g/dev/c/DYZYNQ_A6_c/m/FpHqeVR2BAAJ

See also:
https://github.com/kubernetes/kubernetes/pull/109938