### PR TITLE
[release-0.10] docs: mark release v0.10 as unsupported

### DIFF
--- a/docs/_includes/templates/content.liquid
+++ b/docs/_includes/templates/content.liquid
@@ -1,0 +1,26 @@
+<div class="content-wrap">
+    <div class="header d-flex flex-justify-between p-2 hide-lg hide-xl" aria-label="top navigation">
+        <button id="toggle" aria-label="Toggle menu" class="btn-octicon p-2 m-0 text-white" type="button">
+            <i class="fa fa-bars"></i>
+        </button>
+        <div class="title flex-1 d-flex flex-justify-center">
+            <a class="h4 no-underline py-1 px-2 rounded-1" href="{{ site.baseurl }}/">{{ site.title }}</a>
+        </div>
+    </div>
+    <div class="bg-red-2">
+        <div class="content p-3 px-sm-5">
+            This documentation is for Node Feature Discovery version that is no longer supported. Please upgrade and visit the
+            <a class="no-underline" href="{{ '../stable' | relative_url }}">documentation of the latest stable release</a>.
+        </div>
+    </div>
+    <div class="content p-3 p-sm-5">
+        {% include templates/breadcrumbs.liquid %}
+        <hr>
+        <div role="main" itemscope="itemscope" itemtype="https://schema.org/Article">
+            <div class="markdown-body" itemprop="articleBody">
+                {{ content }}
+            </div>
+        </div>
+        {% include templates/footer.liquid %}
+    </div>
+</div>


### PR DESCRIPTION
Copied what #1132 did, but adapted to a newer version of jekyll-rtd-theme. Outcome will be similar (https://kubernetes-sigs.github.io/node-feature-discovery/v0.6)