### PR TITLE
[release-0.12] Dockerfile: bump grpc-health-probe to v0.4.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_IMAGE_MINIMAL
 FROM ${BUILDER_IMAGE} as builder
 
 # Build and install the grpc-health-probe binary
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.6 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.18 && \
 	go install github.com/grpc-ecosystem/grpc-health-probe@${GRPC_HEALTH_PROBE_VERSION} \
         # Rename it as it's referenced as grpc_health_probe in the deployment yamls
         # and in its own project https://github.com/grpc-ecosystem/grpc-health-probe


### PR DESCRIPTION
A new version that was just released.

(cherry picked from commit ecc242d78ac00e4a6d483a00ac03b96767f7bd71)

Backported #1145 from master