### PR TITLE
cpu: expose AMD SEV support

### DIFF
--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -607,6 +607,9 @@ The following features are available for matching:
 |                  |              | **`sgx.enabled`** | bool | `true` if Intel SGX (Software Guard Extensions) has been enabled, otherwise does not exist
 |                  |              | **`se.enabled`** | bool  | `true` if IBM Secure Execution for Linux is available and has been enabled, otherwise does not exist
 |                  |              | **`tdx.enabled`** | bool | `true` if Intel TDX (Trusted Domain Extensions) is available on the host and has been enabled, otherwise does not exist
+|                  |              | **`sev.enabled`** | bool | `true` if AMD SEV (Secure Encrypted Virtualization) is available on the host and has been enabled, otherwise does not exist
+|                  |              | **`sev.es.enabled`** | bool | `true` if AMD SEV-ES (Encrypted State supported) is available on the host and has been enabled, otherwise does not exist
+|                  |              | **`sev.snp.enabled`** | bool | `true` if AMD SEV-SNP (Secure Nested Paging supported) is available on the host and has been enabled, otherwise does not exist
 | **`cpu.sgx`**    | attribute    |          |            | **DEPRECATED**: replaced by **`cpu.security`** feature
 |                  |              | **`enabled`** | bool  | **DEPRECATED**: use **`sgx.enabled`** from **`cpu.security`** instead
 | **`cpu.sst`**    | attribute    |          |            | Intel SST (Speed Select Technology) capabilities

--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -58,6 +58,9 @@ option of nfd-worker.
 | **`cpu-security.sgx.enabled`**    | true   | Set to 'true' if Intel SGX is enabled in BIOS (based a non-zero sum value of SGX EPC section sizes).
 | **`cpu-security.se.enabled`**     | true   | Set to 'true' if IBM Secure Execution for Linux (IBM Z & LinuxONE) is available and enabled (requires `/sys/firmware/uv/prot_virt_host` facility)
 | **`cpu-security.tdx.enabled`**    | true   | Set to 'true' if Intel TDX is available on the host and has been enabled (requires `/sys/module/kvm_intel/parameters/tdx`).
+| **`cpu-security.sev.enabled`**    | true   | Set to 'true' if ADM SEV is available on the host and has been enabled (requires `/sys/module/kvm_intel/parameters/sev`).
+| **`cpu-security.sev.es.enabled`** | true   | Set to 'true' if ADM SEV-ES is available on the host and has been enabled (requires `/sys/module/kvm_intel/parameters/sev_es`).
+| **`cpu-security.sev.snp.enabled`**| true   | Set to 'true' if ADM SEV-SNP is available on the host and has been enabled (requires `/sys/module/kvm_intel/parameters/sev_snp`).
 | **`cpu-sgx.enabled`**             | true   | **DEPRECATED**: use **`cpu-security.sgx.enabled`** instead.
 | **`cpu-se.enabled`**              | true   | **DEPRECATED**: use **`cpu-security.se.enabled`** instead.
 | **`cpu-model.vendor_id`**         | string | Comparable CPU vendor ID.

--- a/source/cpu/cpu.go
+++ b/source/cpu/cpu.go
@@ -229,7 +229,7 @@ func (s *cpuSource) Discover() error {
 	// Detect RDT features
 	s.features.Flags[RdtFeature] = nfdv1alpha1.NewFlagFeatures(discoverRDT()...)
 
-	// Detect SGX features
+	// Detect available guest protection(SGX,TDX,SEV) features
 	s.features.Attributes[SecurityFeature] = nfdv1alpha1.NewAttributeFeatures(discoverSecurity())
 
 	// Detect SGX features

--- a/source/cpu/security_amd64.go
+++ b/source/cpu/security_amd64.go
@@ -38,6 +38,18 @@ func discoverSecurity() map[string]string {
 		elems["tdx.enabled"] = "true"
 	}
 
+	if sevParameterEnabled("sev") {
+		elems["sev.enabled"] = "true"
+	}
+
+	if sevParameterEnabled("sev_es") {
+		elems["sev.es.enabled"] = "true"
+	}
+
+	if sevParameterEnabled("sev_snp") {
+		elems["sev.snp.enabled"] = "true"
+	}
+
 	return elems
 }
 
@@ -68,6 +80,18 @@ func tdxEnabled() bool {
 	protVirtHost := hostpath.SysfsDir.Path("module/kvm_intel/parameters/tdx")
 	if content, err := os.ReadFile(protVirtHost); err == nil {
 		if string(content) == "Y\n" {
+			return true
+		}
+	}
+	return false
+}
+
+func sevParameterEnabled(parameter string) bool {
+	// SEV-SNP is supported and enabled when the kvm module `sev_snp` parameter is set to `Y`
+	// SEV-SNP support infers SEV (-ES) support
+	sevKvmParameterPath := hostpath.SysfsDir.Path("module/kvm_amd/parameters/", parameter)
+	if _, err := os.Stat(sevKvmParameterPath); err == nil {
+		if c, err := os.ReadFile(sevKvmParameterPath); err == nil && len(c) > 0 && (c[0] == '1' || c[0] == 'Y') {
 			return true
 		}
 	}


### PR DESCRIPTION
Enable the feature discovery of AMD SEV, SEV_ES and SEV_SNP as part of the `cpu-security` attribute  