### PR TITLE
 cpu: expose the total number of AMD SEV ASID and ES

### DIFF
--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -58,9 +58,11 @@ option of nfd-worker.
 | **`cpu-security.sgx.enabled`**    | true   | Set to 'true' if Intel SGX is enabled in BIOS (based on a non-zero sum value of SGX EPC section sizes).
 | **`cpu-security.se.enabled`**     | true   | Set to 'true' if IBM Secure Execution for Linux (IBM Z & LinuxONE) is available and enabled (requires `/sys/firmware/uv/prot_virt_host` facility)
 | **`cpu-security.tdx.enabled`**    | true   | Set to 'true' if Intel TDX is available on the host and has been enabled (requires `/sys/module/kvm_intel/parameters/tdx`).
-| **`cpu-security.sev.enabled`**    | true   | Set to 'true' if ADM SEV is available on the host and has been enabled (requires `/sys/module/kvm_intel/parameters/sev`).
-| **`cpu-security.sev.es.enabled`** | true   | Set to 'true' if ADM SEV-ES is available on the host and has been enabled (requires `/sys/module/kvm_intel/parameters/sev_es`).
-| **`cpu-security.sev.snp.enabled`**| true   | Set to 'true' if ADM SEV-SNP is available on the host and has been enabled (requires `/sys/module/kvm_intel/parameters/sev_snp`).
+| **`cpu-security.sev.enabled`**    | true   | Set to 'true' if ADM SEV is available on the host and has been enabled (requires `/sys/module/kvm_amd/parameters/sev`).
+| **`cpu-security.sev.es.enabled`** | true   | Set to 'true' if ADM SEV-ES is available on the host and has been enabled (requires `/sys/module/kvm_amd/parameters/sev_es`).
+| **`cpu-security.sev.snp.enabled`**| true   | Set to 'true' if ADM SEV-SNP is available on the host and has been enabled (requires `/sys/module/kvm_amd/parameters/sev_snp`).
+| **`cpu-security.sex.asids`** | int    | The total amount of AMD SEV address-space identifiers (ASIDs), based on the `/sys/fs/cgroup/misc.capacity` information.
+| **`cpu-security.sex.encrypted_state_ids`** | int    | The total amount of AMD SEV-ES and SEV-SNP supported, based on the `/sys/fs/cgroup/misc.capacity` information.
 | **`cpu-sgx.enabled`**             | true   | **DEPRECATED**: use **`cpu-security.sgx.enabled`** instead.
 | **`cpu-se.enabled`**              | true   | **DEPRECATED**: use **`cpu-security.se.enabled`** instead.
 | **`cpu-model.vendor_id`**         | string | Comparable CPU vendor ID.

--- a/source/cpu/cpu.go
+++ b/source/cpu/cpu.go
@@ -176,7 +176,11 @@ func (s *cpuSource) GetLabels() (source.FeatureLabels, error) {
 	// Security
 	// skipLabel lists features that will not have labels created but are only made available for
 	// NodeFeatureRules (e.g. to be published via extended resources instead)
-	skipLabel := sets.NewString("tdx.total_keys", "sgx.epc")
+	skipLabel := sets.NewString(
+		"tdx.total_keys",
+		"sgx.epc",
+		"sev.encrypted_state_ids",
+		"sev.asids")
 	for k, v := range features.Attributes[SecurityFeature].Elements {
 		if !skipLabel.Has(k) {
 			labels["security."+k] = v

--- a/source/cpu/security_amd64.go
+++ b/source/cpu/security_amd64.go
@@ -55,10 +55,20 @@ func discoverSecurity() map[string]string {
 
 	if sevParameterEnabled("sev") {
 		elems["sev.enabled"] = "true"
+
+		sevAddressSpaceIdentifiers := getCgroupMiscCapacity("sev")
+		if sevAddressSpaceIdentifiers > -1 {
+			elems["sev.asids"] = strconv.FormatInt(int64(sevAddressSpaceIdentifiers), 10)
+		}
 	}
 
 	if sevParameterEnabled("sev_es") {
 		elems["sev.es.enabled"] = "true"
+
+		sevEncryptedStateIDs := getCgroupMiscCapacity("sev_es")
+		if sevEncryptedStateIDs > -1 {
+			elems["sev.encrypted_state_ids"] = strconv.FormatInt(int64(sevEncryptedStateIDs), 10)
+		}
 	}
 
 	if sevParameterEnabled("sev_snp") {


### PR DESCRIPTION
This patch add SEV ASIDs and the related (but distinct) SEV Encrypted State (SEV-ES) IDs as two quantities to be exposed via extended resources. In a kernel built with CONFIG_CGROUP_MISC on a suitably equipped AMD CPU, the root control group will have a misc.capacity file that shows the number of available IDs in each category:

```bash
    $ cat misc.capacity
    sev 50
    sev_es 10
```

The added extended resources are:
- sev.asids
- sev.encrypted_state_ids

An example on how to expose them on a suitable system is:

```yaml
apiVersion: nfd.k8s-sigs.io/v1alpha1
kind: NodeFeatureRule
metadata:
  name: sev-capacity
spec:
  rules:
    - name: "SEV system capacity"
      extendedResources:
       sev_asids: "@cpu.security.sev.asids"
       sev_es: "@cpu.security.sev.encrypted_state_ids"
      matchFeatures:
        - feature: cpu.security
          matchExpressions:
            sev.enabled: {op: Exists}
```