### PR TITLE
Replace gRPC health probe utility with k8s built-in health probe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,6 @@ ARG BASE_IMAGE_MINIMAL
 # Build node feature discovery
 FROM ${BUILDER_IMAGE} as builder
 
-# Build and install the grpc-health-probe binary
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.19 && \
-    go install -tags osusergo,netgo -ldflags -extldflags=-static \
-        github.com/grpc-ecosystem/grpc-health-probe@${GRPC_HEALTH_PROBE_VERSION} \
-        # Rename it as it's referenced as grpc_health_probe in the deployment yamls
-        # and in its own project https://github.com/grpc-ecosystem/grpc-health-probe
-        && mv /go/bin/grpc-health-probe /go/bin/grpc_health_probe
-
 # Get (cache) deps in a separate layer
 COPY go.mod go.sum /go/node-feature-discovery/
 

--- a/deployment/base/master-worker-combined/master-worker-daemonset.yaml
+++ b/deployment/base/master-worker-combined/master-worker-daemonset.yaml
@@ -21,13 +21,13 @@ spec:
         image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
         imagePullPolicy: Always
         livenessProbe:
-          exec:
-            command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+          grpc:
+            port: 8080
           initialDelaySeconds: 10
           periodSeconds: 10
         readinessProbe:
-          exec:
-            command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+          grpc:
+            port: 8080
           initialDelaySeconds: 5
           periodSeconds: 10
           failureThreshold: 10

--- a/deployment/base/master/master-deployment.yaml
+++ b/deployment/base/master/master-deployment.yaml
@@ -22,13 +22,13 @@ spec:
           image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
           imagePullPolicy: Always
           livenessProbe:
-            exec:
-              command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+            grpc:
+              port: 8080
             initialDelaySeconds: 10
             periodSeconds: 10
           readinessProbe:
-            exec:
-              command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+            grpc:
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 10

--- a/deployment/helm/node-feature-discovery/templates/cert-manager-certs.yaml
+++ b/deployment/helm/node-feature-discovery/templates/cert-manager-certs.yaml
@@ -17,8 +17,6 @@ spec:
   # first one is configured for use by the worker; below are for completeness
   - {{ include "node-feature-discovery.fullname" . }}-master.{{ include "node-feature-discovery.namespace" .  }}.svc
   - {{ include "node-feature-discovery.fullname" . }}-master.{{ include "node-feature-discovery.namespace" .  }}.svc.cluster.local
-  # localhost needed for grpc_health_probe
-  - localhost
   issuerRef:
     name: nfd-ca-issuer
     kind: Issuer

--- a/deployment/helm/node-feature-discovery/templates/master.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master.yaml
@@ -41,29 +41,13 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
-            exec:
-              command:
-              - "/usr/bin/grpc_health_probe"
-              - "-addr=:{{ .Values.master.port | default "8080" }}"
-              {{- if .Values.tls.enable }}
-              - "-tls"
-              - "-tls-ca-cert=/etc/kubernetes/node-feature-discovery/certs/ca.crt"
-              - "-tls-client-key=/etc/kubernetes/node-feature-discovery/certs/tls.key"
-              - "-tls-client-cert=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
-              {{- end }}
+            grpc:
+              port: 8080
             initialDelaySeconds: 10
             periodSeconds: 10
           readinessProbe:
-            exec:
-              command:
-              - "/usr/bin/grpc_health_probe"
-              - "-addr=:{{ .Values.master.port | default "8080" }}"
-              {{- if .Values.tls.enable }}
-              - "-tls"
-              - "-tls-ca-cert=/etc/kubernetes/node-feature-discovery/certs/ca.crt"
-              - "-tls-client-key=/etc/kubernetes/node-feature-discovery/certs/tls.key"
-              - "-tls-client-cert=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
-              {{- end }}
+            grpc:
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 10

--- a/deployment/overlays/samples/cert-manager/master-cert.yaml
+++ b/deployment/overlays/samples/cert-manager/master-cert.yaml
@@ -13,7 +13,6 @@ spec:
   - nfd-master.node-feature-discovery.svc
   - nfd-master.node-feature-discovery.svc.cluster.local
   - nfd-master
-  - localhost    # needed for grpc_health_probe
   issuerRef:
     name: nfd-ca-issuer
     kind: Issuer


### PR DESCRIPTION
Kubernetes [1.23](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-grpc-liveness-probe) has introduced native health probes for gRPC which can replace
`grpc_health_probe` utility. This commit removes baking in `grpc_health_probe`
binary into the image and updates related health checks to use k8s native gRPC.
