### PR TITLE
test/e2e: add basic e2e-tests for NodeFeature API

### DIFF
--- a/test/e2e/utils/pod/pod.go
+++ b/test/e2e/utils/pod/pod.go
@@ -307,7 +307,7 @@ func nfdWorkerSpec(opts ...SpecOption) *corev1.PodSpec {
 				},
 			},
 		},
-		ServiceAccountName: "nfd-master-e2e",
+		ServiceAccountName: "nfd-worker-e2e",
 		DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
 		Volumes: []corev1.Volume{
 			{


### PR DESCRIPTION
Add an initial test set for the NodeFeature API. This is done simply by
running a second pass of the tests but with -enable-nodefeature-api
(i.e. NodeFeature API enabled and gRPC disabled). This should give basic
confidence that the API actually works and form a basis for further
imporovements on testing the new CRD API.