### PR TITLE
Error strings should not be capitalized

### DIFF
--- a/pkg/apis/nfd/v1alpha1/expression.go
+++ b/pkg/apis/nfd/v1alpha1/expression.go
@@ -30,17 +30,17 @@ import (
 )
 
 var matchOps = map[MatchOp]struct{}{
-	MatchAny:          struct{}{},
-	MatchIn:           struct{}{},
-	MatchNotIn:        struct{}{},
-	MatchInRegexp:     struct{}{},
-	MatchExists:       struct{}{},
-	MatchDoesNotExist: struct{}{},
-	MatchGt:           struct{}{},
-	MatchLt:           struct{}{},
-	MatchGtLt:         struct{}{},
-	MatchIsTrue:       struct{}{},
-	MatchIsFalse:      struct{}{},
+	MatchAny:          {},
+	MatchIn:           {},
+	MatchNotIn:        {},
+	MatchInRegexp:     {},
+	MatchExists:       {},
+	MatchDoesNotExist: {},
+	MatchGt:           {},
+	MatchLt:           {},
+	MatchGtLt:         {},
+	MatchIsTrue:       {},
+	MatchIsFalse:      {},
 }
 
 type valueRegexpCache []*regexp.Regexp
@@ -80,44 +80,44 @@ func (m *MatchExpression) Validate() error {
 	switch m.Op {
 	case MatchExists, MatchDoesNotExist, MatchIsTrue, MatchIsFalse, MatchAny:
 		if len(m.Value) != 0 {
-			return fmt.Errorf("Value must be empty for Op %q (have %v)", m.Op, m.Value)
+			return fmt.Errorf("value must be empty for Op %q (have %v)", m.Op, m.Value)
 		}
 	case MatchGt, MatchLt:
 		if len(m.Value) != 1 {
-			return fmt.Errorf("Value must contain exactly one element for Op %q (have %v)", m.Op, m.Value)
+			return fmt.Errorf("value must contain exactly one element for Op %q (have %v)", m.Op, m.Value)
 		}
 		if _, err := strconv.Atoi(m.Value[0]); err != nil {
-			return fmt.Errorf("Value must be an integer for Op %q (have %v)", m.Op, m.Value[0])
+			return fmt.Errorf("value must be an integer for Op %q (have %v)", m.Op, m.Value[0])
 		}
 	case MatchGtLt:
 		if len(m.Value) != 2 {
-			return fmt.Errorf("Value must contain exactly two elements for Op %q (have %v)", m.Op, m.Value)
+			return fmt.Errorf("value must contain exactly two elements for Op %q (have %v)", m.Op, m.Value)
 		}
 		var err error
 		v := make([]int, 2)
 		for i := 0; i < 2; i++ {
 			if v[i], err = strconv.Atoi(m.Value[i]); err != nil {
-				return fmt.Errorf("Value must contain integers for Op %q (have %v)", m.Op, m.Value)
+				return fmt.Errorf("value must contain integers for Op %q (have %v)", m.Op, m.Value)
 			}
 		}
 		if v[0] >= v[1] {
-			return fmt.Errorf("Value[0] must be less than Value[1] for Op %q (have %v)", m.Op, m.Value)
+			return fmt.Errorf("value[0] must be less than Value[1] for Op %q (have %v)", m.Op, m.Value)
 		}
 	case MatchInRegexp:
 		if len(m.Value) == 0 {
-			return fmt.Errorf("Value must be non-empty for Op %q", m.Op)
+			return fmt.Errorf("value must be non-empty for Op %q", m.Op)
 		}
 		m.valueRe = make([]*regexp.Regexp, len(m.Value))
 		for i, v := range m.Value {
 			re, err := regexp.Compile(v)
 			if err != nil {
-				return fmt.Errorf("Value must only contain valid regexps for Op %q (have %v)", m.Op, m.Value)
+				return fmt.Errorf("value must only contain valid regexps for Op %q (have %v)", m.Op, m.Value)
 			}
 			m.valueRe[i] = re
 		}
 	default:
 		if len(m.Value) == 0 {
-			return fmt.Errorf("Value must be non-empty for Op %q", m.Op)
+			return fmt.Errorf("value must be non-empty for Op %q", m.Op)
 		}
 	}
 	return nil

--- a/pkg/apis/nfd/v1alpha1/rule_test.go
+++ b/pkg/apis/nfd/v1alpha1/rule_test.go
@@ -175,7 +175,7 @@ func TestRule(t *testing.T) {
 
 	// Test MatchAny
 	r5.MatchAny = []MatchAnyElem{
-		MatchAnyElem{
+		{
 			MatchFeatures: FeatureMatcher{
 				FeatureMatcherTerm{
 					Feature: "domain-1.kf-1",
@@ -209,18 +209,18 @@ func TestRule(t *testing.T) {
 
 func TestTemplating(t *testing.T) {
 	f := map[string]*feature.DomainFeatures{
-		"domain_1": &feature.DomainFeatures{
+		"domain_1": {
 			Flags: map[string]feature.FlagFeatureSet{
-				"kf_1": feature.FlagFeatureSet{
+				"kf_1": {
 					Elements: map[string]feature.Nil{
-						"key-a": feature.Nil{},
-						"key-b": feature.Nil{},
-						"key-c": feature.Nil{},
+						"key-a": {},
+						"key-b": {},
+						"key-c": {},
 					},
 				},
 			},
 			Attributes: map[string]feature.AttributeFeatureSet{
-				"vf_1": feature.AttributeFeatureSet{
+				"vf_1": {
 					Elements: map[string]string{
 						"key-1": "val-1",
 						"keu-2": "val-2",
@@ -229,21 +229,21 @@ func TestTemplating(t *testing.T) {
 				},
 			},
 			Instances: map[string]feature.InstanceFeatureSet{
-				"if_1": feature.InstanceFeatureSet{
+				"if_1": {
 					Elements: []feature.InstanceFeature{
-						feature.InstanceFeature{
+						{
 							Attributes: map[string]string{
 								"attr-1": "1",
 								"attr-2": "val-2",
 							},
 						},
-						feature.InstanceFeature{
+						{
 							Attributes: map[string]string{
 								"attr-1": "10",
 								"attr-2": "val-20",
 							},
 						},
-						feature.InstanceFeature{
+						{
 							Attributes: map[string]string{
 								"attr-1": "100",
 								"attr-2": "val-200",

--- a/test/e2e/utils/pod.go
+++ b/test/e2e/utils/pod.go
@@ -52,7 +52,7 @@ func GuaranteedSleeperPod(cpuLimit string) *v1.Pod {
 		Spec: v1.PodSpec{
 			RestartPolicy: v1.RestartPolicyNever,
 			Containers: []v1.Container{
-				v1.Container{
+				{
 					Name:  "sleeper-gu-cnt",
 					Image: PauseImage,
 					Resources: v1.ResourceRequirements{
@@ -78,7 +78,7 @@ func BestEffortSleeperPod() *v1.Pod {
 		Spec: v1.PodSpec{
 			RestartPolicy: v1.RestartPolicyNever,
 			Containers: []v1.Container{
-				v1.Container{
+				{
 					Name:  "sleeper-be-cnt",
 					Image: PauseImage,
 				},


### PR DESCRIPTION
Error strings should not be capitalized [(ST1005)](https://staticcheck.io/docs/checks#ST1005) and remove
the redundancy from array, slice or map composite literals.
