### PR TITLE
[release-0.13] Update references to release v0.13.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ IMAGE_BUILD_CMD ?= docker build
 IMAGE_BUILD_EXTRA_OPTS ?=
 IMAGE_PUSH_CMD ?= docker push
 CONTAINER_RUN_CMD ?= docker run
-BUILDER_IMAGE ?= golang:1.20-bullseye
+BUILDER_IMAGE ?= golang:1.20.3-bullseye
 BASE_IMAGE_FULL ?= debian:bullseye-slim
 BASE_IMAGE_MINIMAL ?= gcr.io/distroless/base
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ features and system configuration!
 #### Quick-start – the short-short version
 
 ```bash
-$ kubectl apply -k https://github.com/kubernetes-sigs/node-feature-discovery/deployment/overlays/default?ref=v0.12.2
+$ kubectl apply -k https://github.com/kubernetes-sigs/node-feature-discovery/deployment/overlays/default?ref=v0.13.0
   namespace/node-feature-discovery created
   customresourcedefinition.apiextensions.k8s.io/nodefeaturerules.nfd.k8s-sigs.io created
   serviceaccount/nfd-master created
@@ -39,4 +39,4 @@ $ kubectl get no -o json | jq .items[].metadata.labels
 
 ```
 
-[documentation]: https://kubernetes-sigs.github.io/node-feature-discovery
+[documentation]: https://kubernetes-sigs.github.io/node-feature-discovery/v0.13

--- a/deployment/base/master-worker-combined/master-worker-daemonset.yaml
+++ b/deployment/base/master-worker-combined/master-worker-daemonset.yaml
@@ -18,8 +18,8 @@ spec:
       tolerations: []
       containers:
       - name: nfd-master
-        image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
-        imagePullPolicy: Always
+        image: registry.k8s.io/nfd/node-feature-discovery:v0.13.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
             command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
@@ -34,8 +34,8 @@ spec:
         command:
         - "nfd-master"
       - name: nfd-worker
-        image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
-        imagePullPolicy: Always
+        image: registry.k8s.io/nfd/node-feature-discovery:v0.13.0
+        imagePullPolicy: IfNotPresent
         command:
         - "nfd-worker"
         args: []

--- a/deployment/base/master/master-deployment.yaml
+++ b/deployment/base/master/master-deployment.yaml
@@ -19,8 +19,8 @@ spec:
       tolerations: []
       containers:
         - name: nfd-master
-          image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
-          imagePullPolicy: Always
+          image: registry.k8s.io/nfd/node-feature-discovery:v0.13.0
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             exec:
               command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]

--- a/deployment/base/topology-gc/topology-gc.yaml
+++ b/deployment/base/topology-gc/topology-gc.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccount: nfd-topology-gc
       containers:
         - name: nfd-topology-gc
-          image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
-          imagePullPolicy: Always
+          image: registry.k8s.io/nfd/node-feature-discovery:v0.13.0
+          imagePullPolicy: IfNotPresent
           command:
             - "nfd-topology-gc"

--- a/deployment/base/topologyupdater-daemonset/topologyupdater-daemonset.yaml
+++ b/deployment/base/topologyupdater-daemonset/topologyupdater-daemonset.yaml
@@ -17,8 +17,8 @@ spec:
       serviceAccount: nfd-topology-updater
       containers:
         - name: nfd-topology-updater
-          image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
-          imagePullPolicy: Always
+          image: registry.k8s.io/nfd/node-feature-discovery:v0.13.0
+          imagePullPolicy: IfNotPresent
           command:
             - "nfd-topology-updater"
           args: []

--- a/deployment/base/worker-daemonset/worker-daemonset.yaml
+++ b/deployment/base/worker-daemonset/worker-daemonset.yaml
@@ -17,8 +17,8 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: nfd-worker
-          image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
-          imagePullPolicy: Always
+          image: registry.k8s.io/nfd/node-feature-discovery:v0.13.0
+          imagePullPolicy: IfNotPresent
           command:
             - "nfd-worker"
           args:

--- a/deployment/base/worker-job/worker-job.yaml
+++ b/deployment/base/worker-job/worker-job.yaml
@@ -27,8 +27,8 @@ spec:
                       - nfd-worker
       containers:
         - name: nfd-worker
-          image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
-          imagePullPolicy: Always
+          image: registry.k8s.io/nfd/node-feature-discovery:v0.13.0
+          imagePullPolicy: IfNotPresent
           command:
             - "nfd-worker"
           args:

--- a/deployment/helm/node-feature-discovery/Chart.yaml
+++ b/deployment/helm/node-feature-discovery/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: master
+appVersion: v0.13.0
 description: |
   Detects hardware features available on each node in a Kubernetes cluster, and advertises
   those features using node labels.

--- a/deployment/helm/node-feature-discovery/README.md
+++ b/deployment/helm/node-feature-discovery/README.md
@@ -6,5 +6,5 @@ labels. NFD provides flexible configuration and extension points for a wide
 range of vendor and application specific node labeling needs.
 
 See
-[NFD documentation](https://kubernetes-sigs.github.io/node-feature-discovery/master/deployment/helm.html)
+[NFD documentation](https://kubernetes-sigs.github.io/node-feature-discovery/v0.13/deployment/helm.html)
 for deployment instructions.

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -1,7 +1,7 @@
 image:
-  repository: gcr.io/k8s-staging-nfd/node-feature-discovery
+  repository: registry.k8s.io/nfd/node-feature-discovery
   # This should be set to 'IfNotPresent' for released version
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   # tag, if defined will use the given image tag, else Chart.AppVersion will be used
   # tag
 imagePullSecrets: []

--- a/deployment/overlays/prune/master-job.yaml
+++ b/deployment/overlays/prune/master-job.yaml
@@ -15,8 +15,8 @@ spec:
       tolerations: []
       containers:
         - name: nfd-master
-          image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
-          imagePullPolicy: Always
+          image: registry.k8s.io/nfd/node-feature-discovery:v0.13.0
+          imagePullPolicy: IfNotPresent
           command:
             - "nfd-master"
           args:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -43,7 +43,7 @@ plugins:
 #   - vendor/ruby/
 
 # Document versioning
-version: master
+version: v0.13
 display_version_list: true
 
 # Customize page width (make it wider) for large screens
@@ -57,7 +57,7 @@ scss: |
 # Release is the full released version number. Used to make external links to
 # point to the correct blobs in the Github repo. This is also the version shown
 # in the sidebar (top left corner of the page)
-release: master
+release: v0.13.0
 
 # Container image which to point to in the documentation
-container_image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
+container_image: registry.k8s.io/nfd/node-feature-discovery:v0.13.0


### PR DESCRIPTION
Bump Golang builder image to v1.20.3.

Generated with:

    hack/prepare-release.sh -g 1.20.3 v0.13.0