### PR TITLE
Advertise RDT L3 num_closid

### DIFF
--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -601,8 +601,9 @@ The following features are available for matching:
 |                  |              | **`status`** | string | Status of the driver, possible values are 'active' and 'passive'
 |                  |              | **`turbo`**  | bool   | 'true' if turbo frequencies are enabled, otherwise 'false'
 |                  |              | **`scaling`** | string | Active scaling_governor, possible values are 'powersave' or 'performance'.
-| **`cpu.rdt`**    | flag         |          |            | Intel RDT capabilities supported by the system
+| **`cpu.rdt`**    | attribute    |          |            | Intel RDT capabilities supported by the system
 |                  |              | **`<rdt-flag>`** |    | RDT capability is supported, see [RDT flags](#intel-rdt-flags) for details
+|                  |              | **`RDTL3CA_NUM_CLOSID`** | int  | The number or available CLOSID (Class of service ID) for Intel L3 Cache Allocation Technology
 | **`cpu.security`** | attribute  |          |            | Features related to security and trusted execution environments
 |                  |              | **`sgx.enabled`** | bool | `true` if Intel SGX (Software Guard Extensions) has been enabled, otherwise does not exist
 |                  |              | **`se.enabled`** | bool  | `true` if IBM Secure Execution for Linux is available and has been enabled, otherwise does not exist

--- a/source/cpu/cpu.go
+++ b/source/cpu/cpu.go
@@ -164,8 +164,12 @@ func (s *cpuSource) GetLabels() (source.FeatureLabels, error) {
 	}
 
 	// RDT
-	for k := range features.Flags[RdtFeature].Elements {
-		labels["rdt."+k] = true
+	for k, v := range features.Attributes[RdtFeature].Elements {
+		if k == "RDTL3CA_NUM_CLOSID" {
+			continue
+		}
+
+		labels["rdt."+k] = v
 	}
 
 	// Security
@@ -227,7 +231,7 @@ func (s *cpuSource) Discover() error {
 	s.features.Attributes[PstateFeature] = nfdv1alpha1.NewAttributeFeatures(pstate)
 
 	// Detect RDT features
-	s.features.Flags[RdtFeature] = nfdv1alpha1.NewFlagFeatures(discoverRDT()...)
+	s.features.Attributes[RdtFeature] = nfdv1alpha1.NewAttributeFeatures(discoverRDT())
 
 	// Detect available guest protection(SGX,TDX,SEV) features
 	s.features.Attributes[SecurityFeature] = nfdv1alpha1.NewAttributeFeatures(discoverSecurity())

--- a/source/cpu/rdt_stub.go
+++ b/source/cpu/rdt_stub.go
@@ -19,6 +19,6 @@ limitations under the License.
 
 package cpu
 
-func discoverRDT() []string {
-	return []string{}
+func discoverRDT() map[string]string {
+	return map[string]string{}
 }


### PR DESCRIPTION
Enable the feature discovery of `RDTL3CA_NUM_CLOSID` as part of the cpu-rdt source.

This feature is intended to be used as `extended` resource when this PR is merged https://github.com/kubernetes-sigs/node-feature-discovery/pull/1099