### PR TITLE
nfd-worker: drop deprecated command line flags

### DIFF
--- a/cmd/nfd-worker/main.go
+++ b/cmd/nfd-worker/main.go
@@ -84,15 +84,6 @@ func parseArgs(flags *flag.FlagSet, osArgs ...string) *worker.Args {
 			args.Overrides.FeatureSources = overrides.FeatureSources
 		case "label-sources":
 			args.Overrides.LabelSources = overrides.LabelSources
-		case "label-whitelist":
-			klog.Warningf("-label-whitelist is deprecated, use 'core.labelWhiteList' option in the config file, instead")
-			args.Overrides.LabelWhiteList = overrides.LabelWhiteList
-		case "sleep-interval":
-			klog.Warningf("-sleep-interval is deprecated, use 'core.sleepInterval' option in the config file, instead")
-			args.Overrides.SleepInterval = overrides.SleepInterval
-		case "sources":
-			klog.Warningf("-sources is deprecated, use '-label-sources' flag, instead")
-			args.Overrides.LabelSources = overrides.LabelSources
 		}
 	})
 
@@ -124,7 +115,6 @@ func initFlags(flagset *flag.FlagSet) (*worker.Args, *worker.ConfigOverrideArgs)
 
 	// Flags overlapping with config file options
 	overrides := &worker.ConfigOverrideArgs{
-		LabelWhiteList: &utils.RegexpVal{},
 		FeatureSources: &utils.StringSliceVal{},
 		LabelSources:   &utils.StringSliceVal{},
 	}
@@ -136,17 +126,6 @@ func initFlags(flagset *flag.FlagSet) (*worker.Args, *worker.ConfigOverrideArgs)
 	flagset.Var(overrides.LabelSources, "label-sources",
 		"Comma separated list of label sources. Special value 'all' enables all sources. "+
 			"Prefix the source name with '-' to disable it.")
-	flagset.Var(overrides.LabelWhiteList, "label-whitelist",
-		"Regular expression to filter label names to publish to the Kubernetes API server. "+
-			"NB: the label namespace is omitted i.e. the filter is only applied to the name part after '/'. "+
-			"DEPRECATED: This parameter should be set via the config file.")
-	overrides.SleepInterval = flagset.Duration("sleep-interval", 0,
-		"Time to sleep between re-labeling. Non-positive value implies no re-labeling (i.e. infinite sleep). "+
-			"DEPRECATED: This parameter should be set via the config file")
-	flagset.Var(overrides.LabelSources, "sources",
-		"Comma separated list of label sources. Special value 'all' enables all feature sources. "+
-			"Prefix the source name with '-' to disable it. "+
-			"DEPRECATED: use -label-sources instead")
 
 	return args, overrides
 }

--- a/cmd/nfd-worker/main_test.go
+++ b/cmd/nfd-worker/main_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"testing"
-	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -36,8 +35,6 @@ func TestParseArgs(t *testing.T) {
 			Convey("overrides should be nil", func() {
 				So(args.Oneshot, ShouldBeTrue)
 				So(args.Overrides.NoPublish, ShouldBeNil)
-				So(args.Overrides.LabelWhiteList, ShouldBeNil)
-				So(args.Overrides.SleepInterval, ShouldBeNil)
 				So(args.Overrides.FeatureSources, ShouldBeNil)
 				So(args.Overrides.LabelSources, ShouldBeNil)
 			})
@@ -46,18 +43,14 @@ func TestParseArgs(t *testing.T) {
 		Convey("When all override args are specified", func() {
 			args := parseArgs(flags,
 				"-no-publish",
-				"-label-whitelist=.*rdt.*",
 				"-feature-sources=cpu",
-				"-label-sources=fake1,fake2,fake3",
-				"-sleep-interval=30s")
+				"-label-sources=fake1,fake2,fake3")
 
 			Convey("args.sources is set to appropriate values", func() {
 				So(args.Oneshot, ShouldBeFalse)
 				So(*args.Overrides.NoPublish, ShouldBeTrue)
-				So(*args.Overrides.SleepInterval, ShouldEqual, 30*time.Second)
 				So(*args.Overrides.FeatureSources, ShouldResemble, utils.StringSliceVal{"cpu"})
 				So(*args.Overrides.LabelSources, ShouldResemble, utils.StringSliceVal{"fake1", "fake2", "fake3"})
-				So(args.Overrides.LabelWhiteList.Regexp.String(), ShouldResemble, ".*rdt.*")
 			})
 		})
 	})

--- a/docs/reference/worker-commandline-reference.md
+++ b/docs/reference/worker-commandline-reference.md
@@ -178,10 +178,6 @@ Example:
 nfd-worker -label-sources=kernel,system,local
 ```
 
-### -sources
-
-**DEPRECATED**: use [`-label-sources`](#-label-sources) instead.
-
 ### -no-publish
 
 The `-no-publish` flag disables all communication with the nfd-master, making
@@ -196,29 +192,6 @@ Example:
 nfd-worker -no-publish
 ```
 
-### -label-whitelist
-
-The `-label-whitelist` specifies a regular expression for filtering feature
-labels based on their name. Each label must match against the given reqular
-expression in order to be published.
-
-Note: The regular expression is only matches against the "basename" part of the
-label, i.e. to the part of the name after '/'. The label namespace is omitted.
-
-Note: This flag takes precedence over the `core.labelWhiteList` configuration
-file option.
-
-Default: *empty*
-
-Example:
-
-```bash
-nfd-worker -label-whitelist='.*cpuid\.'
-```
-
-**DEPRECATED**: you should use the `core.labelWhiteList` option in the
-configuration file, instead.
-
 ### -oneshot
 
 The `-oneshot` flag causes nfd-worker to exit after one pass of feature
@@ -231,26 +204,6 @@ Example:
 ```bash
 nfd-worker -oneshot -no-publish
 ```
-
-### -sleep-interval
-
-The `-sleep-interval` specifies the interval between feature re-detection (and
-node re-labeling). A non-positive value implies infinite sleep interval, i.e.
-no re-detection or re-labeling is done.
-
-Note: This flag takes precedence over the `core.sleepInterval` configuration
-file option.
-
-Default: 60s
-
-Example:
-
-```bash
-nfd-worker -sleep-interval=1h
-```
-
-**DEPRECATED**: you should use the `core.sleepInterval` option in the
-configuration file, instead.
 
 ### Logging
 

--- a/docs/reference/worker-configuration-reference.md
+++ b/docs/reference/worker-configuration-reference.md
@@ -31,9 +31,6 @@ feature (re-)detection, and thus also the interval between node re-labeling. A
 non-positive value implies infinite sleep interval, i.e. no re-detection or
 re-labeling is done.
 
-Note: Overridden by the deprecated `-sleep-interval` command line flag (if
-specified).
-
 Default: `60s`
 
 Example:
@@ -82,8 +79,8 @@ conjunction with `all`. This configuration option affects the generation of
 node labels but not the actual discovery of the underlying feature data that is
 used e.g. in custom/`NodeFeatureRule` rules.
 
-Note: Overridden by the `-label-sources` and `-sources` command line flags and
-the `core.sources` configurations option (if any of them is specified).
+Note: Overridden by the `-label-sources` command line flag and
+the `core.sources` configurations option (if either of them is specified).
 
 Default: `[all]`
 
@@ -121,9 +118,6 @@ labels based on the label name. Non-matching labels are not published.
 Note: The regular expression is only matches against the "basename" part of the
 label, i.e. to the part of the name after '/'. The label prefix (or namespace)
 is omitted.
-
-Note: Overridden by the deprecated `-label-whitelist` command line flag (if
-specified).
 
 Default: `null`
 

--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -84,9 +84,7 @@ labels, accordingly.
 is received from nfd-worker. That is, in practice rules are evaluated and
 labels for each node are created on intervals specified by the
 [`core.sleepInterval`](../reference/worker-configuration-reference#coresleepinterval)
-configuration option (or
-[`-sleep-interval`](../reference/worker-commandline-reference#-sleep-interval)
-command line flag) of nfd-worker instances. This means that modification or
+configuration option of nfd-worker instances. This means that modification or
 creation of `NodeFeatureRule` objects does not instantly cause the node labels
 to be updated.  Instead, the changes only come visible in node labels as
 nfd-worker instances send their labelling requests.

--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -33,10 +33,14 @@ have the following format.
 feature.node.kubernetes.io/<feature> = <value>
 ```
 
-*Note: Consecutive runs of nfd-worker will update the labels on a
+> NOTE: Consecutive runs of nfd-worker will update the labels on a
 given node. If features are not discovered on a consecutive run, the corresponding
 label will be removed. This includes any restrictions placed on the consecutive run,
-such as restricting discovered features with the -label-whitelist option.*
+such as restricting discovered features with the
+[`-label-whitelist`](../reference/master-commandline-reference#-label-whitelist)
+flag of nfd-master or
+[`core.labelWhiteList`](../reference/worker-configuration-reference#corelabelwhitelist)
+option of nfd-worker.
 
 ### CPU
 

--- a/docs/usage/nfd-worker.md
+++ b/docs/usage/nfd-worker.md
@@ -23,9 +23,7 @@ Worker connects to the nfd-master service to advertise hardware features.
 When run as a daemonset, nodes are re-labeled at an default interval of 60s.
 This can be changed by using the
 [`core.sleepInterval`](../reference/worker-configuration-reference.html#coresleepinterval)
-config option (or
-[`-sleep-interval`](../reference/worker-commandline-reference.html#-sleep-interval)
-command line flag).
+config option.
 
 The worker configuration file is watched and re-read on every change which
 provides a simple mechanism of dynamic run-time reconfiguration. See

--- a/pkg/nfd-client/worker/nfd-worker.go
+++ b/pkg/nfd-client/worker/nfd-worker.go
@@ -88,9 +88,6 @@ type Args struct {
 type ConfigOverrideArgs struct {
 	NoPublish *bool
 
-	// Deprecated
-	LabelWhiteList *utils.RegexpVal
-	SleepInterval  *time.Duration
 	FeatureSources *utils.StringSliceVal
 	LabelSources   *utils.StringSliceVal
 }
@@ -415,14 +412,8 @@ func (w *nfdWorker) configure(filepath string, overrides string) error {
 		return fmt.Errorf("failed to parse -options: %s", err)
 	}
 
-	if w.args.Overrides.LabelWhiteList != nil {
-		c.Core.LabelWhiteList = *w.args.Overrides.LabelWhiteList
-	}
 	if w.args.Overrides.NoPublish != nil {
 		c.Core.NoPublish = *w.args.Overrides.NoPublish
-	}
-	if w.args.Overrides.SleepInterval != nil {
-		c.Core.SleepInterval = duration{*w.args.Overrides.SleepInterval}
 	}
 	if w.args.Overrides.FeatureSources != nil {
 		c.Core.FeatureSources = *w.args.Overrides.FeatureSources


### PR DESCRIPTION
Drop the following flags that were deprecated already in v0.8.0:

`-sleep-interval`  (replaced by `core.sleepInterval` config file option)
`-label-whitelist` (replaced by `core.labelWhiteList` config file option)
`-sources`         (replaced by `-label-sources flag`)