### PR TITLE
helm: fix topology-updater rbac

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/clusterrole.yaml
+++ b/deployment/helm/node-feature-discovery/templates/clusterrole.yaml
@@ -19,12 +19,6 @@ rules:
   - update
   - list
 - apiGroups:
-    - ""
-  resources:
-    - nodes/proxy
-  verbs:
-    - get
-- apiGroups:
   - nfd.k8s-sigs.io
   resources:
   - nodefeatures
@@ -51,6 +45,12 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+    - ""
+  resources:
+    - nodes/proxy
+  verbs:
+    - get
 - apiGroups:
   - ""
   resources:

--- a/deployment/helm/node-feature-discovery/templates/clusterrole.yaml
+++ b/deployment/helm/node-feature-discovery/templates/clusterrole.yaml
@@ -30,7 +30,7 @@ rules:
 {{- end }}
 
 ---
-{{- if .Values.topologyUpdater.rbac.create }}
+{{- if and .Values.topologyUpdater.enable .Values.topologyUpdater.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -393,7 +393,7 @@ topologyUpdater:
     annotations: {}
     name:
   rbac:
-    create: false
+    create: true
 
   kubeletConfigPath:
   kubeletPodResourcesSockPath:


### PR DESCRIPTION
- fix topology-updater rbac clusterrole 
  Access to nodes/proxy resource was accidentally given to nfd-master
  (which really doesn't need it), not topology-updater.
- create topology-updater RBAC rules by default 
  Create RBAC rules if topology-updater is enabled. Previously installing
  with topologyUpdater.enable=true (without
  topologyUpdater.rbac.create=true) resulted in a crashloogbackoff as RBAC
  was missing.