### PR TITLE
test: add code coverage reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ helm-lint:
 	helm lint --strict deployment/helm/node-feature-discovery/
 
 test:
-	$(GO_CMD) test ./cmd/... ./pkg/... ./source/...
+	$(GO_CMD) test -covermode=atomic -coverprofile=coverage.out ./cmd/... ./pkg/... ./source/...
 
 e2e-test:
 	@if [ -z ${KUBECONFIG} ]; then echo "[ERR] KUBECONFIG missing, must be defined"; exit 1; fi


### PR DESCRIPTION
Add code coverage reporting so that the report is then available to the PR author and reviewers via codecov GitHub app.

@marquiz for uploading/reporting the coverage results, we need to run `make test`. We already run the `make test` with one of the Prow job and I didn't want to add another one in the form of GitHub action. But GA is the most straightforward way of adding codecov and uploading it. There is an uploader available which can be executed from shell as well, so that can be added into Prow job run section, but for that codecov requires the token. We could store the token as a secret on GitHub but I don't know if there is a way actually for the Prow to ready/fetch that token. At least I have not seen anything like that. 

With GitHub actions it is not a problem, because we just pass the `${{ secrets.CODECOV_TOKEN }}` and voilà.

Do you have any other alternatives in mind or if not shall I go for adding another make test as GitHub action? I also thought that maybe we drop running unit tests from Prow to avoid duplication but Prow runs on much faster environment than what GitHub provides for free.

Fixes: https://github.com/kubernetes-sigs/node-feature-discovery/issues/1033