### PR TITLE
test/e2e: add helper for creating new configmaps

### DIFF
--- a/test/e2e/node_feature_discovery.go
+++ b/test/e2e/node_feature_discovery.go
@@ -32,7 +32,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	extclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
@@ -308,25 +307,18 @@ var _ = SIGDescribe("Node Feature Discovery", func() {
 				targetLabelNameNegative := "nodename-test-negative"
 
 				// create 2 configmaps
-				data1 := make(map[string]string)
-				data1["custom1.conf"] = `
+				data1 := `
 - name: ` + targetLabelName + `
   matchOn:
   # default value is true
   - nodename:
     - ` + targetNodeName
 
-				cm1 := &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "custom-config-extra-" + string(uuid.NewUUID()),
-					},
-					Data: data1,
-				}
+				cm1 := testutils.NewConfigMap("custom-config-extra-1", "custom.conf", data1)
 				cm1, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), cm1, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				data2 := make(map[string]string)
-				data2["custom1.conf"] = `
+				data2 := `
 - name: ` + targetLabelNameWildcard + `
   value: ` + targetLabelValueWildcard + `
   matchOn:
@@ -337,12 +329,7 @@ var _ = SIGDescribe("Node Feature Discovery", func() {
   - nodename:
     - "thisNameShouldNeverMatch"`
 
-				cm2 := &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "custom-config-extra-" + string(uuid.NewUUID()),
-					},
-					Data: data2,
-				}
+				cm2 := testutils.NewConfigMap("custom-config-extra-2", "custom.conf", data2)
 				cm2, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), cm2, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/topology_updater.go
+++ b/test/e2e/topology_updater.go
@@ -260,21 +260,12 @@ var _ = SIGDescribe("Node Feature Discovery topology updater", func() {
 	})
 
 	When("topology-updater configure to exclude memory", func() {
-		var topologyUpdaterConfigMap *corev1.ConfigMap
-
 		BeforeEach(func() {
-			data := make(map[string]string)
-			data["nfd-topology-updater.conf"] = `excludeList:
+			cm := testutils.NewConfigMap("nfd-topology-updater-conf", "nfd-topology-updater.conf", `
+excludeList:
   '*': [memory]
-`
-			topologyUpdaterConfigMap = &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "nfd-topology-updater-conf",
-				},
-				Data: data,
-			}
-
-			cm, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), topologyUpdaterConfigMap, metav1.CreateOptions{})
+`)
+			cm, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), cm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			cfg, err := testutils.GetConfig()

--- a/test/e2e/utils/configmap.go
+++ b/test/e2e/utils/configmap.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateConfigMap is a helper for creating a simple ConfigMap object with one key.
+func NewConfigMap(name, key, data string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Data: map[string]string{key: data},
+	}
+}


### PR DESCRIPTION
Implement a simple helper for creating a configmap with one key. One key (one config file) is enough for our current tests.