### PR TITLE
Increase allowed image build timeout for 500s

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 1500s
+timeout: 2000s
 steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90
     entrypoint: scripts/test-infra/push-image.sh


### PR DESCRIPTION
Image build is failing otherwise as per discussion on https://github.com/kubernetes-sigs/node-feature-discovery/pull/935#issuecomment-1292504879.
/cc @marquiz 