### PR TITLE
cpu: ignore unknown cpuid flags on non-x86

### DIFF
--- a/source/cpu/cpuid_arm.go
+++ b/source/cpu/cpuid_arm.go
@@ -98,8 +98,8 @@ func getCpuidFlags() []string {
 	hwcap := uint64(C.gethwcap())
 	for i := uint(0); i < 64; i++ {
 		key := uint64(1 << i)
-		val := flagNames_arm[key]
-		if hwcap&key != 0 {
+		val, ok := flagNames_arm[key]
+		if hwcap&key != 0 && ok {
 			r = append(r, val)
 		}
 	}

--- a/source/cpu/cpuid_arm64.go
+++ b/source/cpu/cpuid_arm64.go
@@ -185,15 +185,15 @@ func getCpuidFlags() []string {
 	hwcap2 := uint64(C.gethwcap2())
 	for i := uint(0); i < 64; i++ {
 		key := uint64(1 << i)
-		val := flagNames_arm64[key]
-		if hwcap&key != 0 {
+		val, ok := flagNames_arm64[key]
+		if hwcap&key != 0 && ok {
 			r = append(r, val)
 		}
 	}
 	for i := uint(0); i < 64; i++ {
 		key := uint64(1 << i)
-		val := flag2Names_arm64[key]
-		if hwcap2&key != 0 {
+		val, ok := flag2Names_arm64[key]
+		if hwcap2&key != 0 && ok {
 			r = append(r, val)
 		}
 	}

--- a/source/cpu/cpuid_ppc64le.go
+++ b/source/cpu/cpuid_ppc64le.go
@@ -139,15 +139,15 @@ func getCpuidFlags() []string {
 	hwcap2 := uint64(C.gethwcap2())
 	for i := uint(0); i < 64; i++ {
 		key := uint64(1 << i)
-		val := flagNames_ppc64le[key]
-		if hwcap&key != 0 {
+		val, ok := flagNames_ppc64le[key]
+		if hwcap&key != 0 && ok {
 			r = append(r, val)
 		}
 	}
 	for i := uint(0); i < 64; i++ {
 		key := uint64(1 << i)
-		val := flag2Names_ppc64le[key]
-		if hwcap2&key != 0 {
+		val, ok := flag2Names_ppc64le[key]
+		if hwcap2&key != 0 && ok {
 			r = append(r, val)
 		}
 	}

--- a/source/cpu/cpuid_s390x.go
+++ b/source/cpu/cpuid_s390x.go
@@ -88,8 +88,8 @@ func getCpuidFlags() []string {
 	hwcap := uint64(C.gethwcap())
 	for i := uint(0); i < 64; i++ {
 		key := uint64(1 << i)
-		val := flagNames_s390x[key]
-		if hwcap&key != 0 {
+		val, ok := flagNames_s390x[key]
+		if hwcap&key != 0 && ok {
 			r = append(r, val)
 		}
 	}


### PR DESCRIPTION
Avoid trying to create empty "cpu-cpuid." labels for cpuid flags that we don't have a description for.