### PR TITLE
nfd-master: update all nodes at startup when NodeFeature API enabled

### DIFF
--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -259,7 +259,9 @@ func (m *nfdMaster) runGrpcServer(errChan chan<- error) {
 
 // nfdAPIUpdateHandler handles events from the nfd API controller.
 func (m *nfdMaster) nfdAPIUpdateHandler() {
-	updateAll := false
+	// We want to unconditionally update all nodes at startup if gRPC is
+	// disabled (i.e. NodeFeature API is enabled)
+	updateAll := m.args.EnableNodeFeatureApi
 	updateNodes := make(map[string]struct{})
 	rateLimit := time.After(time.Second)
 	for {


### PR DESCRIPTION
We want to always update all nodes at startup. Without this patch we don't get any update event from the controller if no NodeFeature or NodeFeatureRule objects exist in the cluster. Thus all nodes would stay untouched whereas we really want to remove all labels from all nodes in this case.