### PR TITLE
nfd-master: deprecate the -resource-labels flag

### DIFF
--- a/cmd/nfd-master/main.go
+++ b/cmd/nfd-master/main.go
@@ -61,6 +61,7 @@ func main() {
 		case "label-whitelist":
 			args.Overrides.LabelWhiteList = overrides.LabelWhiteList
 		case "resource-labels":
+			klog.Warningf("-resource-labels is deprecated, extended resources should be managed with NodeFeatureRule objects")
 			args.Overrides.ResourceLabels = overrides.ResourceLabels
 		case "enable-taints":
 			args.Overrides.EnableTaints = overrides.EnableTaints
@@ -143,7 +144,7 @@ func initFlags(flagset *flag.FlagSet) (*master.Args, *master.ConfigOverrideArgs)
 	flagset.Var(overrides.DenyLabelNs, "deny-label-ns",
 		"Comma separated list of denied label namespaces")
 	flagset.Var(overrides.ResourceLabels, "resource-labels",
-		"Comma separated list of labels to be exposed as extended resources.")
+		"Comma separated list of labels to be exposed as extended resources. DEPRECATED: use NodeFeatureRule objects instead")
 
 	return args, overrides
 }

--- a/docs/reference/master-commandline-reference.md
+++ b/docs/reference/master-commandline-reference.md
@@ -256,6 +256,9 @@ nfd-master -deny-label-ns=*.vendor.com,vendor-2.io
 
 ### -resource-labels
 
+**DEPRECATED**: [NodeFeatureRule](../usage/custom-resources.md#nodefeaturerule)
+should be used for managing extended resources in NFD.
+
 The `-resource-labels` flag specifies a comma-separated list of features to be
 advertised as extended resources instead of labels. Features that have integer
 values can be published as Extended Resources by listing them in this flag.

--- a/docs/reference/master-configuration-reference.md
+++ b/docs/reference/master-configuration-reference.md
@@ -71,6 +71,10 @@ denyLabelNs: ["denied.ns.io","denied.kubernetes.io"]
 ```
 
 ## resourceLabels
+
+**DEPRECATED**: [NodeFeatureRule](../usage/custom-resources.md#nodefeaturerule)
+should be used for managing extended resources in NFD.
+
 The `resourceLabels` option specifies a list of features to be
 advertised as extended resources instead of labels. Features that have integer
 values can be published as Extended Resources by listing them in this option.


### PR DESCRIPTION
Mark the -resource-labels flag (and the corresponding resourceLabels config option) as deprecated. We now support managing extended resources via NodeFeatureRule objects. This kludge deserves to go, eventually.

Refs #1125