### PR TITLE
docs: add missing mentions of extended resources and taints

### DIFF
--- a/docs/deployment/uninstallation.md
+++ b/docs/deployment/uninstallation.md
@@ -23,7 +23,8 @@ Follow the uninstallation instructions of the deployment method used
 ## Removing feature labels
 
 NFD-Master has a special `-prune` command line flag for removing all
-nfd-related node labels, annotations and extended resources from the cluster.
+nfd-related node labels, annotations, extended resources and taints from the
+cluster.
 
 ```bash
 kubectl apply -k https://github.com/kubernetes-sigs/node-feature-discovery/deployment/overlays/prune?ref={{ site.release }}

--- a/docs/get-started/introduction.md
+++ b/docs/get-started/introduction.md
@@ -17,7 +17,8 @@ sort: 1
 
 This software enables node feature discovery for Kubernetes. It detects
 hardware features available on each node in a Kubernetes cluster, and
-advertises those features using node labels and optionally node taints.
+advertises those features using node labels and optionally node extended
+resources and node taints.
 
 NFD consists of four software components:
 


### PR DESCRIPTION
A small update to fix some missing mentions of extended resources and taints as assets managed by NFD.