### PR TITLE
Enhancement: add IBM zSystems model detection

### DIFF
--- a/source/system/s390x_model.go
+++ b/source/system/s390x_model.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+var s390xModelMap = map[string][]string{
+	"z9":   {"2094", "2096"},
+	"z10":  {"2097", "2098"},
+	"z196": {"2817"},
+	"z114": {"2818"},
+	"z12":  {"2827", "2828"},
+	"z13":  {"2964", "2965"},
+	"z14":  {"3906", "3907"},
+	"z15":  {"8561", "8562"},
+	"z16":  {"3931"},
+}
+
+// S390xModels ist the main struct for querying IBM z Systems hardware models
+type S390xModels struct {
+	HwMap map[string][]string
+}
+
+// NewS390xModels creates a new instance of S390xModels
+func NewS390xModels() S390xModels {
+	s390xmodels := S390xModels{}
+	s390xmodels.HwMap = s390xModelMap
+	return s390xmodels
+}
+
+// LookupModel looks for the IBM z Systems hardware model matching the given machine type
+func (s S390xModels) LookupModel(machineType string) (model string) {
+	found := false
+	for k, v := range s.HwMap {
+		if s.stringInSlice(machineType, v) {
+			model = k
+			found = true
+			break
+		}
+	}
+	if !found {
+		model = "unknown"
+	}
+	return
+}
+
+func (s S390xModels) stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}

--- a/source/system/system.go
+++ b/source/system/system.go
@@ -175,7 +175,6 @@ func splitVersion(version string) map[string]string {
 // Retrieve the IBM z Systems specific hardware model information
 func getS390xModelInfo() (string, error) {
 	model := ""
-	// sysinfo, err := exec.Command("cat", "/proc/sysinfo").Output()
 	sysinfo, err := os.ReadFile("/proc/sysinfo")
 	if err != nil {
 		return "", err

--- a/source/system/system.go
+++ b/source/system/system.go
@@ -180,7 +180,7 @@ func getS390xModelInfo() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	re := regexp.MustCompile(`(?m)^Type:[\\s]*(\\d+)$`)
+	re := regexp.MustCompile(`(?m)^Type:[\s]*(\d+)$`)
 	if match := re.FindStringSubmatch(strings.TrimSpace(string(sysinfo))); match != nil {
 		if len(match) < 2 || len(match[1]) == 0 {
 			return "", errors.New("unsupported machine type format")
@@ -188,6 +188,8 @@ func getS390xModelInfo() (string, error) {
 		machineType := match[1]
 		s390xModels := NewS390xModels()
 		model = s390xModels.LookupModel(machineType)
+	} else {
+		return "", errors.New("unable to get machine type information")
 	}
 	return model, nil
 }

--- a/source/system/system.go
+++ b/source/system/system.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"errors"
 	"os"
-	"os/exec"
 	"regexp"
 	"runtime"
 	"strings"
@@ -79,7 +78,7 @@ func (s *systemSource) GetLabels() (source.FeatureLabels, error) {
 	}
 
 	if value, exists := features.Attributes[ModelFeature].Elements["s390x"]; exists {
-		labels["model_s390x"] = value
+		labels["model.s390x"] = value
 	}
 
 	return labels, nil
@@ -176,12 +175,13 @@ func splitVersion(version string) map[string]string {
 // Retrieve the IBM z Systems specific hardware model information
 func getS390xModelInfo() (string, error) {
 	model := ""
-	sysinfo, err := exec.Command("cat", "/proc/sysinfo").Output()
+	// sysinfo, err := exec.Command("cat", "/proc/sysinfo").Output()
+	sysinfo, err := os.ReadFile("/proc/sysinfo")
 	if err != nil {
 		return "", err
 	}
 	re := regexp.MustCompile(`(?m)^Type:[\\s]*(\\d+)$`)
-	if match := re.FindStringSubmatch(string(sysinfo)); match != nil {
+	if match := re.FindStringSubmatch(strings.TrimSpace(string(sysinfo))); match != nil {
 		if len(match) < 2 || len(match[1]) == 0 {
 			return "", errors.New("unsupported machine type format")
 		}

--- a/source/system/system.go
+++ b/source/system/system.go
@@ -77,6 +77,11 @@ func (s *systemSource) GetLabels() (source.FeatureLabels, error) {
 			labels[feature] = value
 		}
 	}
+
+	if value, exists := features.Attributes[ModelFeature].Elements["s390x"]; exists {
+		labels["model_s390x"] = value
+	}
+
 	return labels, nil
 }
 


### PR DESCRIPTION
This PR implements the required changes to address the enhancement suggestion in #957.

With this PR, s390x cluster nodes will have an additional label set called 'feature.node.kubernetes.io/system-model.s390x' that contains the corresponding IBM zSystems model generation name, e.g. 'z15'.

Here's an example for a worker running on a z15 model:

```
  labels:
    beta.kubernetes.io/arch: s390x
    beta.kubernetes.io/os: linux
    feature.node.kubernetes.io/cpu-cpuid.DFLT: "true"
    feature.node.kubernetes.io/cpu-cpuid.DFP: "true"
    feature.node.kubernetes.io/cpu-cpuid.EDAT: "true"
    feature.node.kubernetes.io/cpu-cpuid.EIMM: "true"
    feature.node.kubernetes.io/cpu-cpuid.ESAN3: "true"
    feature.node.kubernetes.io/cpu-cpuid.ETF3EH: "true"
    feature.node.kubernetes.io/cpu-cpuid.GS: "true"
    feature.node.kubernetes.io/cpu-cpuid.HIGHGPRS: "true"
    feature.node.kubernetes.io/cpu-cpuid.LDISP: "true"
    feature.node.kubernetes.io/cpu-cpuid.MSA: "true"
    feature.node.kubernetes.io/cpu-cpuid.SORT: "true"
    feature.node.kubernetes.io/cpu-cpuid.STFLE: "true"
    feature.node.kubernetes.io/cpu-cpuid.TE: "true"
    feature.node.kubernetes.io/cpu-cpuid.VX: "true"
    feature.node.kubernetes.io/cpu-cpuid.VXD: "true"
    feature.node.kubernetes.io/cpu-cpuid.VXE: "true"
    feature.node.kubernetes.io/cpu-cpuid.VXE2: "true"
    feature.node.kubernetes.io/cpu-cpuid.VXP: "true"
    feature.node.kubernetes.io/cpu-cpuid.ZARCH: "true"
    feature.node.kubernetes.io/cpu-hardware_multithreading: "false"
    feature.node.kubernetes.io/cpu-model.family: "0"
    feature.node.kubernetes.io/cpu-model.id: "0"
    feature.node.kubernetes.io/cpu-model.vendor_id: VendorUnknown
    feature.node.kubernetes.io/kernel-version.full: 4.15.0-191-generic
    feature.node.kubernetes.io/kernel-version.major: "4"
    feature.node.kubernetes.io/kernel-version.minor: "15"
    feature.node.kubernetes.io/kernel-version.revision: "0"
    feature.node.kubernetes.io/system-model.s390x: z15
    feature.node.kubernetes.io/system-os_release.ID: ubuntu
    feature.node.kubernetes.io/system-os_release.VERSION_ID: "21.10"
    feature.node.kubernetes.io/system-os_release.VERSION_ID.major: "21"
    feature.node.kubernetes.io/system-os_release.VERSION_ID.minor: "10"
    kubernetes.io/arch: s390x
    kubernetes.io/hostname: kind-worker
    kubernetes.io/os: linux
```
