### PR TITLE
nfd-master svc should select only nfd-master pods

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/service.yaml
+++ b/deployment/helm/node-feature-discovery/templates/service.yaml
@@ -15,3 +15,4 @@ spec:
       name: grpc
   selector:
     {{- include "node-feature-discovery.selectorLabels" . | nindent 4 }}
+    role: master


### PR DESCRIPTION
The nfd-workers don't have any exposed ports. It would be cleaner to have the service selector only point to the pods that actually expose a container port and host the grpc service