### PR TITLE
[release-0.12] e2e: init docker image

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"flag"
+	"fmt"
 	"math/rand"
 	"os"
 	"testing"
@@ -29,12 +30,22 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 )
 
+var (
+	dockerRepo = flag.String("nfd.repo", "registry.k8s.io/nfd/node-feature-discovery", "Docker repository to fetch image from")
+	dockerTag  = flag.String("nfd.tag", "v0.12.0", "Docker tag to use")
+)
+
 // handleFlags sets up all flags and parses the command line.
 func handleFlags() {
 	config.CopyFlags(config.Flags, flag.CommandLine)
 	framework.RegisterCommonFlags(flag.CommandLine)
 	framework.RegisterClusterFlags(flag.CommandLine)
 	flag.Parse()
+}
+
+// must be called after flags are parsed
+func dockerImage() string {
+	return fmt.Sprintf("%s:%s", *dockerRepo, *dockerTag)
 }
 
 func TestMain(m *testing.M) {

--- a/test/e2e/node_feature_discovery.go
+++ b/test/e2e/node_feature_discovery.go
@@ -18,7 +18,6 @@ package e2e
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -49,9 +48,6 @@ import (
 )
 
 var (
-	dockerRepo      = flag.String("nfd.repo", "registry.k8s.io/nfd/node-feature-discovery", "Docker repository to fetch image from")
-	dockerTag       = flag.String("nfd.tag", "v0.12.0", "Docker tag to use")
-	dockerImage     = fmt.Sprintf("%s:%s", *dockerRepo, *dockerTag)
 	testTolerations = []corev1.Toleration{
 		{
 			Key:    "nfd.node.kubernetes.io/fake-special-node",
@@ -216,7 +212,7 @@ var _ = SIGDescribe("Node Feature Discovery", func() {
 				// Launch nfd-master
 				By("Creating nfd master pod and nfd-master service")
 				podSpecOpts := createPodSpecOpts(
-					testpod.SpecWithContainerImage(dockerImage),
+					testpod.SpecWithContainerImage(dockerImage()),
 					testpod.SpecWithTolerations(testTolerations),
 					testpod.SpecWithContainerExtraArgs("-enable-taints"),
 				)
@@ -265,7 +261,7 @@ var _ = SIGDescribe("Node Feature Discovery", func() {
 					By("Creating a nfd worker pod")
 					podSpecOpts := createPodSpecOpts(
 						testpod.SpecWithRestartPolicy(corev1.RestartPolicyNever),
-						testpod.SpecWithContainerImage(dockerImage),
+						testpod.SpecWithContainerImage(dockerImage()),
 						testpod.SpecWithContainerExtraArgs("-oneshot", "-label-sources=fake"),
 						testpod.SpecWithTolerations(testTolerations),
 					)
@@ -318,7 +314,7 @@ var _ = SIGDescribe("Node Feature Discovery", func() {
 
 					By("Creating nfd-worker daemonset")
 					podSpecOpts := createPodSpecOpts(
-						testpod.SpecWithContainerImage(dockerImage),
+						testpod.SpecWithContainerImage(dockerImage()),
 						testpod.SpecWithTolerations(testTolerations),
 					)
 					workerDS := testds.NFDWorker(podSpecOpts...)
@@ -448,7 +444,7 @@ var _ = SIGDescribe("Node Feature Discovery", func() {
 
 					By("Creating nfd-worker daemonset with configmap mounted")
 					podSpecOpts := createPodSpecOpts(
-						testpod.SpecWithContainerImage(dockerImage),
+						testpod.SpecWithContainerImage(dockerImage()),
 						testpod.SpecWithConfigMap(cm1.Name, filepath.Join(custom.Directory, "cm1")),
 						testpod.SpecWithConfigMap(cm2.Name, filepath.Join(custom.Directory, "cm2")),
 						testpod.SpecWithTolerations(testTolerations),
@@ -511,7 +507,7 @@ core:
 
 					By("Creating nfd-worker daemonset")
 					podSpecOpts := createPodSpecOpts(
-						testpod.SpecWithContainerImage(dockerImage),
+						testpod.SpecWithContainerImage(dockerImage()),
 						testpod.SpecWithConfigMap(cm.Name, "/etc/kubernetes/node-feature-discovery"),
 						testpod.SpecWithTolerations(testTolerations),
 					)

--- a/test/e2e/topology_updater.go
+++ b/test/e2e/topology_updater.go
@@ -115,7 +115,7 @@ var _ = SIGDescribe("Node Feature Discovery topology updater", func() {
 			kcfg := cfg.GetKubeletConfig()
 			By(fmt.Sprintf("Using config (%#v)", kcfg))
 
-			podSpecOpts := []testpod.SpecOption{testpod.SpecWithContainerImage(dockerImage)}
+			podSpecOpts := []testpod.SpecOption{testpod.SpecWithContainerImage(dockerImage())}
 			topologyUpdaterDaemonSet = testds.NFDTopologyUpdater(kcfg, podSpecOpts...)
 		})
 
@@ -281,7 +281,7 @@ excludeList:
 			By(fmt.Sprintf("Using config (%#v)", kcfg))
 
 			podSpecOpts := []testpod.SpecOption{
-				testpod.SpecWithContainerImage(dockerImage),
+				testpod.SpecWithContainerImage(dockerImage()),
 				testpod.SpecWithConfigMap(cm.Name, "/etc/kubernetes/node-feature-discovery"),
 			}
 			topologyUpdaterDaemonSet = testds.NFDTopologyUpdater(kcfg, podSpecOpts...)


### PR DESCRIPTION
The docker image that used during e2e test
composed of repo and tag flags that are
passed to the test itself.

The problem is that the docker image initialized
before the flags are parsed. Hence, it will always contains the default flags value.
Moving the variable into a separate function, fixing the issue.

Also, moving the global variables to `e2e_test.go` since it commonly used by all tests.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>