### PR TITLE
docs: document NodeFeature API

### DIFF
--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -97,7 +97,7 @@ We have introduced the following Chart parameters.
 | `fullnameOverride` | string |  | Override a default fully qualified app name |
 | `tls.enable` | bool | false | Specifies whether to use TLS for communications between components |
 | `tls.certManager` | bool | false | If enabled, requires [cert-manager](https://cert-manager.io/docs/) to be installed and will automatically create the required TLS certificates |
-| `enableNodeFeatureApi` | bool  | false | Enable the NodeFeature CRD API for communicating node features. This will automatically disable the gRPC communication.
+| `enableNodeFeatureApi` | bool  | false | Enable the [NodeFeature](../usage/custom-resources#nodefeature) CRD API for communicating node features. This will automatically disable the gRPC communication.
 
 ### Master pod parameters
 

--- a/docs/get-started/introduction.md
+++ b/docs/get-started/introduction.md
@@ -106,9 +106,13 @@ only created on nodes running nfd-master.
 
 NFD takes use of some Kubernetes Custom Resources.
 
-NFD-Master uses [NodeFeatureRule](../usage/custom-resources/nodefeaturerule)s
+[NodeFeature](../usage/custom-resources#nodefeature)s (EXPERIMENTAL)
+can be used for representing node features and requesting node labels to be
+generated.
+
+NFD-Master uses [NodeFeatureRule](../usage/custom-resources#nodefeaturerule)s
 for custom labeling of nodes.
 
 NFD-Topology-Updater creates
-[NodeResourceTopology](../usage/custom-resources/noderesourcetopology) objects
+[NodeResourceTopology](../usage/custom-resources#noderesourcetopology) objects
 that describe the hardware topology of node resources.

--- a/docs/reference/master-commandline-reference.md
+++ b/docs/reference/master-commandline-reference.md
@@ -139,9 +139,9 @@ nfd-master -verify-node-name -ca-file=/opt/nfd/ca.crt \
 
 ### -enable-nodefeature-api
 
-The `-enable-nodefeature-api` flag enables the NodeFeature CRD API for
-receiving feature requests. This will also automatically disable the gRPC
-interface.
+The `-enable-nodefeature-api` flag enables the
+[NodeFeature](../usage/custom-resources#nodefeature) CRD API for receiving
+feature requests. This will also automatically disable the gRPC interface.
 
 Default: false
 
@@ -180,8 +180,9 @@ nfd-master -no-publish
 ### -crd-controller
 
 The `-crd-controller` flag specifies whether the NFD CRD API controller is
-enabled or not. The controller is responsible for processing NodeFeature and
-NodeFeatureRule objects.
+enabled or not. The controller is responsible for processing
+[NodeFeature](../usage/custom-resources#nodefeature) and
+[NodeFeatureRule](../usage/custom-resources#nodefeaturerule) objects.
 
 Default: *true*
 

--- a/docs/reference/worker-commandline-reference.md
+++ b/docs/reference/worker-commandline-reference.md
@@ -125,8 +125,9 @@ nfd-worker -key-file=/opt/nfd/worker.key -cert-file=/opt/nfd/worker.crt -ca-file
 ### -kubeconfig
 
 The `-kubeconfig` flag specifies the kubeconfig to use for connecting to the
-Kubernetes API server. It is only needed for manipulating NodeFeature
-objects, and thus the flag only takes effect when
+Kubernetes API server. It is only needed for manipulating
+[NodeFeature](../usage/custom-resources#nodefeature) objects, and thus the flag
+only takes effect when
 [`-enable-nodefeature-api`](#-enable-nodefeature-api)) is specified. An empty
 value (which is also the default) implies in-cluster kubeconfig.
 
@@ -196,7 +197,8 @@ nfd-worker -label-sources=kernel,system,local
 
 ### -enable-nodefeature-api
 
-The `-enable-nodefeature-api` flag enables the experimental NodeFeature CRD API
+The `-enable-nodefeature-api` flag enables the experimental
+[NodeFeature](../usage/custom-resources#nodefeature) CRD API
 for communicating with nfd-master. This will also automatically disable the
 gRPC communication to nfd-master. When enabled, nfd-worker will create per-node
 NodeFeature objects the contain all discovered node features and the set of

--- a/docs/reference/worker-configuration-reference.md
+++ b/docs/reference/worker-configuration-reference.md
@@ -133,8 +133,8 @@ core:
 Setting `core.noPublish` to `true` disables all communication with the
 nfd-master and the Kubernetes API server. It is effectively a "dry-run" option.
 NFD-Worker runs feature detection normally, but no labeling requests are sent
-to nfd-master and no NodeFeature objects are created or updated in the API
-server.
+to nfd-master and no [NodeFeature](../usage/custom-resources#nodefeature)
+objects are created or updated in the API server.
 
 Note: Overridden by the
 [`-no-publish`](worker-commandline-reference#-no-publish) command line flag (if

--- a/docs/usage/custom-resources.md
+++ b/docs/usage/custom-resources.md
@@ -17,6 +17,39 @@ sort: 6
 
 NFD uses some Kubernetes [custom resources][custom-resources].
 
+## NodeFeature
+
+**EXPERIMENTAL**
+NodeFeatureRule is an NFD-specific custom resource for communicating node
+features and node labeling requests. Support for NodeFeatureRule objects is
+disabled by default. If enabled, nfd-master watches for NodeFeature objects,
+labels nodes accordingly and uses the listed features as input when evaluating
+[NodeFeatureRule](#nodefeaturerule)s.
+
+```yaml
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeature
+metadata:
+  labels:
+    nfd.node.kubernetes.io/node-name: node-1
+  name: node-1-vendor-features
+spec:
+  features:
+    instances:
+      vendor.device:
+        elements:
+        - attributes:
+            model: "xpu-1"
+            memory: "4000"
+            type: "fast"
+        - attributes:
+            model: "xpu-2"
+            memory: "16000"
+            type: "slow"
+  labels:
+    vendor-xpu-present: "true"
+```
+
 ## NodeFeatureRule
 
 NodeFeatureRule is an NFD-specific custom resource that is designed for

--- a/docs/usage/nfd-master.md
+++ b/docs/usage/nfd-master.md
@@ -9,7 +9,52 @@ sort: 3
 
 ---
 
-NFD-Master runs as a deployment (with a replica count of 1), by default
+NFD-Master is responsible for connecting to the Kubernetes API server and
+updating node objects. More specifically, it modifies node labels, taints and
+extended resources based on requests from nfd-workers and 3rd party extensions.
+
+## NodeFeature controller
+
+**EXPERIMENTAL**
+Controller for [NodeFeature](custom-resources#nodefeature-custom-resource)
+objects can be enabled with the
+[`-enable-nodefeature-api`](../reference/master-commandline-reference#-enable-nodefeature-api)
+command line flag. When enabled, features from NodeFeature objects are used as
+the input for the [NodeFeatureRule](custom-resources#nodefeaturerule)
+processing pipeline. In addition, any labels listed in the NodeFeature object
+are created on the node (note the allowed
+[label namespaces](customization-guide#node-labels) are controlled).
+
+> NOTE: NodeFeature API must also be enabled in nfd-worker with
+> its [`-enable-nodefeature-api`](../reference/worker-commandline-reference#-enable-nodefeature-api)
+> flag.
+
+## NodeFeatureRule controller
+
+NFD-Master acts as the controller for
+[NodeFeatureRule](custom-resources#nodefeaturerule) objects.
+It applies the rules specified in NodeFeatureRule objects on raw feature data
+and creates node labels accordingly. The feature data used as the input can be
+received from nfd-worker instances through the gRPC interface or from
+[NodeFeature](custom-resources#nodefeature-custom-resource) objects. The latter
+requires that the [NodeFeaure controller](#nodefeature-controller) has been
+enabled.
+
+> NOTE: when gRPC is used for communicating the features (the default
+> mechanism), (re-)labelling only happens when a request is received from
+> nfd-worker. That is, in practice rules are evaluated and labels for each node
+> are created on intervals specified by the
+> [`core.sleepInterval`](../reference/worker-configuration-reference#coresleepinterval)
+> configuration option of nfd-worker instances. This means that modification or
+> creation of NodeFeatureRule objects does not instantly cause the node
+> labels to be updated.  Instead, the changes only come visible in node labels
+> as nfd-worker instances send their labelling requests. This limitation is not
+> present when gRPC interface is disabled
+> and [NodeFeature](custom-resources#nodefeature-custom-resource) API is used.
+
+## Deployment notes
+
+NFD-Master runs as a deployment, by default
 it prefers running on the cluster's master nodes but will run on worker
 nodes if no master nodes are found.
 
@@ -20,8 +65,8 @@ affinity to prevent masters from running on the same node.
 However note that inter-pod affinity is costly and is not recommended
 in bigger clusters.
 
-NFD-Master listens for connections from nfd-worker(s) and connects to the
-Kubernetes API server to add node labels advertised by them.
+> NOTE: If the [NodeFeature controller](#nodefeature-controller) is enabled the
+> replica count should be 1.
 
 If you have RBAC authorization enabled (as is the default e.g. with clusters
 initialized with kubeadm) you need to configure the appropriate ClusterRoles,


### PR DESCRIPTION
Document the usage of the NodeFeature CRD API. Also re-organize the
documentation a bit, moving the description of NodeFeatureRule
controller from customization guide to nfd-master usage page.