### PR TITLE
Update base image to Debian bullseye

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ IMAGE_BUILD_EXTRA_OPTS ?=
 IMAGE_PUSH_CMD ?= docker push
 CONTAINER_RUN_CMD ?= docker run
 BUILDER_IMAGE ?= golang:1.19-bullseye
-BASE_IMAGE_FULL ?= debian:buster-slim
+BASE_IMAGE_FULL ?= debian:bullseye-slim
 BASE_IMAGE_MINIMAL ?= gcr.io/distroless/base
 
 # Docker base command for working with html documentation.

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,7 +1,7 @@
 # -*- mode: Python -*-
 
 BASE_IMAGE_MINIMAL="gcr.io/distroless/base"
-BASE_IMAGE_FULL="debian:buster-slim"
+BASE_IMAGE_FULL="debian:bullseye-slim"
 BUILDER_IMAGE="golang:1.19-bullseye"
 HOSTMOUNT_PREFIX="/host-"
 IMAGE_TAG_NAME = os.getenv('IMAGE_TAG_NAME', "master")


### PR DESCRIPTION
Update the base used for our "full" image to debian:bullseye-slim. Will ensure we get the latest and greatest updates and fixes.