### PR TITLE
test/e2e: reduce worker wait-for-ready period to 2s

### DIFF
--- a/test/e2e/node_feature_discovery_test.go
+++ b/test/e2e/node_feature_discovery_test.go
@@ -321,8 +321,8 @@ var _ = SIGDescribe("NFD master and worker", func() {
 					workerDS, err = f.ClientSet.AppsV1().DaemonSets(f.Namespace.Name).Create(context.TODO(), workerDS, metav1.CreateOptions{})
 					Expect(err).NotTo(HaveOccurred())
 
-					By("Waiting for daemonset pods to be ready")
-					Expect(testpod.WaitForReady(f.ClientSet, f.Namespace.Name, workerDS.Spec.Template.Labels["name"], 5)).NotTo(HaveOccurred())
+					By("Waiting for worker daemonset pods to be ready")
+					Expect(testpod.WaitForReady(f.ClientSet, f.Namespace.Name, workerDS.Spec.Template.Labels["name"], 2)).NotTo(HaveOccurred())
 
 					By("Getting node objects")
 					nodeList, err := f.ClientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
@@ -454,8 +454,8 @@ var _ = SIGDescribe("NFD master and worker", func() {
 					workerDS, err = f.ClientSet.AppsV1().DaemonSets(f.Namespace.Name).Create(context.TODO(), workerDS, metav1.CreateOptions{})
 					Expect(err).NotTo(HaveOccurred())
 
-					By("Waiting for daemonset pods to be ready")
-					Expect(testpod.WaitForReady(f.ClientSet, f.Namespace.Name, workerDS.Spec.Template.Labels["name"], 5)).NotTo(HaveOccurred())
+					By("Waiting for worker daemonset pods to be ready")
+					Expect(testpod.WaitForReady(f.ClientSet, f.Namespace.Name, workerDS.Spec.Template.Labels["name"], 2)).NotTo(HaveOccurred())
 
 					By("Getting target node and checking labels")
 					targetNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), targetNodeName, metav1.GetOptions{})
@@ -537,7 +537,7 @@ var _ = SIGDescribe("NFD master and worker", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					By("Waiting for worker daemonset pods to be ready")
-					Expect(testpod.WaitForReady(f.ClientSet, f.Namespace.Name, workerDS.Spec.Template.Labels["name"], 5)).NotTo(HaveOccurred())
+					Expect(testpod.WaitForReady(f.ClientSet, f.Namespace.Name, workerDS.Spec.Template.Labels["name"], 2)).NotTo(HaveOccurred())
 
 					By("Verifying node labels from nfd-worker")
 					expectedLabels = map[string]k8sLabels{
@@ -603,8 +603,8 @@ core:
 					workerDS, err = f.ClientSet.AppsV1().DaemonSets(f.Namespace.Name).Create(context.TODO(), workerDS, metav1.CreateOptions{})
 					Expect(err).NotTo(HaveOccurred())
 
-					By("Waiting for daemonset pods to be ready")
-					Expect(testpod.WaitForReady(f.ClientSet, f.Namespace.Name, workerDS.Spec.Template.Labels["name"], 5)).NotTo(HaveOccurred())
+					By("Waiting for worker daemonset pods to be ready")
+					Expect(testpod.WaitForReady(f.ClientSet, f.Namespace.Name, workerDS.Spec.Template.Labels["name"], 2)).NotTo(HaveOccurred())
 
 					expected := map[string]k8sLabels{
 						"*": {


### PR DESCRIPTION
Reduce the wait time of nfd-worker pods to be in ready-state (before proceeding with tests) from five to two seconds. Make tests faster to run. Two seconds should be enough for nfd-workers to do their job and get nodes labeled.