### PR TITLE
feat: add master config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,13 @@ templates:
 	@# Need to prepend each line in the sample config with spaces in order to
 	@# fit correctly in the configmap spec.
 	@sed s'/^/    /' deployment/components/worker-config/nfd-worker.conf.example > nfd-worker.conf.tmp
+	@sed s'/^/    /' deployment/components/master-config/nfd-master.conf.example > nfd-master.conf.tmp
 	@sed s'/^/    /' deployment/components/topology-updater-config/nfd-topology-updater.conf.example > nfd-topology-updater.conf.tmp
 	@# The sed magic below replaces the block of text between the lines with start and end markers
+	@start=NFD-MASTER-CONF-START-DO-NOT-REMOVE; \
+	end=NFD-MASTER-CONF-END-DO-NOT-REMOVE; \
+	sed -e "/$$start/,/$$end/{ /$$start/{ p; r nfd-master.conf.tmp" \
+	    -e "}; /$$end/p; d }" -i deployment/helm/node-feature-discovery/values.yaml
 	@start=NFD-WORKER-CONF-START-DO-NOT-REMOVE; \
 	end=NFD-WORKER-CONF-END-DO-NOT-REMOVE; \
 	sed -e "/$$start/,/$$end/{ /$$start/{ p; r nfd-worker.conf.tmp" \
@@ -130,6 +135,7 @@ templates:
 	end=NFD-TOPOLOGY-UPDATER-CONF-END-DO-NOT-REMOVE; \
 	sed -e "/$$start/,/$$end/{ /$$start/{ p; r nfd-topology-updater.conf.tmp" \
 		-e "}; /$$end/p; d }" -i deployment/helm/node-feature-discovery/values.yaml
+	@rm nfd-master.conf.tmp
 	@rm nfd-worker.conf.tmp
 	@rm nfd-topology-updater.conf.tmp
 

--- a/deployment/base/master/master-deployment.yaml
+++ b/deployment/base/master/master-deployment.yaml
@@ -34,6 +34,3 @@ spec:
             failureThreshold: 10
           command:
             - "nfd-master"
-          args: []
-          volumeMounts: []
-      volumes: []

--- a/deployment/components/common/kustomization.yaml
+++ b/deployment/components/common/kustomization.yaml
@@ -35,3 +35,7 @@ patches:
   target:
     labelSelector: app=nfd
     name: nfd
+- path: master-mounts.yaml
+  target:
+    labelSelector: app=nfd
+    name: nfd-master

--- a/deployment/components/common/master-mounts.yaml
+++ b/deployment/components/common/master-mounts.yaml
@@ -1,0 +1,13 @@
+- op: add
+  path: /spec/template/spec/volumes
+  value:
+  - name: nfd-master-conf
+    configMap:
+      name: nfd-master-conf
+
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts
+  value:
+  - name: nfd-master-conf
+    mountPath: "/etc/kubernetes/node-feature-discovery"
+    readOnly: true

--- a/deployment/components/master-config/kustomization.yaml
+++ b/deployment/components/master-config/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+- files:
+  - nfd-master.conf=nfd-master.conf.example
+  name: nfd-master-conf

--- a/deployment/components/master-config/nfd-master.conf.example
+++ b/deployment/components/master-config/nfd-master.conf.example
@@ -1,0 +1,6 @@
+# noPublish: false
+# extraLabelNs: ["added.ns.io","added.kubernets.io"]
+# denyLabelNs: ["denied.ns.io","denied.kubernetes.io"]
+# resourceLabels: ["vendor-1.com/feature-1","vendor-2.io/feature-2"]
+# enableTaints: false
+# labelWhiteList: "foo"

--- a/deployment/helm/node-feature-discovery/templates/master.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master.yaml
@@ -109,10 +109,20 @@ spec:
             - name: nfd-master-cert
               mountPath: "/etc/kubernetes/node-feature-discovery/certs"
               readOnly: true
+            - name: nfd-master-conf
+              mountPath: "/etc/kubernetes/node-feature-discovery"
+              readOnly: true
       volumes:
         - name: nfd-master-cert
           secret:
             secretName: nfd-master-cert
+        - name: nfd-master-conf
+          configMap:
+            name: {{ include "node-feature-discovery.fullname" . }}-master-conf
+            items:
+              - key: nfd-master.conf
+                path: nfd-master.conf
+
     ## /TLS ##
     {{- end }}
     {{- with .Values.master.nodeSelector }}

--- a/deployment/helm/node-feature-discovery/templates/nfd-master-conf.yaml
+++ b/deployment/helm/node-feature-discovery/templates/nfd-master-conf.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "node-feature-discovery.fullname" . }}-master-conf
+  namespace: {{ include "node-feature-discovery.namespace" . }}
+  labels:
+  {{- include "node-feature-discovery.labels" . | nindent 4 }}
+data:
+  nfd-master.conf: |-
+    {{- .Values.master.config | toYaml | nindent 4 }}

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -13,6 +13,14 @@ namespaceOverride: ""
 enableNodeFeatureApi: false
 
 master:
+  config: ### <NFD-MASTER-CONF-START-DO-NOT-REMOVE>
+    # noPublish: false
+    # extraLabelNs: ["added.ns.io","added.kubernets.io"]
+    # denyLabelNs: ["denied.ns.io","denied.kubernetes.io"]
+    # resourceLabels: ["vendor-1.com/feature-1","vendor-2.io/feature-2"]
+    # enableTaints: false
+    # labelWhiteList: "foo"
+  ### <NFD-MASTER-CONF-END-DO-NOT-REMOVE>
   # The TCP port that nfd-master listens for incoming requests. Default: 8080
   port: 8080
   instance:

--- a/deployment/overlays/default-combined/kustomization.yaml
+++ b/deployment/overlays/default-combined/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
 components:
 - ../../components/worker-config
 - ../../components/common
+- ../../components/master-config

--- a/deployment/overlays/default-job/kustomization.yaml
+++ b/deployment/overlays/default-job/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
 components:
 - ../../components/worker-config
 - ../../components/common
+- ../../components/master-config

--- a/deployment/overlays/default/kustomization.yaml
+++ b/deployment/overlays/default/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
 components:
 - ../../components/worker-config
 - ../../components/common
+- ../../components/master-config

--- a/deployment/overlays/master-worker-topologyupdater/kustomization.yaml
+++ b/deployment/overlays/master-worker-topologyupdater/kustomization.yaml
@@ -22,3 +22,4 @@ components:
 - ../../components/common
 - ../../components/topology-updater
 - ../../components/topology-updater-config
+- ../../components/master-config

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -129,6 +129,7 @@ We have introduced the following Chart parameters.
 | `master.annotations`        | dict    | {}                                      | NFD master pod [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)                                |
 | `master.affinity`           | dict    |                                         | NFD master pod required [node affinity](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/) |
 | `master.deploymentAnnotations` | dict | {}                                      | NFD master deployment [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) |
+| `master.config`             | dict    |                                         | NFD master [configuration](../reference/master-configuration-reference) |
 
 ### Worker pod parameters
 

--- a/docs/reference/master-commandline-reference.md
+++ b/docs/reference/master-commandline-reference.md
@@ -268,6 +268,34 @@ Example:
 nfd-master -resource-labels=vendor-1.com/feature-1,vendor-2.io/feature-2
 ```
 
+### -config
+
+The `-config` flag specifies the path of the nfd-master configuration file to
+use.
+
+Default: /etc/kubernetes/node-feature-discovery/nfd-master.conf
+
+Example:
+
+```bash
+nfd-master -config=/opt/nfd/master.conf
+```
+
+### -options
+
+The `-options` flag may be used to specify and override configuration file
+options directly from the command line. The required format is the same as in
+the config file i.e. JSON or YAML. Configuration options specified via this
+flag will override those from the configuration file:
+
+Default: *empty*
+
+Example:
+
+```bash
+nfd-master -options='{"noPublish": true}'
+```
+
 ### Logging
 
 The following logging-related flags are inherited from the

--- a/docs/reference/master-configuration-reference.md
+++ b/docs/reference/master-configuration-reference.md
@@ -1,0 +1,111 @@
+---
+title: "Master config reference"
+layout: default
+sort: 3
+---
+
+# Configuration file reference of nfd-master
+{: .no_toc}
+
+## Table of contents
+{: .no_toc .text-delta}
+
+1. TOC
+{:toc}
+
+---
+
+See the
+[sample configuration file](https://github.com/kubernetes-sigs/node-feature-discovery/blob/{{site.release}}/deployment/components/master-config/nfd-master.conf.example)
+for a full example configuration.
+
+## noPublish
+
+`noPublish` option disables updates to the Node objects in the Kubernetes
+API server, making a "dry-run" flag for nfd-master. No Labels, Annotations, Taints
+or ExtendedResources of nodes are updated.
+
+Default: `false`
+
+Example:
+
+```yaml
+noPublish: true
+```
+
+## extraLabelNs
+`extraLabelNs` specifies a list of allowed feature
+label namespaces. This option can be used to allow
+other vendor or application specific namespaces for custom labels from the
+local and custom feature sources, even though these labels were denied using
+the `denyLabelNs` parameter.
+
+The same namespace control and this option applies to Extended Resources (created
+with `resourceLabels`), too.
+
+Default: *empty*
+
+Example:
+
+```yaml
+extraLabelNs: ["added.ns.io","added.kubernets.io"]
+```
+
+## denyLabelNs
+`denyLabelNs` specifies a list of excluded
+label namespaces. By default, nfd-master allows creating labels in all
+namespaces, excluding `kubernetes.io` namespace and its sub-namespaces
+(i.e. `*.kubernetes.io`). However, you should note that
+`kubernetes.io` and its sub-namespaces are always denied.
+This option can be used to exclude some vendors or application specific
+namespaces.
+Note that the namespaces `feature.node.kubernetes.io` and `profile.node.kubernetes.io`
+and their sub-namespaces are always allowed and cannot be denied.
+
+Default: *empty*
+
+Example:
+
+```yaml
+denyLabelNs: ["denied.ns.io","denied.kubernetes.io"]
+```
+
+## resourceLabels
+The `resourceLabels` option specifies a list of features to be
+advertised as extended resources instead of labels. Features that have integer
+values can be published as Extended Resources by listing them in this option.
+
+Default: *empty*
+
+Example:
+
+```yaml
+resourceLabels: ["vendor-1.com/feature-1","vendor-2.io/feature-2"]
+```
+
+## enableTaints
+`enableTaints` enables/disables node tainting feature of NFD.
+
+Default: *false*
+
+Example:
+
+```yaml
+enableTaints: true
+```
+
+## labelWhiteList
+`labelWhiteList` specifies a regular expression for filtering feature
+labels based on their name. Each label must match against the given reqular
+expression in order to be published.
+
+Note: The regular expression is only matches against the "basename" part of the
+label, i.e. to the part of the name after '/'. The label namespace is omitted.
+
+Default: *empty*
+
+Example:
+
+```yaml
+labelWhiteList: "foo"
+```

--- a/docs/reference/topology-gc-commandline-reference.md
+++ b/docs/reference/topology-gc-commandline-reference.md
@@ -1,7 +1,7 @@
 ---
 title: "Topology Garbage Collector Cmdline Reference"
 layout: default
-sort: 6
+sort: 7
 ---
 
 # NFD-Topology-Garbage-Collector Commandline Flags

--- a/docs/reference/topology-updater-commandline-reference.md
+++ b/docs/reference/topology-updater-commandline-reference.md
@@ -1,7 +1,7 @@
 ---
 title: "Topology Updater Cmdline Reference"
 layout: default
-sort: 4
+sort: 5
 ---
 
 # NFD-Topology-Updater Commandline Flags

--- a/docs/reference/topology-updater-configuration-reference.md
+++ b/docs/reference/topology-updater-configuration-reference.md
@@ -1,7 +1,7 @@
 ---
 title: "Topology-Updater config reference"
 layout: default
-sort: 5
+sort: 6
 ---
 
 # Configuration file reference of nfd-topology-updater

--- a/docs/reference/worker-configuration-reference.md
+++ b/docs/reference/worker-configuration-reference.md
@@ -1,7 +1,7 @@
 ---
 title: "Worker config reference"
 layout: default
-sort: 3
+sort: 4
 ---
 
 # Configuration file reference of nfd-worker

--- a/docs/usage/nfd-master.md
+++ b/docs/usage/nfd-master.md
@@ -52,6 +52,39 @@ enabled.
 > present when gRPC interface is disabled
 > and [NodeFeature](custom-resources.md#nodefeature-custom-resource) API is used.
 
+## Master configuration
+
+NFD-Master supports dynamic configuration through a configuration file. The
+default location is `/etc/kubernetes/node-feature-discovery/nfd-master.conf`,
+but, this can be changed by specifying the`-config` command line flag.
+Configuration file is re-read whenever it is modified which makes run-time
+re-configuration of nfd-master straightforward.
+
+Master configuration file is read inside the container, and thus, Volumes and
+VolumeMounts are needed to make your configuration available for NFD. The
+preferred method is to use a ConfigMap which provides easy deployment and
+re-configurability.
+
+The provided nfd-master deployment templates create an empty configmap and
+mount it inside the nfd-master containers. In kustomize deployments,
+configuration can be edited with:
+
+```bash
+kubectl -n ${NFD_NS} edit configmap nfd-master-conf
+```
+
+In Helm deployments,
+[Master pod parameter](../deployment/helm.md#master-pod-parameters)
+`master.config` can be used to edit the respective configuration.
+
+See
+[nfd-master configuration file reference](../reference/master-configuration-reference.md)
+for more details.
+The (empty-by-default)
+[example config](https://github.com/kubernetes-sigs/node-feature-discovery/blob/{{site.release}}/deployment/components/master-config/nfd-master.conf.example)
+contains all available configuration options and can be used as a reference
+for creating a configuration.
+
 ## Deployment notes
 
 NFD-Master runs as a deployment, by default

--- a/pkg/nfd-master/nfd-master_test.go
+++ b/pkg/nfd-master/nfd-master_test.go
@@ -35,5 +35,11 @@ func TestNewNfdMaster(t *testing.T) {
 				So(err3, ShouldNotBeNil)
 			})
 		})
+		Convey("When -config is supplied", func() {
+			_, err := m.NewNfdMaster(&m.Args{CertFile: "crt", KeyFile: "key", CaFile: "ca", ConfigFile: "master-config.yaml"})
+			Convey("An error should not be returned", func() {
+				So(err, ShouldBeNil)
+			})
+		})
 	})
 }

--- a/pkg/nfd-worker/nfd-worker_test.go
+++ b/pkg/nfd-worker/nfd-worker_test.go
@@ -38,9 +38,12 @@ type testContext struct {
 
 func setupTest(args *master.Args) testContext {
 	// Fixed port and no-publish, for convenience
-	args.NoPublish = true
+	publish := true
+	args.Overrides = master.ConfigOverrideArgs{
+		NoPublish:      &publish,
+		LabelWhiteList: &utils.RegexpVal{Regexp: *regexp.MustCompile("")},
+	}
 	args.Port = 8192
-	args.LabelWhiteList.Regexp = *regexp.MustCompile("")
 	m, err := master.NewNfdMaster(args)
 	if err != nil {
 		fmt.Printf("Test setup failed: %v\n", err)

--- a/test/e2e/utils/configmap.go
+++ b/test/e2e/utils/configmap.go
@@ -17,8 +17,12 @@ limitations under the License.
 package utils
 
 import (
+	"context"
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
 )
 
 // CreateConfigMap is a helper for creating a simple ConfigMap object with one key.
@@ -29,4 +33,18 @@ func NewConfigMap(name, key, data string) *corev1.ConfigMap {
 		},
 		Data: map[string]string{key: data},
 	}
+}
+
+// UpdateConfigMap is a helper for updating a ConfigMap object.
+func UpdateConfigMap(c clientset.Interface, name, namespace, key, data string) error {
+	cm, err := c.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("configmap %s is not found", name)
+	}
+	cm.Data[key] = data
+	_, err = c.CoreV1().ConfigMaps(namespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("error while updating configmap with name %s", name)
+	}
+	return nil
 }


### PR DESCRIPTION
Resolves #485.
Tasks done:
- [x] Support config file for the master, with `fsnotify`, `config parsing`, and `overrides from command line flags`
- [x] Unit Tests
- [x] Deployment (Kustomize, Helm, Update `make templates`) with the default configuration
- [x] Documentation (command line reference, config reference, nfd-master usage page)
- [x] E2E Tests