### PR TITLE
gitignore: ignore codecov coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 demo/helper-scripts/*.pdf
 demo/helper-scripts/*.log
 /kustomization.yaml
+coverage.out


### PR DESCRIPTION
We don't necessarily need to keep the codecov coverage report on the git. As such, adding it to the gitignore to avoid it from accidental commiting.