### PR TITLE
E2E: default seccompProfile to runtimeDefault for nfd worker

### DIFF
--- a/test/e2e/utils/pod/pod.go
+++ b/test/e2e/utils/pod/pod.go
@@ -271,6 +271,9 @@ func nfdWorkerSpec(opts ...SpecOption) *corev1.PodSpec {
 					RunAsNonRoot:             &yes,
 					ReadOnlyRootFilesystem:   &yes,
 					AllowPrivilegeEscalation: &no,
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{
@@ -387,6 +390,9 @@ func NFDTopologyUpdaterSpec(kc utils.KubeletConfig, opts ...SpecOption) *corev1.
 					RunAsUser:                pointer.Int64(0),
 					ReadOnlyRootFilesystem:   pointer.Bool(true),
 					AllowPrivilegeEscalation: pointer.Bool(false),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{


### PR DESCRIPTION
Use RuntimeDefault seccomp profile in nfd worker and topology updater pod spec similar to nfd master.
Otherwise, we get PodSecurity violation when running locally:

```
  Dec 14 16:45:41.440: Unexpected error:
      <*errors.StatusError | 0xc000d58a00>: {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "pods \"nfd-worker-6ee0652e-2dca-49a0-ac88-9896453b3655\" is forbidden: violates PodSecurity \"restricted:latest\": restricted volume types (volumes \"host-boot\", \"host-os-release\", \"host-sys\", \"host-usr-lib\", \"host-usr-src\" use restricted volume type \"hostPath\"), seccompProfile (pod or container \"node-feature-discovery\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")",
              Reason: "Forbidden",
              Details: {
                  Name: "nfd-worker-6ee0652e-2dca-49a0-ac88-9896453b3655",
                  Group: "",
                  Kind: "pods",
                  UID: "",
                  Causes: nil,
                  RetryAfterSeconds: 0,
              },
              Code: 403,
          },
      }
      pods "nfd-worker-6ee0652e-2dca-49a0-ac88-9896453b3655" is forbidden: violates PodSecurity "restricted:latest": restricted volume types (volumes "host-boot", "host-os-release", "host-sys", "host-usr-lib", "host-usr-src" use restricted volume type "hostPath"), seccompProfile (pod or container "node-feature-discovery" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
  occurred

```