### PR TITLE
nfd-worker: rename some symbols

### DIFF
--- a/pkg/nfd-client/worker/nfd-worker-internal_test.go
+++ b/pkg/nfd-client/worker/nfd-worker-internal_test.go
@@ -393,7 +393,7 @@ func TestAdvertiseFeatureLabels(t *testing.T) {
 		worker := w.(*nfdWorker)
 
 		mockClient := &labeler.MockLabelerClient{}
-		worker.client = mockClient
+		worker.grpcClient = mockClient
 
 		labels := map[string]string{"feature-1": "value-1"}
 


### PR DESCRIPTION
Some renames in preparation for adding support for NFD CRD API client. I.e. a second client in addition to the existing gRPC client.

Split out from #903 