### PR TITLE
[release-0.12] Update docker builder image to golang v19.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ IMAGE_BUILD_CMD ?= docker build
 IMAGE_BUILD_EXTRA_OPTS ?=
 IMAGE_PUSH_CMD ?= docker push
 CONTAINER_RUN_CMD ?= docker run
-BUILDER_IMAGE ?= golang:1.19.4-bullseye
+BUILDER_IMAGE ?= golang:1.19.5-bullseye
 BASE_IMAGE_FULL ?= debian:bullseye-slim
 BASE_IMAGE_MINIMAL ?= gcr.io/distroless/base
 


### PR DESCRIPTION
Update to the latest patch release of golang.