### PR TITLE
test/e2e: fix topologu-updater cmdline args

### DIFF
--- a/test/e2e/utils/pod.go
+++ b/test/e2e/utils/pod.go
@@ -311,7 +311,7 @@ func nfdTopologyUpdaterPodSpec(kc KubeletConfig, image string, extraArgs []strin
 				ImagePullPolicy: pullPolicy(),
 				Command:         []string{"nfd-topology-updater"},
 				Args: append([]string{
-					"--kubelet-config-file=/podresources/config.yaml",
+					"--kubelet-config-uri=file:///podresources/config.yaml",
 					"--podresources-socket=unix:///podresources/kubelet.sock",
 					"--sleep-interval=3s",
 					"--watch-namespace=rte",


### PR DESCRIPTION
The -kubelet-config-file flag got renamed to -kubelet-config-uri and the expected format changed from plain filepath to URI.