### PR TITLE
test: move out unit testing from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,6 @@ ARG HOSTMOUNT_PREFIX
 
 RUN make install VERSION=$VERSION HOSTMOUNT_PREFIX=$HOSTMOUNT_PREFIX
 
-RUN make test
-
 # Create full variant of the production image
 FROM ${BASE_IMAGE_FULL} as full
 

--- a/scripts/test-infra/verify.sh
+++ b/scripts/test-infra/verify.sh
@@ -21,6 +21,9 @@ make ci-lint
 echo "Running Helm lint"
 make helm-lint
 
+echo "Running unit tests"
+make test
+
 # Check that repo is clean
 if ! git diff --quiet; then
     echo "Repository is dirty!"


### PR DESCRIPTION
Move out running unit tests as part of container image building and 
instead add it into verify.sh script which runs linter, formatter and
other checks. As a future improvement, we could have separate
Prow jobs for fmt, golangci-lint, helm-linter and unit tests separately. 
