### PR TITLE
test/e2e: no pod restart policy of nfd-worker by default

### DIFF
--- a/test/e2e/node_feature_discovery.go
+++ b/test/e2e/node_feature_discovery.go
@@ -158,6 +158,7 @@ var _ = SIGDescribe("Node Feature Discovery", func() {
 				// Launch nfd-worker
 				By("Creating a nfd worker pod")
 				podSpecOpts := []testpod.SpecOption{
+					testpod.SpecWithRestartPolicy(corev1.RestartPolicyNever),
 					testpod.SpecWithContainerImage(fmt.Sprintf("%s:%s", *dockerRepo, *dockerTag)),
 					testpod.SpecWithContainerExtraArgs("-oneshot", "-label-sources=fake"),
 				}

--- a/test/e2e/utils/pod/pod.go
+++ b/test/e2e/utils/pod/pod.go
@@ -174,10 +174,14 @@ func NFDWorker(opts ...SpecOption) *corev1.Pod {
 		},
 		Spec: *nfdWorkerSpec(opts...),
 	}
-
-	p.Spec.RestartPolicy = corev1.RestartPolicyNever
-
 	return p
+}
+
+// SpecWithRestartPolicy returns a SpecOption that sets the pod restart policy
+func SpecWithRestartPolicy(restartpolicy corev1.RestartPolicy) SpecOption {
+	return func(spec *corev1.PodSpec) {
+		spec.RestartPolicy = restartpolicy
+	}
 }
 
 // SpecWithContainerImage returns a SpecOption that sets the image used by the first container.


### PR DESCRIPTION
Fixes stricter API check on daemonset pod spec that started to cause e2e test failures. RestartPolicyNever that we previously set (by defaylt) isn't compatible with DaemonSets.