### PR TITLE
test/e2e: fix mistake in ginkgo focus

### DIFF
--- a/test/e2e/node_feature_discovery.go
+++ b/test/e2e/node_feature_discovery.go
@@ -112,7 +112,7 @@ func cleanupCRDs(cli *nfdclient.Clientset) {
 }
 
 // Actual test suite
-var _ = SIGDescribe("devel", func() {
+var _ = SIGDescribe("Node Feature Discovery", func() {
 	f := framework.NewDefaultFramework("node-feature-discovery")
 
 	Context("when deploying a single nfd-master pod", Ordered, func() {


### PR DESCRIPTION
Leftover from development that got accidentally merged in 43910e6925e2bf1c050bbacf806f3ef3469f427d