### PR TITLE
source/cpu: don't create cpu-security.tdx.total_keys label

### DIFF
--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -58,7 +58,6 @@ option of nfd-worker.
 | **`cpu-security.sgx.enabled`**    | true   | Set to 'true' if Intel SGX is enabled in BIOS (based a non-zero sum value of SGX EPC section sizes).
 | **`cpu-security.se.enabled`**     | true   | Set to 'true' if IBM Secure Execution for Linux (IBM Z & LinuxONE) is available and enabled (requires `/sys/firmware/uv/prot_virt_host` facility)
 | **`cpu-security.tdx.enabled`**    | true   | Set to 'true' if Intel TDX is available on the host and has been enabled (requires `/sys/module/kvm_intel/parameters/tdx`).
-| **`cpu-security.tdx.total_keys`** | int    | The total amount of keys an Intel TDX enabled host can provide, based on the `/sys/fs/cgroup/misc.capacity` information.
 | **`cpu-security.sev.enabled`**    | true   | Set to 'true' if ADM SEV is available on the host and has been enabled (requires `/sys/module/kvm_intel/parameters/sev`).
 | **`cpu-security.sev.es.enabled`** | true   | Set to 'true' if ADM SEV-ES is available on the host and has been enabled (requires `/sys/module/kvm_intel/parameters/sev_es`).
 | **`cpu-security.sev.snp.enabled`**| true   | Set to 'true' if ADM SEV-SNP is available on the host and has been enabled (requires `/sys/module/kvm_intel/parameters/sev_snp`).

--- a/source/cpu/cpu.go
+++ b/source/cpu/cpu.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strconv"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
 	"github.com/klauspost/cpuid/v2"
@@ -173,8 +174,13 @@ func (s *cpuSource) GetLabels() (source.FeatureLabels, error) {
 	}
 
 	// Security
+	// skipLabel lists features that will not have labels created but are only made available for
+	// NodeFeatureRules (e.g. to be published via extended resources instead)
+	skipLabel := sets.NewString("tdx.total_keys")
 	for k, v := range features.Attributes[SecurityFeature].Elements {
-		labels["security."+k] = v
+		if !skipLabel.Has(k) {
+			labels["security."+k] = v
+		}
 	}
 
 	// SGX


### PR DESCRIPTION
Just have that as a feature for NodeFeatureRules to consume.