### PR TITLE
Add E2E test for NFD tainting feature

### DIFF
--- a/test/e2e/data/nodefeaturerule-3-updated.yaml
+++ b/test/e2e/data/nodefeaturerule-3-updated.yaml
@@ -1,0 +1,32 @@
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: e2e-test-3
+spec:
+  rules:
+    # Positive test expected to set the taints
+    - name: "e2e-taint-test-1"
+      taints:
+        - effect: PreferNoSchedule
+          key: "nfd.node.kubernetes.io/fake-special-node"
+          value: "exists"
+        - effect: NoExecute
+          key: "nfd.node.kubernetes.io/foo"
+          value: "true"
+      matchFeatures:
+        - feature: "fake.attribute"
+          matchExpressions:
+            "attr_1": {op: IsTrue}
+            "attr_2": {op: IsFalse}
+
+    # Negative test not supposed to set the taints
+    - name: "e2e-taint-test-2"
+      taints:
+        - effect: PreferNoSchedule
+          key: "nfd.node.kubernetes.io/fake-cpu"
+          value: "true"
+      matchFeatures:
+        - feature: "fake.attribute"
+          matchExpressions:
+            "attr_1": {op: IsTrue}
+            "attr_2": {op: IsTrue}

--- a/test/e2e/data/nodefeaturerule-3.yaml
+++ b/test/e2e/data/nodefeaturerule-3.yaml
@@ -1,0 +1,35 @@
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: e2e-test-3
+spec:
+  rules:
+    # Positive test expected to set the taints
+    - name: "e2e-taint-test-1"
+      taints:
+        - effect: PreferNoSchedule
+          key: "nfd.node.kubernetes.io/fake-special-node"
+          value: "exists"
+        - effect: NoExecute
+          key: "nfd.node.kubernetes.io/fake-dedicated-node"
+          value: "true"
+        - effect: "NoExecute"
+          key: "nfd.node.kubernetes.io/performance-optimized-node"
+          value: "true"
+      matchFeatures:
+        - feature: "fake.attribute"
+          matchExpressions:
+            "attr_1": {op: IsTrue}
+            "attr_2": {op: IsFalse}
+
+    # Negative test not supposed to set the taints
+    - name: "e2e-taint-test-2"
+      taints:
+        - effect: PreferNoSchedule
+          key: "nfd.node.kubernetes.io/fake-special-cpu"
+          value: "true"
+      matchFeatures:
+        - feature: "fake.attribute"
+          matchExpressions:
+            "attr_1": {op: IsTrue}
+            "attr_2": {op: IsTrue}

--- a/test/e2e/utils/crd.go
+++ b/test/e2e/utils/crd.go
@@ -74,6 +74,27 @@ func CreateNodeFeatureRulesFromFile(cli nfdclientset.Interface, filename string)
 	return nil
 }
 
+// UpdateNodeFeatureRulesFromFile updates existing NodeFeatureRule object from a given file located under test data directory.
+func UpdateNodeFeatureRulesFromFile(cli nfdclientset.Interface, filename string) error {
+	objs, err := nodeFeatureRulesFromFile(filepath.Join(packagePath, "..", "data", filename))
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range objs {
+		var nfr *nfdv1alpha1.NodeFeatureRule
+		if nfr, err = cli.NfdV1alpha1().NodeFeatureRules().Get(context.TODO(), obj.Name, metav1.GetOptions{}); err != nil {
+			return fmt.Errorf("failed to get NodeFeatureRule %w", err)
+		}
+
+		obj.SetResourceVersion(nfr.GetResourceVersion())
+		if _, err = cli.NfdV1alpha1().NodeFeatureRules().Update(context.TODO(), obj, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to update NodeFeatureRule %w", err)
+		}
+	}
+	return nil
+}
+
 func apiObjsFromFile(path string, decoder apiruntime.Decoder) ([]apiruntime.Object, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/test/e2e/utils/pod/pod.go
+++ b/test/e2e/utils/pod/pod.go
@@ -219,6 +219,14 @@ func SpecWithMasterNodeSelector(args ...string) SpecOption {
 	}
 }
 
+// SpecWithTolerations returns a SpecOption that modifies the pod to
+// be run on a node with NodeFeatureRule taints.
+func SpecWithTolerations(tolerations []corev1.Toleration) SpecOption {
+	return func(spec *corev1.PodSpec) {
+		spec.Tolerations = append(spec.Tolerations, tolerations...)
+	}
+}
+
 // SpecWithConfigMap returns a SpecOption that mounts a configmap to the first container.
 func SpecWithConfigMap(name, mountPath string) SpecOption {
 	return func(spec *corev1.PodSpec) {


### PR DESCRIPTION
This PR extends E2E to test NodeFeatureRule tainting functionality implemented in https://github.com/kubernetes-sigs/node-feature-discovery/pull/910.

/hold 
until https://github.com/kubernetes-sigs/node-feature-discovery/pull/910 is not merged.