### PR TITLE
nfd-worker: add annotation with worker-conf sha256 hash

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/worker.yaml
+++ b/deployment/helm/node-feature-discovery/templates/worker.yaml
@@ -7,7 +7,10 @@ metadata:
     {{- include "node-feature-discovery.labels" . | nindent 4 }}
     role: worker
   annotations:
+    checksum/worker-conf: {{ include (print $.Template.BasePath "/nfd-worker-conf.yaml") . | sha256sum }}
+  {{- if .Values.worker.daemonsetAnnotations }}
     {{- toYaml .Values.worker.daemonsetAnnotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
This PR allows for automatic rolling of worker pods whenever there is an update to the `nfd-worker-conf` configmap.

By default helm will not refresh the DaemonSet/Deployment when there is no change observed in the manifest. This gets around that. 


For more details: see [here](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments)