### PR TITLE
helm: drop NodeFeatureRule CRD from templates

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/nodefeaturerule-crd.yaml
+++ b/deployment/helm/node-feature-discovery/templates/nodefeaturerule-crd.yaml
@@ -1,3 +1,0 @@
-{{- if .Values.nodeFeatureRule.createCRD }}
-{{ .Files.Get "crds/nodefeaturerule-crd.yaml" }}
-{{- end}}

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -10,9 +10,6 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 
-nodeFeatureRule:
-  createCRD: true
-
 master:
   instance:
   extraLabelNs: []


### PR DESCRIPTION
Helm 3 can manage CRDs in a more user friendly way. In fact, this now causes deployment failure as Helm automatically tries to install the CRD from the "crds/" subdir, too.