### PR TITLE
Makefile: set e2e test timeout to 1 hour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,12 +193,14 @@ e2e-test:
 	    -nfd.e2e-config=$(E2E_TEST_CONFIG) \
 	    -nfd.pull-if-not-present=$(E2E_PULL_IF_NOT_PRESENT) \
 	    -ginkgo.focus="\[kubernetes-sigs\]" \
+	    -test.timeout=1h \
 	    $(if $(OPENSHIFT),-nfd.openshift,)
 	$(GO_CMD) test -v ./test/e2e/ -args -nfd.repo=$(IMAGE_REPO) -nfd.tag=$(IMAGE_TAG_NAME)-full \
 	    -kubeconfig=$(KUBECONFIG) \
 	    -nfd.e2e-config=$(E2E_TEST_CONFIG) \
 	    -nfd.pull-if-not-present=$(E2E_PULL_IF_NOT_PRESENT) \
 	    -ginkgo.focus="\[kubernetes-sigs\]" \
+	    -test.timeout=1h \
 	    $(if $(OPENSHIFT),-nfd.openshift,)
 
 push:


### PR DESCRIPTION
Previously we were using the default, which even if equal to 0, still means 10 minute timout in practice (with the way we run the tests with invoking go test directly). With the addition of latest e2e tests we hit the limit and got bitten by it. Set the timeout to 1 hour which should be enough for anyone...