### PR TITLE
nfd-master: increase controller resync period to 1 hour

### DIFF
--- a/pkg/nfd-master/nfd-api-controller.go
+++ b/pkg/nfd-master/nfd-api-controller.go
@@ -50,7 +50,7 @@ func newNfdController(config *restclient.Config, disableNodeFeature bool) (*nfdC
 
 	nfdClient := nfdclientset.NewForConfigOrDie(config)
 
-	informerFactory := nfdinformers.NewSharedInformerFactory(nfdClient, 5*time.Minute)
+	informerFactory := nfdinformers.NewSharedInformerFactory(nfdClient, 1*time.Hour)
 
 	// Add informer for NodeFeature objects
 	if !disableNodeFeature {


### PR DESCRIPTION
Increase the NFD API controller resync period from 5 minutes to 1 hour.
The resync causes nfd-master to replay all NodeFeature and
NodeFeatureRule objects, being effectively a "big hammer reset all"
button. This should only be needed as an "insurance" to fix labels et al
in case they have been manually tampered (outside NFD) and against
certain bugs in nfd itself. NFD is not supposed to manage anything
fast-changing so 1 hour should be enough.

This change only affects behavior when the NodeFeature API has been
enabled (with -enable-nodefeature-api).