### PR TITLE
Add missing TopologyManagerPolicy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.9
 	github.com/jaypipes/ghw v0.8.1-0.20210827132705-c7224150a17e
-	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.12
+	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.13
 	github.com/klauspost/cpuid/v2 v2.2.3
 	github.com/onsi/ginkgo/v2 v2.4.0
 	github.com/onsi/gomega v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,8 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.12 h1:NhXbOjO1st8hIcVpegr3zw/AGG12vs3z//tCDDcfPpE=
-github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.12/go.mod h1:AkACMQGiTgCt0lQw3m7TTU8PLH9lYKNK5e9DqFf5VuM=
+github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.13 h1:Y1RjPskyGMkVtNL8lq75bEdjqgq8gi+JJ1oWaz/mIJE=
+github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.13/go.mod h1:AkACMQGiTgCt0lQw3m7TTU8PLH9lYKNK5e9DqFf5VuM=
 github.com/karrick/godirwalk v1.17.0 h1:b4kY7nqDdioR/6qnbHQyDvmA17u5G1cZ6J+CZXwSWoI=
 github.com/karrick/godirwalk v1.17.0/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/pkg/topologypolicy/topology-policy.go
+++ b/pkg/topologypolicy/topology-policy.go
@@ -24,20 +24,39 @@ import (
 // DetectTopologyPolicy returns string type which present
 // both Topology manager policy and scope
 func DetectTopologyPolicy(policy string, scope string) v1alpha1.TopologyManagerPolicy {
+	switch scope {
+	case config.PodTopologyManagerScope:
+		return detectPolicyPodScope(policy)
+	case config.ContainerTopologyManagerScope:
+		return detectPolicyContainerScope(policy)
+	default:
+		return v1alpha1.None
+	}
+}
+
+func detectPolicyPodScope(policy string) v1alpha1.TopologyManagerPolicy {
 	switch policy {
 	case config.SingleNumaNodeTopologyManagerPolicy:
-		if scope == config.PodTopologyManagerScope {
-			return v1alpha1.SingleNUMANodePodLevel
-		} else if scope == config.ContainerTopologyManagerScope {
-			return v1alpha1.SingleNUMANodeContainerLevel
-		} else {
-			// default scope for single-numa-node
-			return v1alpha1.SingleNUMANodeContainerLevel
-		}
+		return v1alpha1.SingleNUMANodePodLevel
 	case config.RestrictedTopologyManagerPolicy:
-		return v1alpha1.Restricted
+		return v1alpha1.RestrictedPodLevel
 	case config.BestEffortTopologyManagerPolicy:
-		return v1alpha1.BestEffort
+		return v1alpha1.BestEffortPodLevel
+	case config.NoneTopologyManagerPolicy:
+		return v1alpha1.None
+	default:
+		return v1alpha1.None
+	}
+}
+
+func detectPolicyContainerScope(policy string) v1alpha1.TopologyManagerPolicy {
+	switch policy {
+	case config.SingleNumaNodeTopologyManagerPolicy:
+		return v1alpha1.SingleNUMANodeContainerLevel
+	case config.RestrictedTopologyManagerPolicy:
+		return v1alpha1.RestrictedContainerLevel
+	case config.BestEffortTopologyManagerPolicy:
+		return v1alpha1.BestEffortContainerLevel
 	case config.NoneTopologyManagerPolicy:
 		return v1alpha1.None
 	default:

--- a/pkg/topologypolicy/topology-policy_test.go
+++ b/pkg/topologypolicy/topology-policy_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologypolicy
+
+import (
+	"testing"
+
+	v1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+)
+
+func TestDetectTopologyPolicy(t *testing.T) {
+	testCases := []struct {
+		scope    string
+		policy   string
+		expected v1alpha1.TopologyManagerPolicy
+	}{
+		{
+			policy:   "best-effort",
+			scope:    "pod",
+			expected: v1alpha1.BestEffortPodLevel,
+		},
+		{
+			policy:   "best-effort",
+			scope:    "container",
+			expected: v1alpha1.BestEffortContainerLevel,
+		},
+		{
+			policy:   "restricted",
+			scope:    "container",
+			expected: v1alpha1.RestrictedContainerLevel,
+		},
+		{
+			policy:   "restricted",
+			scope:    "pod",
+			expected: v1alpha1.RestrictedPodLevel,
+		},
+		{
+			policy:   "single-numa-node",
+			scope:    "pod",
+			expected: v1alpha1.SingleNUMANodePodLevel,
+		},
+		{
+			policy:   "single-numa-node",
+			scope:    "container",
+			expected: v1alpha1.SingleNUMANodeContainerLevel,
+		},
+		{
+			policy:   "none",
+			scope:    "container",
+			expected: v1alpha1.None,
+		},
+		{
+			policy:   "none",
+			scope:    "pod",
+			expected: v1alpha1.None,
+		},
+		{
+			policy:   "non-existent",
+			scope:    "pod",
+			expected: v1alpha1.None,
+		},
+		{
+			policy:   "non-existent",
+			scope:    "container",
+			expected: v1alpha1.None,
+		},
+		{
+			policy:   "single-numa-node",
+			scope:    "non-existent",
+			expected: v1alpha1.None,
+		},
+		{
+			policy:   "single-numa-node",
+			scope:    "non-existent",
+			expected: v1alpha1.None,
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := DetectTopologyPolicy(tc.policy, tc.scope)
+		if actual != tc.expected {
+			t.Errorf("Expected TopologyPolicy to equal: %s not: %s", tc.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Version `0.0.13` of NodeResourceTopology API added missing `TopologyManagerPolicy` for other policies than `single-numa-node`. This PR adds support for those new values.