### PR TITLE
apis/nfd: make all fields in NodeFeatureSpec optional

### DIFF
--- a/deployment/base/nfd-crds/nfd-api-crds.yaml
+++ b/deployment/base/nfd-crds/nfd-api-crds.yaml
@@ -52,6 +52,8 @@ spec:
                       required:
                       - elements
                       type: object
+                    description: Attributes contains all the attribute-type features
+                      of the node.
                     type: object
                   flags:
                     additionalProperties:
@@ -67,6 +69,8 @@ spec:
                       required:
                       - elements
                       type: object
+                    description: Flags contains all the flag-type features of the
+                      node.
                     type: object
                   instances:
                     additionalProperties:
@@ -89,11 +93,9 @@ spec:
                       required:
                       - elements
                       type: object
+                    description: Instances contains all the instance-type features
+                      of the node.
                     type: object
-                required:
-                - attributes
-                - flags
-                - instances
                 type: object
               labels:
                 additionalProperties:
@@ -101,8 +103,6 @@ spec:
                 description: Labels is the set of node labels that are requested to
                   be created.
                 type: object
-            required:
-            - features
             type: object
         required:
         - spec

--- a/deployment/helm/node-feature-discovery/crds/nfd-api-crds.yaml
+++ b/deployment/helm/node-feature-discovery/crds/nfd-api-crds.yaml
@@ -52,6 +52,8 @@ spec:
                       required:
                       - elements
                       type: object
+                    description: Attributes contains all the attribute-type features
+                      of the node.
                     type: object
                   flags:
                     additionalProperties:
@@ -67,6 +69,8 @@ spec:
                       required:
                       - elements
                       type: object
+                    description: Flags contains all the flag-type features of the
+                      node.
                     type: object
                   instances:
                     additionalProperties:
@@ -89,11 +93,9 @@ spec:
                       required:
                       - elements
                       type: object
+                    description: Instances contains all the instance-type features
+                      of the node.
                     type: object
-                required:
-                - attributes
-                - flags
-                - instances
                 type: object
               labels:
                 additionalProperties:
@@ -101,8 +103,6 @@ spec:
                 description: Labels is the set of node labels that are requested to
                   be created.
                 type: object
-            required:
-            - features
             type: object
         required:
         - spec

--- a/pkg/apis/nfd/v1alpha1/generated.proto
+++ b/pkg/apis/nfd/v1alpha1/generated.proto
@@ -35,10 +35,16 @@ message AttributeFeatureSet {
 //
 // +protobuf=true
 message Features {
+  // Flags contains all the flag-type features of the node.
+  // +optional
   map<string, FlagFeatureSet> flags = 1;
 
+  // Attributes contains all the attribute-type features of the node.
+  // +optional
   map<string, AttributeFeatureSet> vattributes = 2;
 
+  // Instances contains all the instance-type features of the node.
+  // +optional
   map<string, InstanceFeatureSet> instances = 3;
 }
 

--- a/pkg/apis/nfd/v1alpha1/types.go
+++ b/pkg/apis/nfd/v1alpha1/types.go
@@ -46,6 +46,7 @@ type NodeFeature struct {
 // NodeFeatureSpec describes a NodeFeature object.
 type NodeFeatureSpec struct {
 	// Features is the full "raw" features data that has been discovered.
+	// +optional
 	Features Features `json:"features"`
 	// Labels is the set of node labels that are requested to be created.
 	// +optional
@@ -56,9 +57,15 @@ type NodeFeatureSpec struct {
 //
 // +protobuf=true
 type Features struct {
-	Flags      map[string]FlagFeatureSet      `json:"flags" protobuf:"bytes,1,rep,name=flags"`
+	// Flags contains all the flag-type features of the node.
+	// +optional
+	Flags map[string]FlagFeatureSet `json:"flags" protobuf:"bytes,1,rep,name=flags"`
+	// Attributes contains all the attribute-type features of the node.
+	// +optional
 	Attributes map[string]AttributeFeatureSet `json:"attributes" protobuf:"bytes,2,rep,name=vattributes"`
-	Instances  map[string]InstanceFeatureSet  `json:"instances" protobuf:"bytes,3,rep,name=instances"`
+	// Instances contains all the instance-type features of the node.
+	// +optional
+	Instances map[string]InstanceFeatureSet `json:"instances" protobuf:"bytes,3,rep,name=instances"`
 }
 
 // FlagFeatureSet is a set of simple features only containing names without values.


### PR DESCRIPTION
Don't require features to be specified. The creator possibly only wants
to create labels or only some types of features. No need to specify
empty structs for the unused fields.