### PR TITLE
Increase image waiting timeout

### DIFF
--- a/scripts/test-infra/test-e2e.sh
+++ b/scripts/test-infra/test-e2e.sh
@@ -21,7 +21,7 @@ i=1
 while true; do
     if make poll-images; then
         break
-    elif [ $i -ge 27 ]; then
+    elif [ $i -ge 35 ]; then
         echo "ERROR: too many tries when polling for image"
         exit 1
     fi


### PR DESCRIPTION
We recently increased timeout in https://github.com/kubernetes-sigs/node-feature-discovery/pull/936  for image building and pushing
to GCR due to some failures with timeout. This commit extends timeout
for waiting that image to be published during E2E tests.
/cc @marquiz 