### PR TITLE
chore: add debug dump of nfd worker configuration

### DIFF
--- a/pkg/nfd-worker/nfd-worker.go
+++ b/pkg/nfd-worker/nfd-worker.go
@@ -548,7 +548,7 @@ func (w *nfdWorker) configure(filepath string, overrides string) error {
 	}
 
 	klog.Infof("worker (re-)configuration successfully completed")
-
+	utils.KlogDump(1, "effective configuration:", "  ", w.config)
 	return nil
 }
 


### PR DESCRIPTION
As discussed in #1084, we need to add the dump of the nfd worker configuration, which can be really useful when debugging.