### PR TITLE
Set shortName for NodeFeatureRule CRD

### DIFF
--- a/deployment/base/nfd-crds/nodefeaturerule-crd.yaml
+++ b/deployment/base/nfd-crds/nodefeaturerule-crd.yaml
@@ -12,6 +12,8 @@ spec:
     kind: NodeFeatureRule
     listKind: NodeFeatureRuleList
     plural: nodefeaturerules
+    shortNames:
+    - nfr
     singular: nodefeaturerule
   scope: Cluster
   versions:

--- a/deployment/helm/node-feature-discovery/crds/nodefeaturerule-crd.yaml
+++ b/deployment/helm/node-feature-discovery/crds/nodefeaturerule-crd.yaml
@@ -12,6 +12,8 @@ spec:
     kind: NodeFeatureRule
     listKind: NodeFeatureRuleList
     plural: nodefeaturerules
+    shortNames:
+    - nfr
     singular: nodefeaturerule
   scope: Cluster
   versions:

--- a/pkg/apis/nfd/v1alpha1/types.go
+++ b/pkg/apis/nfd/v1alpha1/types.go
@@ -33,7 +33,7 @@ type NodeFeatureRuleList struct {
 // NodeFeatureRule resource specifies a configuration for feature-based
 // customization of node objects, such as node labeling.
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName=nfr
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient
 // +genclient:nonNamespaced


### PR DESCRIPTION
This patch adds a kubebuilder marker to add a short name `nfr` for
NodeFeatureRule CRD.