### PR TITLE
nfd-master: fix creation of the -enable-nodefeature-api flag

### DIFF
--- a/cmd/nfd-master/main.go
+++ b/cmd/nfd-master/main.go
@@ -94,7 +94,7 @@ func initFlags(flagset *flag.FlagSet) *master.Args {
 	flagset.Var(&args.LabelWhiteList, "label-whitelist",
 		"Regular expression to filter label names to publish to the Kubernetes API server. "+
 			"NB: the label namespace is omitted i.e. the filter is only applied to the name part after '/'.")
-	flagset.BoolVar(&args.EnableNodeFeatureApi, "-enable-nodefeature-api", false,
+	flagset.BoolVar(&args.EnableNodeFeatureApi, "enable-nodefeature-api", false,
 		"Enable the NodeFeature CRD API for receiving node features. This will automatically disable the gRPC communication.")
 	flagset.BoolVar(&args.NoPublish, "no-publish", false,
 		"Do not publish feature labels")


### PR DESCRIPTION
Extra dash caused a panic when trying to run the binary.