### PR TITLE
deployment: fixes for mounting kubelet config

### DIFF
--- a/deployment/components/topology-updater/topologyupdater-mounts.yaml
+++ b/deployment/components/topology-updater/topologyupdater-mounts.yaml
@@ -4,9 +4,6 @@
   - name: host-sys
     hostPath:
       path: "/sys"
-  - name: kubelet-podresources-conf
-    hostPath:
-      path: /var/lib/kubelet/config.yaml
   - name: kubelet-podresources-sock
     hostPath:
       path: /var/lib/kubelet/pod-resources/kubelet.sock
@@ -17,8 +14,6 @@
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts
   value:
-  - name: kubelet-podresources-conf
-    mountPath: /host-var/lib/kubelet/config.yaml
   - name: kubelet-podresources-sock
     mountPath: /host-var/lib/kubelet/pod-resources/kubelet.sock
   - name: host-sys

--- a/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
+++ b/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
@@ -58,9 +58,14 @@ spec:
           {{- if .Values.topologyUpdater.podSetFingerprint }}
           - "-pods-fingerprint"
           {{- end }}
+          {{- if .Values.topologyUpdater.kubeletConfigPath | empty | not }}
+          - "-kubelet-config-uri=file:///host-var/kubelet-config"
+          {{- end }}
         volumeMounts:
+        {{- if .Values.topologyUpdater.kubeletConfigPath | empty | not }}
         - name: kubelet-config
-          mountPath: /host-var/lib/kubelet/config.yaml
+          mountPath: /host-var/kubelet-config
+        {{- end }}
         - name: kubelet-podresources-sock
           mountPath: /host-var/lib/kubelet/pod-resources/kubelet.sock
         - name: host-sys
@@ -82,13 +87,11 @@ spec:
       - name: host-sys
         hostPath:
           path: "/sys"
+      {{- if .Values.topologyUpdater.kubeletConfigPath | empty | not }}
       - name: kubelet-config
         hostPath:
-          {{- if .Values.topologyUpdater.kubeletConfigPath | empty | not }}
           path: {{ .Values.topologyUpdater.kubeletConfigPath }}
-          {{- else }}
-          path: /var/lib/kubelet/config.yaml
-          {{- end }}
+      {{- end }}
       - name: kubelet-podresources-sock
         hostPath:
           {{- if .Values.topologyUpdater.kubeletPodResourcesSockPath | empty | not }}


### PR DESCRIPTION
- kustomize: drop mount for kubelet config in topology-updater
  We use the configz endpoint nowadays.
- helm: fix handling of topologyUpdater.kubeletConfigPath
  By default we use the configz API endpoint so no mounts are needed.