### PR TITLE
[release-0.12] docs: Fix link for Helm docs

### DIFF
--- a/deployment/helm/node-feature-discovery/README.md
+++ b/deployment/helm/node-feature-discovery/README.md
@@ -6,5 +6,5 @@ labels. NFD provides flexible configuration and extension points for a wide
 range of vendor and application specific node labeling needs.
 
 See
-[NFD documentation](https://kubernetes-sigs.github.io/node-feature-discovery/v0.12/get-started/deployment-and-usage.html#deployment-with-helm)
+[NFD documentation](https://kubernetes-sigs.github.io/node-feature-discovery/v0.12/deployment/helm.html)
 for deployment instructions.


### PR DESCRIPTION
(cherry picked from commit 1c095f5e8e278015da887ef28d66c6f3e5de4130)