### PR TITLE
Use single-dash format for nfd cmdline flags

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/master.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master.yaml
@@ -76,16 +76,16 @@ spec:
             {{- toYaml .Values.master.resources | nindent 12 }}
           args:
             {{- if .Values.master.instance | empty | not }}
-            - "--instance={{ .Values.master.instance }}"
+            - "-instance={{ .Values.master.instance }}"
             {{- end }}
             {{- if .Values.enableNodeFeatureApi }}
             - "-enable-nodefeature-api"
             {{- end }}
             {{- if .Values.master.extraLabelNs | empty | not }}
-            - "--extra-label-ns={{- join "," .Values.master.extraLabelNs }}"
+            - "-extra-label-ns={{- join "," .Values.master.extraLabelNs }}"
             {{- end }}
             {{- if .Values.master.resourceLabels | empty | not }}
-            - "--resource-labels={{- join "," .Values.master.resourceLabels }}"
+            - "-resource-labels={{- join "," .Values.master.resourceLabels }}"
             {{- end }}
             {{- if .Values.master.crdController | kindIs "invalid" | not }}
             - "-crd-controller={{ .Values.master.crdController }}"
@@ -97,9 +97,9 @@ spec:
             - "-featurerules-controller={{ .Values.master.featureRulesController }}"
             {{- end }}
     {{- if .Values.tls.enable }}
-            - "--ca-file=/etc/kubernetes/node-feature-discovery/certs/ca.crt"
-            - "--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
-            - "--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
+            - "-ca-file=/etc/kubernetes/node-feature-discovery/certs/ca.crt"
+            - "-key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
+            - "-cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
           volumeMounts:
             - name: nfd-master-cert
               mountPath: "/etc/kubernetes/node-feature-discovery/certs"

--- a/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
+++ b/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
@@ -41,19 +41,19 @@ spec:
           - "nfd-topology-updater"
         args:
           {{- if .Values.topologyUpdater.updateInterval | empty | not }}
-          - "--sleep-interval={{ .Values.topologyUpdater.updateInterval }}"
+          - "-sleep-interval={{ .Values.topologyUpdater.updateInterval }}"
           {{- else }}
-          - "--sleep-interval=3s"
+          - "-sleep-interval=3s"
           {{- end }}
           {{- if .Values.topologyUpdater.watchNamespace | empty | not }}
-          - "--watch-namespace={{ .Values.topologyUpdater.watchNamespace }}"
+          - "-watch-namespace={{ .Values.topologyUpdater.watchNamespace }}"
           {{- else }}
-          - "--watch-namespace=*"
+          - "-watch-namespace=*"
           {{- end }}
           {{- if .Values.tls.enable }}
-          - "--ca-file=/etc/kubernetes/node-feature-discovery/certs/ca.crt"
-          - "--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
-          - "--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
+          - "-ca-file=/etc/kubernetes/node-feature-discovery/certs/ca.crt"
+          - "-key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
+          - "-cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
           {{- end }}
         volumeMounts:
         - name: kubelet-config

--- a/deployment/helm/node-feature-discovery/templates/worker.yaml
+++ b/deployment/helm/node-feature-discovery/templates/worker.yaml
@@ -45,14 +45,14 @@ spec:
         command:
         - "nfd-worker"
         args:
-        - "--server={{ include "node-feature-discovery.fullname" . }}-master:{{ .Values.master.service.port }}"
+        - "-server={{ include "node-feature-discovery.fullname" . }}-master:{{ .Values.master.service.port }}"
         {{- if .Values.enableNodeFeatureApi }}
         - "-enable-nodefeature-api"
         {{- end }}
 {{- if .Values.tls.enable }}
-        - "--ca-file=/etc/kubernetes/node-feature-discovery/certs/ca.crt"
-        - "--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
-        - "--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
+        - "-ca-file=/etc/kubernetes/node-feature-discovery/certs/ca.crt"
+        - "-key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
+        - "-cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
 {{- end }}
         volumeMounts:
         - name: host-boot

--- a/deployment/overlays/prune/master-job.yaml
+++ b/deployment/overlays/prune/master-job.yaml
@@ -20,6 +20,6 @@ spec:
           command:
             - "nfd-master"
           args:
-            - "--prune"
+            - "-prune"
       restartPolicy: Never
 

--- a/test/e2e/utils/pod/pod.go
+++ b/test/e2e/utils/pod/pod.go
@@ -363,10 +363,10 @@ func NFDTopologyUpdaterSpec(kc utils.KubeletConfig, opts ...SpecOption) *corev1.
 				ImagePullPolicy: pullPolicy(),
 				Command:         []string{"nfd-topology-updater"},
 				Args: []string{
-					"--kubelet-config-uri=file:///podresources/config.yaml",
-					"--podresources-socket=unix:///podresources/kubelet.sock",
-					"--sleep-interval=3s",
-					"--watch-namespace=rte"},
+					"-kubelet-config-uri=file:///podresources/config.yaml",
+					"-podresources-socket=unix:///podresources/kubelet.sock",
+					"-sleep-interval=3s",
+					"-watch-namespace=rte"},
 				Env: []corev1.EnvVar{
 					{
 						Name: "NODE_NAME",


### PR DESCRIPTION
Use the "single-dash" version of nfd command line flags in deployment files and e2e-tests. No impact in functionality, just aligns with documentation and other parts of the codebase.