### PR TITLE
nfd-master: disallow unprefixed and kubernetes taints

### DIFF
--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -159,6 +159,7 @@ re-labeling delay up to the sleep-interval of nfd-worker (1 minute by default).
 
 See [Label rule format](#label-rule-format) for detailed description of
 available fields and how to write labeling rules.
+
 ### NodeFeatureRule tainting feature
 
 This feature is experimental.
@@ -208,6 +209,15 @@ spec:
 
 In this example, if the `my sample taint rule` rule is matched, `feature.node.kubernetes.io/pci-0300_1d0f.present=true:NoExecute`
 and `feature.node.kubernetes.io/cpu-cpuid.ADX:NoExecute` taints are set on the node.
+
+There are some limitations to the namespace part (i.e. prefix/) of the taint
+key:
+
+- `kubernetes.io/` and its sub-namespaces (like `sub.ns.kubernetes.io/`) cannot
+  generally be used
+- the only exception is `feature.node.kubernetes.io/` and its sub-namespaces
+  (like `sub.ns.feature.node.kubernetes.io`)
+- unprefixed keys (like `foo`) keys are disallowed
 
 ## Local feature source
 

--- a/pkg/apis/nfd/v1alpha1/annotations_labels.go
+++ b/pkg/apis/nfd/v1alpha1/annotations_labels.go
@@ -29,6 +29,12 @@ const (
 	// ProfileLabelSubNsSuffix is the suffix for allowed profile label sub-namespaces.
 	ProfileLabelSubNsSuffix = "." + ProfileLabelNs
 
+	// TaintNs is the k8s.io namespace that can be used for NFD-managed taints.
+	TaintNs = "feature.node.kubernetes.io"
+
+	// TaintSubNsSuffix is the suffix for allowed sub-namespaces for NFD-managed taints.
+	TaintSubNsSuffix = "." + TaintNs
+
 	// AnnotationNs namespace for all NFD-related annotations.
 	AnnotationNs = "nfd.node.kubernetes.io"
 

--- a/test/e2e/data/nodefeaturerule-3-updated.yaml
+++ b/test/e2e/data/nodefeaturerule-3-updated.yaml
@@ -8,11 +8,18 @@ spec:
     - name: "e2e-taint-test-1"
       taints:
         - effect: PreferNoSchedule
-          key: "nfd.node.kubernetes.io/fake-special-node"
+          key: "feature.node.kubernetes.io/fake-special-node"
           value: "exists"
         - effect: NoExecute
-          key: "nfd.node.kubernetes.io/foo"
+          key: "feature.node.kubernetes.io/foo"
           value: "true"
+        # The following taints should be filtered out by nfd-master
+        - effect: PreferNoSchedule
+          key: "kubernetes.io/denied-1"
+        - effect: PreferNoSchedule
+          key: "node.kubernetes.io/denied-2"
+        - effect: PreferNoSchedule
+          key: "unprefixed-taint"
       matchFeatures:
         - feature: "fake.attribute"
           matchExpressions:
@@ -23,7 +30,7 @@ spec:
     - name: "e2e-taint-test-2"
       taints:
         - effect: PreferNoSchedule
-          key: "nfd.node.kubernetes.io/fake-cpu"
+          key: "feature.node.kubernetes.io/fake-cpu"
           value: "true"
       matchFeatures:
         - feature: "fake.attribute"

--- a/test/e2e/data/nodefeaturerule-3.yaml
+++ b/test/e2e/data/nodefeaturerule-3.yaml
@@ -8,13 +8,13 @@ spec:
     - name: "e2e-taint-test-1"
       taints:
         - effect: PreferNoSchedule
-          key: "nfd.node.kubernetes.io/fake-special-node"
+          key: "feature.node.kubernetes.io/fake-special-node"
           value: "exists"
         - effect: NoExecute
-          key: "nfd.node.kubernetes.io/fake-dedicated-node"
+          key: "feature.node.kubernetes.io/fake-dedicated-node"
           value: "true"
         - effect: "NoExecute"
-          key: "nfd.node.kubernetes.io/performance-optimized-node"
+          key: "feature.node.kubernetes.io/performance-optimized-node"
           value: "true"
       matchFeatures:
         - feature: "fake.attribute"
@@ -26,7 +26,7 @@ spec:
     - name: "e2e-taint-test-2"
       taints:
         - effect: PreferNoSchedule
-          key: "nfd.node.kubernetes.io/fake-special-cpu"
+          key: "feature.node.kubernetes.io/fake-special-cpu"
           value: "true"
       matchFeatures:
         - feature: "fake.attribute"


### PR DESCRIPTION
Disallow taints having a key with "kubernetes.io/" or "*.kubernetes.io/"
prefix. This is a precaution to protect the user from messing up with
the "official" well-known taints from Kubernetes itself. The only
exception is that the "nfd.node.kubernetes.io/" prefix is allowed.

However, there is one allowed NFD-specific namespace (and its
sub-namespaces) i.e. "feature.node.kubernetes.io" under the
kubernetes.io domain that can be used for NFD-managed taints.

Also disallow unprefixed taint keys. We don't add a default prefix to
unprefixed taints (like we do for labels) from NodeFeatureRules. This is
to prevent unpleasant surprises to users that need to manage matching
tolerations for their workloads.