### PR TITLE
docs: Fix link for Helm docs

### DIFF
--- a/deployment/helm/node-feature-discovery/README.md
+++ b/deployment/helm/node-feature-discovery/README.md
@@ -6,5 +6,5 @@ labels. NFD provides flexible configuration and extension points for a wide
 range of vendor and application specific node labeling needs.
 
 See
-[NFD documentation](https://kubernetes-sigs.github.io/node-feature-discovery/master/get-started/deployment-and-usage.html#deployment-with-helm)
+[NFD documentation](https://kubernetes-sigs.github.io/node-feature-discovery/master/deployment/helm.html)
 for deployment instructions.


### PR DESCRIPTION
Fix/Update link from README to Docs on the Helm folder 