### PR TITLE
[release-0.11] Update base image to Debian bullseye

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ IMAGE_BUILD_CMD ?= docker build
 IMAGE_BUILD_EXTRA_OPTS ?=
 IMAGE_PUSH_CMD ?= docker push
 CONTAINER_RUN_CMD ?= docker run
-BASE_IMAGE_FULL ?= debian:buster-slim
+BASE_IMAGE_FULL ?= debian:bullseye-slim
 BASE_IMAGE_MINIMAL ?= gcr.io/distroless/base
 
 MDL ?= mdl


### PR DESCRIPTION
Update the base used for our "full" image to debian:bullseye-slim. Will ensure we get the latest and greatest updates and fixes.

(cherry picked from commit a798b4517d4bb570a26f702698e0731cbbf083fd)