### PR TITLE
images: base the default image on distroless/base

### DIFF
--- a/docs/deployment/image-variants.md
+++ b/docs/deployment/image-variants.md
@@ -15,15 +15,9 @@ sort: 1
 
 ---
 
-NFD currently offers two variants of the container image. The "full" variant is
+NFD currently offers two variants of the container image. The "minimal" variant is
 currently deployed by default. Released container images are available for
 x86_64 and Arm64 architectures.
-
-## Full
-
-This image is based on [debian:bullseye-slim](https://hub.docker.com/_/debian)
-and contains a full Linux system for running shell-based nfd-worker hooks and
-doing live debugging and diagnosis of the NFD images.
 
 ## Minimal
 
@@ -31,5 +25,14 @@ This is a minimal image based on
 [gcr.io/distroless/base](https://github.com/GoogleContainerTools/distroless/blob/master/base/README.md)
 and only supports running statically linked binaries.
 
-The container image tag has suffix `-minimal`
-(e.g. `{{ site.container_image }}-minimal`)
+For backwards compatibility a container image tag with suffix `-minimal`
+(e.g. `{{ site.container_image }}-minimal`) is provided.
+
+## Full
+
+This image is based on [debian:bullseye-slim](https://hub.docker.com/_/debian)
+and contains a full Linux system for running shell-based nfd-worker hooks and
+doing live debugging and diagnosis of the NFD images.
+
+The container image tag has suffix `-full`
+(e.g. `{{ site.container_image }}-full`).

--- a/docs/reference/worker-configuration-reference.md
+++ b/docs/reference/worker-configuration-reference.md
@@ -336,6 +336,11 @@ Hooks are DEPRECATED since v0.12.0 release and support will be removed in a
 future release. Use
 [feature files](../usage//customization-guide.md#feature-files) instead.
 
+Note: The default NFD container image only supports statically linked binaries.
+Use the [full](../deployment/image-variants.md#full) image variant for a
+slightly more extensive environment that additionally supports bash and perl
+runtimes.
+
 Related tracking issues:
 
 1. Config option to disable hooks [#859](https://github.com/kubernetes-sigs/node-feature-discovery/issues/859).

--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -257,9 +257,8 @@ on the nfd-master command line.
 **DEPRECATED** The `local` source executes hooks found in
 `/etc/kubernetes/node-feature-discovery/source.d/`. The hook files must be
 executable and they are supposed to print all discovered features in `stdout`.
-With ELF binaries static linking is recommended as the selection of system
-libraries available in the NFD release image is very limited. Other runtimes
-currently supported by the NFD image are bash and perl.
+Since NFD v0.13 the default container image only supports statically linked ELF
+binaries.
 
 `stderr` output of hooks is propagated to NFD log so it can be used for
 debugging and logging.
@@ -284,8 +283,9 @@ sources:
 directory. It is the user's responsibility to review the hooks for e.g.
 possible security implications.
 
-**NOTE:** The [minimal](../deployment/image-variants.md#minimal) image
-variant only supports running statically linked binaries.
+**NOTE:** The [full](../deployment/image-variants.md#full) image variant
+provides backwards-compatibility with older NFD versions by including a more
+expanded environment, supporting bash and perl runtimes.
 
 ### Feature files
 


### PR DESCRIPTION
Make distroless/base as the base image for the default image, effectively making the minimal image as the default. Add a new "full" image variant that corresponds the previous default image. The "*-minimal" container image tag is provided for backwards compatibility.

The practical user impact of this change is that hook support is limited to statically linked ELF binaries. Bash or Perl scripts are not supported by the default image, anymore, but the new "full" image variant can be used for backwards compatibility.

Refs #855 
Fixes #963 