### PR TITLE
pkg/utils: move hostpath helpers from source to utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ KUBECONFIG ?=
 E2E_TEST_CONFIG ?=
 E2E_PULL_IF_NOT_PRESENT ?= false
 
-LDFLAGS = -ldflags "-s -w -X sigs.k8s.io/node-feature-discovery/pkg/version.version=$(VERSION) -X sigs.k8s.io/node-feature-discovery/source.pathPrefix=$(HOSTMOUNT_PREFIX)"
+LDFLAGS = -ldflags "-s -w -X sigs.k8s.io/node-feature-discovery/pkg/version.version=$(VERSION) -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=$(HOSTMOUNT_PREFIX)"
 
 # multi-arch build with buildx
 IMAGE_ALL_PLATFORMS ?= linux/amd64,linux/arm64

--- a/cmd/nfd-topology-updater/main.go
+++ b/cmd/nfd-topology-updater/main.go
@@ -29,8 +29,8 @@ import (
 	"sigs.k8s.io/node-feature-discovery/pkg/resourcemonitor"
 	"sigs.k8s.io/node-feature-discovery/pkg/topologypolicy"
 	"sigs.k8s.io/node-feature-discovery/pkg/utils"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath"
 	"sigs.k8s.io/node-feature-discovery/pkg/version"
-	"sigs.k8s.io/node-feature-discovery/source"
 )
 
 const (
@@ -109,9 +109,9 @@ func initFlags(flagset *flag.FlagSet) (*topology.Args, *resourcemonitor.Args) {
 		"Time to sleep between CR updates. Non-positive value implies no CR updatation (i.e. infinite sleep). [Default: 60s]")
 	flagset.StringVar(&resourcemonitorArgs.Namespace, "watch-namespace", "*",
 		"Namespace to watch pods (for testing/debugging purpose). Use * for all namespaces.")
-	flagset.StringVar(&resourcemonitorArgs.KubeletConfigFile, "kubelet-config-file", source.VarDir.Path("lib/kubelet/config.yaml"),
+	flagset.StringVar(&resourcemonitorArgs.KubeletConfigFile, "kubelet-config-file", hostpath.VarDir.Path("lib/kubelet/config.yaml"),
 		"Kubelet config file path.")
-	flagset.StringVar(&resourcemonitorArgs.PodResourceSocketPath, "podresources-socket", source.VarDir.Path("lib/kubelet/pod-resources/kubelet.sock"),
+	flagset.StringVar(&resourcemonitorArgs.PodResourceSocketPath, "podresources-socket", hostpath.VarDir.Path("lib/kubelet/pod-resources/kubelet.sock"),
 		"Pod Resource Socket path to use.")
 	flagset.StringVar(&args.Server, "server", "localhost:8080",
 		"NFD server address to connecto to.")

--- a/pkg/resourcemonitor/noderesourcesaggregator.go
+++ b/pkg/resourcemonitor/noderesourcesaggregator.go
@@ -31,7 +31,7 @@ import (
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 
 	"sigs.k8s.io/node-feature-discovery/pkg/utils"
-	"sigs.k8s.io/node-feature-discovery/source"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath"
 )
 
 const (
@@ -58,7 +58,7 @@ func NewResourcesAggregator(podResourceClient podresourcesapi.PodResourcesLister
 	var err error
 
 	topo, err := ghw.Topology(ghw.WithPathOverrides(ghw.PathOverrides{
-		"/sys": string(source.SysfsDir),
+		"/sys": string(hostpath.SysfsDir),
 	}))
 	if err != nil {
 		return nil, err

--- a/pkg/utils/hostpath/hostpath.go
+++ b/pkg/utils/hostpath/hostpath.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package source
+package hostpath
 
 import (
 	"path/filepath"

--- a/pkg/utils/memory_resources.go
+++ b/pkg/utils/memory_resources.go
@@ -28,11 +28,11 @@ import (
 	"k8s.io/klog/v2"
 	resourcehelper "k8s.io/kubernetes/pkg/apis/core/helper"
 
-	"sigs.k8s.io/node-feature-discovery/source"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath"
 )
 
 var (
-	sysBusNodeBasepath = source.SysfsDir.Path("bus/node/devices")
+	sysBusNodeBasepath = hostpath.SysfsDir.Path("bus/node/devices")
 )
 
 // NumaMemoryResources contains information of the memory resources per NUMA

--- a/source/cpu/cpu.go
+++ b/source/cpu/cpu.go
@@ -26,6 +26,7 @@ import (
 
 	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
 	"sigs.k8s.io/node-feature-discovery/pkg/utils"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath"
 	"sigs.k8s.io/node-feature-discovery/source"
 )
 
@@ -282,14 +283,14 @@ func discoverTopology() map[string]string {
 // Check if any (online) CPUs have thread siblings
 func haveThreadSiblings() (bool, error) {
 
-	files, err := os.ReadDir(source.SysfsDir.Path("bus/cpu/devices"))
+	files, err := os.ReadDir(hostpath.SysfsDir.Path("bus/cpu/devices"))
 	if err != nil {
 		return false, err
 	}
 
 	for _, file := range files {
 		// Try to read siblings from topology
-		siblings, err := os.ReadFile(source.SysfsDir.Path("bus/cpu/devices", file.Name(), "topology/thread_siblings_list"))
+		siblings, err := os.ReadFile(hostpath.SysfsDir.Path("bus/cpu/devices", file.Name(), "topology/thread_siblings_list"))
 		if err != nil {
 			return false, err
 		}

--- a/source/cpu/cstate_amd64.go
+++ b/source/cpu/cstate_amd64.go
@@ -25,7 +25,7 @@ import (
 
 	"k8s.io/klog/v2"
 
-	"sigs.k8s.io/node-feature-discovery/source"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath"
 )
 
 // Discover if c-states are enabled
@@ -33,7 +33,7 @@ func detectCstate() (map[string]string, error) {
 	cstate := make(map[string]string)
 
 	// Check that sysfs is available
-	sysfsBase := source.SysfsDir.Path("devices/system/cpu")
+	sysfsBase := hostpath.SysfsDir.Path("devices/system/cpu")
 	if _, err := os.Stat(sysfsBase); err != nil {
 		return cstate, fmt.Errorf("unable to detect cstate status: %w", err)
 	}
@@ -55,7 +55,7 @@ func detectCstate() (map[string]string, error) {
 		return cstate, nil
 	}
 
-	data, err := os.ReadFile(source.SysfsDir.Path("module/intel_idle/parameters/max_cstate"))
+	data, err := os.ReadFile(hostpath.SysfsDir.Path("module/intel_idle/parameters/max_cstate"))
 	if err != nil {
 		return cstate, fmt.Errorf("cannot determine cstate from max_cstates: %w", err)
 	}

--- a/source/cpu/power_amd64.go
+++ b/source/cpu/power_amd64.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/node-feature-discovery/pkg/cpuid"
-	"sigs.k8s.io/node-feature-discovery/source"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath"
 )
 
 const (
@@ -51,14 +51,14 @@ func discoverSSTBF() (bool, error) {
 	nominalBaseFrequency := int(freqInfo.EAX)
 
 	// Loop over all CPUs in the system
-	files, err := os.ReadDir(source.SysfsDir.Path("bus/cpu/devices"))
+	files, err := os.ReadDir(hostpath.SysfsDir.Path("bus/cpu/devices"))
 
 	if err != nil {
 		return false, err
 	}
 	for _, file := range files {
 		// Try to read effective base frequency of each cpu in the system
-		filePath := source.SysfsDir.Path("bus/cpu/devices", file.Name(), "cpufreq/base_frequency")
+		filePath := hostpath.SysfsDir.Path("bus/cpu/devices", file.Name(), "cpufreq/base_frequency")
 		data, err := os.ReadFile(filePath)
 		if os.IsNotExist(err) {
 			// Ignore missing file and continue to check other CPUs

--- a/source/cpu/pstate_amd64.go
+++ b/source/cpu/pstate_amd64.go
@@ -24,13 +24,13 @@ import (
 
 	"k8s.io/klog/v2"
 
-	"sigs.k8s.io/node-feature-discovery/source"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath"
 )
 
 // Discover p-state related features such as turbo boost.
 func detectPstate() (map[string]string, error) {
 	// Check that sysfs is available
-	sysfsBase := source.SysfsDir.Path("devices/system/cpu")
+	sysfsBase := hostpath.SysfsDir.Path("devices/system/cpu")
 	if _, err := os.Stat(sysfsBase); err != nil {
 		return nil, fmt.Errorf("unable to detect pstate status: %w", err)
 	}

--- a/source/cpu/security_amd64.go
+++ b/source/cpu/security_amd64.go
@@ -23,7 +23,8 @@ import (
 	"os"
 
 	"github.com/klauspost/cpuid/v2"
-	"sigs.k8s.io/node-feature-discovery/source"
+
+	"sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath"
 )
 
 func discoverSecurity() map[string]string {
@@ -64,7 +65,7 @@ func tdxEnabled() bool {
 	// If /sys/module/kvm_intel/parameters/tdx is not present, or is present
 	// with a value different than "Y\n" assume TDX to be unavailable or
 	// disabled.
-	protVirtHost := source.SysfsDir.Path("module/kvm_intel/parameters/tdx")
+	protVirtHost := hostpath.SysfsDir.Path("module/kvm_intel/parameters/tdx")
 	if content, err := os.ReadFile(protVirtHost); err == nil {
 		if string(content) == "Y\n" {
 			return true

--- a/source/cpu/security_s390x.go
+++ b/source/cpu/security_s390x.go
@@ -22,7 +22,7 @@ package cpu
 import (
 	"os"
 
-	"sigs.k8s.io/node-feature-discovery/source"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath"
 )
 
 func discoverSecurity() map[string]string {
@@ -39,7 +39,7 @@ func seEnabled() bool {
 	// This file is available in kernels >=5.12 + backports. Skip specifically
 	// checking facilities and kernel command lines and just assume Secure
 	// Execution to be unavailable or disabled if the file is not present.
-	protVirtHost := source.SysfsDir.Path("firmware/uv/prot_virt_host")
+	protVirtHost := hostpath.SysfsDir.Path("firmware/uv/prot_virt_host")
 	if content, err := os.ReadFile(protVirtHost); err == nil {
 		if string(content) == "1\n" {
 			return true

--- a/source/kernel/kconfig.go
+++ b/source/kernel/kconfig.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"sigs.k8s.io/node-feature-discovery/source"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath"
 )
 
 // Read gzipped kernel config
@@ -63,21 +63,21 @@ func parseKconfig(configPath string) (realKconfig, legacyKconfig map[string]stri
 	if err != nil {
 		searchPaths = []string{
 			"/proc/config.gz",
-			source.UsrDir.Path("src/linux/.config"),
+			hostpath.UsrDir.Path("src/linux/.config"),
 		}
 	} else {
 		// from k8s.io/system-validator used by kubeadm
 		// preflight checks
 		searchPaths = []string{
 			"/proc/config.gz",
-			source.UsrDir.Path("src/linux-" + kVer + "/.config"),
-			source.UsrDir.Path("src/linux/.config"),
-			source.UsrDir.Path("lib/modules/" + kVer + "/config"),
-			source.UsrDir.Path("lib/ostree-boot/config-" + kVer),
-			source.UsrDir.Path("lib/kernel/config-" + kVer),
-			source.UsrDir.Path("src/linux-headers-" + kVer + "/.config"),
+			hostpath.UsrDir.Path("src/linux-" + kVer + "/.config"),
+			hostpath.UsrDir.Path("src/linux/.config"),
+			hostpath.UsrDir.Path("lib/modules/" + kVer + "/config"),
+			hostpath.UsrDir.Path("lib/ostree-boot/config-" + kVer),
+			hostpath.UsrDir.Path("lib/kernel/config-" + kVer),
+			hostpath.UsrDir.Path("src/linux-headers-" + kVer + "/.config"),
 			"/lib/modules/" + kVer + "/build/.config",
-			source.BootDir.Path("config-" + kVer),
+			hostpath.BootDir.Path("config-" + kVer),
 		}
 	}
 

--- a/source/kernel/selinux.go
+++ b/source/kernel/selinux.go
@@ -23,12 +23,12 @@ import (
 
 	"k8s.io/klog/v2"
 
-	"sigs.k8s.io/node-feature-discovery/source"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath"
 )
 
 // SelinuxEnabled detects if selinux has been enabled in the kernel
 func SelinuxEnabled() (bool, error) {
-	sysfsBase := source.SysfsDir.Path("fs")
+	sysfsBase := hostpath.SysfsDir.Path("fs")
 	if _, err := os.Stat(sysfsBase); err != nil {
 		return false, fmt.Errorf("unable to detect selinux status: %w", err)
 	}

--- a/source/memory/memory.go
+++ b/source/memory/memory.go
@@ -27,6 +27,7 @@ import (
 
 	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
 	"sigs.k8s.io/node-feature-discovery/pkg/utils"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath"
 	"sigs.k8s.io/node-feature-discovery/source"
 )
 
@@ -114,7 +115,7 @@ func (s *memorySource) GetFeatures() *feature.DomainFeatures {
 
 // detectNuma detects NUMA node information
 func detectNuma() (map[string]string, error) {
-	sysfsBasePath := source.SysfsDir.Path("bus/node/devices")
+	sysfsBasePath := hostpath.SysfsDir.Path("bus/node/devices")
 
 	nodes, err := os.ReadDir(sysfsBasePath)
 	if err != nil {
@@ -129,7 +130,7 @@ func detectNuma() (map[string]string, error) {
 
 // detectNv detects NVDIMM devices
 func detectNv() ([]feature.InstanceFeature, error) {
-	sysfsBasePath := source.SysfsDir.Path("bus/nd/devices")
+	sysfsBasePath := hostpath.SysfsDir.Path("bus/nd/devices")
 	info := make([]feature.InstanceFeature, 0)
 
 	devices, err := os.ReadDir(sysfsBasePath)

--- a/source/network/network.go
+++ b/source/network/network.go
@@ -27,6 +27,7 @@ import (
 
 	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
 	"sigs.k8s.io/node-feature-discovery/pkg/utils"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath"
 	"sigs.k8s.io/node-feature-discovery/source"
 )
 
@@ -112,7 +113,7 @@ func (s *networkSource) GetFeatures() *feature.DomainFeatures {
 }
 
 func detectNetDevices() ([]feature.InstanceFeature, error) {
-	sysfsBasePath := source.SysfsDir.Path(sysfsBaseDir)
+	sysfsBasePath := hostpath.SysfsDir.Path(sysfsBaseDir)
 
 	ifaces, err := os.ReadDir(sysfsBasePath)
 	if err != nil {

--- a/source/pci/utils.go
+++ b/source/pci/utils.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
-	"sigs.k8s.io/node-feature-discovery/source"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath"
 )
 
 var mandatoryDevAttrs = []string{"class", "vendor", "device", "subsystem_vendor", "subsystem_device"}
@@ -71,7 +71,7 @@ func readPciDevInfo(devPath string) (*feature.InstanceFeature, error) {
 // detectPci detects available PCI devices and retrieves their device attributes.
 // An error is returned if reading any of the mandatory attributes fails.
 func detectPci() ([]feature.InstanceFeature, error) {
-	sysfsBasePath := source.SysfsDir.Path("bus/pci/devices")
+	sysfsBasePath := hostpath.SysfsDir.Path("bus/pci/devices")
 
 	devices, err := os.ReadDir(sysfsBasePath)
 	if err != nil {

--- a/source/storage/storage.go
+++ b/source/storage/storage.go
@@ -26,6 +26,7 @@ import (
 
 	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
 	"sigs.k8s.io/node-feature-discovery/pkg/utils"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath"
 	"sigs.k8s.io/node-feature-discovery/source"
 )
 
@@ -94,7 +95,7 @@ func (s *storageSource) GetFeatures() *feature.DomainFeatures {
 }
 
 func detectBlock() ([]feature.InstanceFeature, error) {
-	sysfsBasePath := source.SysfsDir.Path("block")
+	sysfsBasePath := hostpath.SysfsDir.Path("block")
 
 	blockdevices, err := os.ReadDir(sysfsBasePath)
 	if err != nil {

--- a/source/system/system.go
+++ b/source/system/system.go
@@ -26,6 +26,7 @@ import (
 
 	"sigs.k8s.io/node-feature-discovery/pkg/api/feature"
 	"sigs.k8s.io/node-feature-discovery/pkg/utils"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath"
 	"sigs.k8s.io/node-feature-discovery/source"
 )
 
@@ -117,7 +118,7 @@ func (s *systemSource) GetFeatures() *feature.DomainFeatures {
 func parseOSRelease() (map[string]string, error) {
 	release := map[string]string{}
 
-	f, err := os.Open(source.EtcDir.Path("os-release"))
+	f, err := os.Open(hostpath.EtcDir.Path("os-release"))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Refactor the code, moving the hostpath helper functionality to new "pkg/utils/hostpath" package. This breaks odd-ish dependency "pkg/utils" -> "source".

No functional changes, preparing for #903 