### PR TITLE
test/e2e: rename ginkgo focus for tests

### DIFF
--- a/test/e2e/node_feature_discovery_test.go
+++ b/test/e2e/node_feature_discovery_test.go
@@ -146,7 +146,7 @@ func cleanupCRDs(cli *nfdclient.Clientset) {
 }
 
 // Actual test suite
-var _ = SIGDescribe("Node Feature Discovery", func() {
+var _ = SIGDescribe("NFD master and worker", func() {
 	f := framework.NewDefaultFramework("node-feature-discovery")
 
 	nfdTestSuite := func(useNodeFeatureApi bool) {

--- a/test/e2e/topology_updater_test.go
+++ b/test/e2e/topology_updater_test.go
@@ -46,7 +46,7 @@ import (
 	testpod "sigs.k8s.io/node-feature-discovery/test/e2e/utils/pod"
 )
 
-var _ = SIGDescribe("Node Feature Discovery topology updater", func() {
+var _ = SIGDescribe("NFD topology updater", func() {
 	var (
 		extClient                *extclient.Clientset
 		topologyClient           *topologyclientset.Clientset


### PR DESCRIPTION
Make it easier to only run tests for nfd master/worker and skip topology-updater tests.