### PR TITLE
e2e: re-write pre-submit test to use minikube as an ephemeral cluster

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,24 @@
+name: End to end verification
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    paths-ignore:
+      - 'docs/**'
+      - 'demo/**'
+      - 'examples/**'
+      - 'README.md'
+      - 'codecov.yaml'
+      - 'OWNERS'
+      - 'SECURITY_CONTACTS'
+      - 'Tiltfile'
+      - 'code-of-conduct.md'
+      - 'CONTRIBUTING.md'
+      - 'netlify.yml'
+jobs:
+  e2e:
+    runs-on: [self-hosted, Linux, X64, nfd01]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Execute E2E script
+        run: ./scripts/test-infra/test-e2e-presubmit.sh
+        shell: bash

--- a/scripts/test-infra/test-e2e-presubmit.sh
+++ b/scripts/test-infra/test-e2e-presubmit.sh
@@ -1,67 +1,25 @@
 #!/bin/bash -e
+
 set -o pipefail
 
-# Configure environment
-KIND_IMAGE="kindest/node:v1.25.3"
-export IMAGE_REGISTRY="localhost:5001"
 export CLUSTER_NAME=$(git describe --tags --dirty --always)
 export KUBECONFIG="/tmp/kubeconfig_$CLUSTER_NAME"
 
-# create registry container unless it already exists
-reg_name='kind-registry'
-reg_port='5001'
-if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
-  docker run \
-    -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
-    registry:2
-fi
+minikube start --bootstrapper=kubeadm \
+  --vm-driver=docker \
+  --memory 2048 \
+  --cpus 2 \
+  --profile $CLUSTER_NAME
 
-# create a cluster with the local registry enabled in containerd
-cat <<EOF | kind create cluster --kubeconfig $KUBECONFIG --config=-
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-name: $CLUSTER_NAME
-nodes:
-- role: control-plane
-  image: $KIND_IMAGE
-- role: worker
-  image: $KIND_IMAGE
-- role: worker
-  image: $KIND_IMAGE
-containerdConfigPatches:
-- |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
-    endpoint = ["http://${reg_name}:5000"]
-EOF
+eval $(minikube --profile $CLUSTER_NAME docker-env)
 
-# connect the registry to the cluster network if not already connected
-if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' "${reg_name}")" = 'null' ]; then
-  docker network connect "kind" "${reg_name}"
-fi
-
-cat <<EOF | kubectl apply -f -
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: local-registry-hosting
-  namespace: kube-public
-data:
-  localRegistryHosting.v1: |
-    host: "localhost:${reg_port}"
-    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
-EOF
-
-# build the local image
+# Build the local container image
 make image
 
-# push the image to the local registry
-make push
-
-# run the tests
+# Use IfNotPresent image pull policy to use locally build image
+export E2E_PULL_IF_NOT_PRESENT=true
 make e2e-test || rc=$?
 
-# clean up the environment
-kind delete cluster --kubeconfig $KUBECONFIG --name $CLUSTER_NAME
-echo "Deleting ${reg_name} container ..."
-docker rm -f "${reg_name}"
+minikube delete --profile $CLUSTER_NAME
+
 exit $rc


### PR DESCRIPTION
Using minikube with docker being the `vm-driver` simplifies our pre-submit
e2e tests with image registry handling. One problem with using kind and
local registry container is that we need to have mounted the same port
(5000) to all the kind clusters that might be created at the same time. And
that's technically impossible, because we can't mount the same port to all
the clusters. Minikube on the other hand, allows pushing directly to the
in-cluster Docker daemon. It comes with its registry and we don't have to
take care of it ourselves. Every minikube cluster will have it is own registry
that will be created & destroyed as the cluster itself. [Ref](https://minikube.sigs.k8s.io/docs/handbook/pushing/#1-pushing-directly-to-the-in-cluster-docker-daemon-docker-env)

Also add a self hosted runner based GitHub Action to run E2E tests on. 