### PR TITLE
nfd-worker: detect the namespace it is running in

### DIFF
--- a/pkg/nfd-client/worker/nfd-worker.go
+++ b/pkg/nfd-client/worker/nfd-worker.go
@@ -95,14 +95,15 @@ type ConfigOverrideArgs struct {
 type nfdWorker struct {
 	clientcommon.NfdBaseClient
 
-	args           Args
-	certWatch      *utils.FsWatcher
-	configFilePath string
-	config         *NFDConfig
-	grpcClient     pb.LabelerClient
-	stop           chan struct{} // channel for signaling stop
-	featureSources []source.FeatureSource
-	labelSources   []source.LabelSource
+	args                Args
+	certWatch           *utils.FsWatcher
+	configFilePath      string
+	config              *NFDConfig
+	kubernetesNamespace string
+	grpcClient          pb.LabelerClient
+	stop                chan struct{} // channel for signaling stop
+	featureSources      []source.FeatureSource
+	labelSources        []source.LabelSource
 }
 
 type duration struct {
@@ -119,9 +120,10 @@ func NewNfdWorker(args *Args) (clientcommon.NfdClient, error) {
 	nfd := &nfdWorker{
 		NfdBaseClient: base,
 
-		args:   *args,
-		config: &NFDConfig{},
-		stop:   make(chan struct{}, 1),
+		args:                *args,
+		config:              &NFDConfig{},
+		kubernetesNamespace: utils.GetKubernetesNamespace(),
+		stop:                make(chan struct{}, 1),
 	}
 
 	if args.ConfigFile != "" {

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"os"
+	"strings"
+)
+
+// GetKubernetesNamespace returns the kubernetes namespace we're running under,
+// or an empty string if the namespace cannot be determined.
+func GetKubernetesNamespace() string {
+	const kubernetesNamespaceFilePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	if _, err := os.Stat(kubernetesNamespaceFilePath); err == nil {
+		data, err := os.ReadFile(kubernetesNamespaceFilePath)
+		if err == nil {
+			return strings.TrimSpace(string(data))
+		}
+	}
+	return os.Getenv("KUBERNETES_NAMESPACE")
+}


### PR DESCRIPTION
Implement detection of kubernetes namespace by reading file /var/run/secrets/kubernetes.io/serviceaccount/namespace

Aa a fallback (if the file is not accessible) we take namespace from KUBERNETES_NAMESPACE environment variable. This is useful for e.g. testing and development where you might run nfd-worker directly from the command line on a host system.

This PR is split out from #903