### PR TITLE
test/e2e: use proper context

### DIFF
--- a/test/e2e/utils/configmap.go
+++ b/test/e2e/utils/configmap.go
@@ -36,13 +36,13 @@ func NewConfigMap(name, key, data string) *corev1.ConfigMap {
 }
 
 // UpdateConfigMap is a helper for updating a ConfigMap object.
-func UpdateConfigMap(c clientset.Interface, name, namespace, key, data string) error {
-	cm, err := c.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+func UpdateConfigMap(ctx context.Context, c clientset.Interface, name, namespace, key, data string) error {
+	cm, err := c.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("configmap %s is not found", name)
 	}
 	cm.Data[key] = data
-	_, err = c.CoreV1().ConfigMaps(namespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
+	_, err = c.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("error while updating configmap with name %s", name)
 	}

--- a/test/e2e/utils/crd.go
+++ b/test/e2e/utils/crd.go
@@ -40,7 +40,7 @@ import (
 var packagePath string
 
 // CreateNfdCRDs creates the NodeFeatureRule CRD in the API server.
-func CreateNfdCRDs(cli extclient.Interface) ([]*apiextensionsv1.CustomResourceDefinition, error) {
+func CreateNfdCRDs(ctx context.Context, cli extclient.Interface) ([]*apiextensionsv1.CustomResourceDefinition, error) {
 	crds, err := crdsFromFile(filepath.Join(packagePath, "..", "..", "..", "deployment", "base", "nfd-crds", "nfd-api-crds.yaml"))
 	if err != nil {
 		return nil, err
@@ -49,13 +49,13 @@ func CreateNfdCRDs(cli extclient.Interface) ([]*apiextensionsv1.CustomResourceDe
 	newCRDs := make([]*apiextensionsv1.CustomResourceDefinition, len(crds))
 	for i, crd := range crds {
 		// Delete existing CRD (if any) with this we also get rid of stale objects
-		err = cli.ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), crd.Name, metav1.DeleteOptions{})
+		err = cli.ApiextensionsV1().CustomResourceDefinitions().Delete(ctx, crd.Name, metav1.DeleteOptions{})
 		if err != nil && !errors.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to delete %q CRD: %w", crd.Name, err)
 		} else if err == nil {
 			// Wait for CRD deletion to complete before trying to re-create it
 			err = wait.Poll(1*time.Second, 1*time.Minute, func() (bool, error) {
-				_, err = cli.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
+				_, err = cli.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crd.Name, metav1.GetOptions{})
 				if err == nil {
 					return false, nil
 				} else if errors.IsNotFound(err) {
@@ -68,7 +68,7 @@ func CreateNfdCRDs(cli extclient.Interface) ([]*apiextensionsv1.CustomResourceDe
 			}
 		}
 
-		newCRDs[i], err = cli.ApiextensionsV1().CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
+		newCRDs[i], err = cli.ApiextensionsV1().CustomResourceDefinitions().Create(ctx, crd, metav1.CreateOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -77,7 +77,7 @@ func CreateNfdCRDs(cli extclient.Interface) ([]*apiextensionsv1.CustomResourceDe
 }
 
 // CreateOrUpdateNodeFeaturesFromFile creates/updates a NodeFeature object from a given file located under test data directory.
-func CreateOrUpdateNodeFeaturesFromFile(cli nfdclientset.Interface, filename, namespace, nodename string) ([]string, error) {
+func CreateOrUpdateNodeFeaturesFromFile(ctx context.Context, cli nfdclientset.Interface, filename, namespace, nodename string) ([]string, error) {
 	objs, err := nodeFeaturesFromFile(filepath.Join(packagePath, "..", "data", filename))
 	if err != nil {
 		return nil, err
@@ -91,13 +91,13 @@ func CreateOrUpdateNodeFeaturesFromFile(cli nfdclientset.Interface, filename, na
 		}
 		obj.Labels[nfdv1alpha1.NodeFeatureObjNodeNameLabel] = nodename
 
-		if oldObj, err := cli.NfdV1alpha1().NodeFeatures(namespace).Get(context.TODO(), obj.Name, metav1.GetOptions{}); errors.IsNotFound(err) {
-			if _, err := cli.NfdV1alpha1().NodeFeatures(namespace).Create(context.TODO(), obj, metav1.CreateOptions{}); err != nil {
+		if oldObj, err := cli.NfdV1alpha1().NodeFeatures(namespace).Get(ctx, obj.Name, metav1.GetOptions{}); errors.IsNotFound(err) {
+			if _, err := cli.NfdV1alpha1().NodeFeatures(namespace).Create(ctx, obj, metav1.CreateOptions{}); err != nil {
 				return names, fmt.Errorf("failed to create NodeFeature %w", err)
 			}
 		} else if err == nil {
 			obj.SetResourceVersion(oldObj.GetResourceVersion())
-			if _, err = cli.NfdV1alpha1().NodeFeatures(namespace).Update(context.TODO(), obj, metav1.UpdateOptions{}); err != nil {
+			if _, err = cli.NfdV1alpha1().NodeFeatures(namespace).Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
 				return names, fmt.Errorf("failed to update NodeFeature object: %w", err)
 			}
 		} else {
@@ -109,14 +109,14 @@ func CreateOrUpdateNodeFeaturesFromFile(cli nfdclientset.Interface, filename, na
 }
 
 // CreateNodeFeatureRuleFromFile creates a NodeFeatureRule object from a given file located under test data directory.
-func CreateNodeFeatureRulesFromFile(cli nfdclientset.Interface, filename string) error {
+func CreateNodeFeatureRulesFromFile(ctx context.Context, cli nfdclientset.Interface, filename string) error {
 	objs, err := nodeFeatureRulesFromFile(filepath.Join(packagePath, "..", "data", filename))
 	if err != nil {
 		return err
 	}
 
 	for _, obj := range objs {
-		if _, err = cli.NfdV1alpha1().NodeFeatureRules().Create(context.TODO(), obj, metav1.CreateOptions{}); err != nil {
+		if _, err = cli.NfdV1alpha1().NodeFeatureRules().Create(ctx, obj, metav1.CreateOptions{}); err != nil {
 			return err
 		}
 	}
@@ -124,7 +124,7 @@ func CreateNodeFeatureRulesFromFile(cli nfdclientset.Interface, filename string)
 }
 
 // UpdateNodeFeatureRulesFromFile updates existing NodeFeatureRule object from a given file located under test data directory.
-func UpdateNodeFeatureRulesFromFile(cli nfdclientset.Interface, filename string) error {
+func UpdateNodeFeatureRulesFromFile(ctx context.Context, cli nfdclientset.Interface, filename string) error {
 	objs, err := nodeFeatureRulesFromFile(filepath.Join(packagePath, "..", "data", filename))
 	if err != nil {
 		return err
@@ -132,12 +132,12 @@ func UpdateNodeFeatureRulesFromFile(cli nfdclientset.Interface, filename string)
 
 	for _, obj := range objs {
 		var nfr *nfdv1alpha1.NodeFeatureRule
-		if nfr, err = cli.NfdV1alpha1().NodeFeatureRules().Get(context.TODO(), obj.Name, metav1.GetOptions{}); err != nil {
+		if nfr, err = cli.NfdV1alpha1().NodeFeatureRules().Get(ctx, obj.Name, metav1.GetOptions{}); err != nil {
 			return fmt.Errorf("failed to get NodeFeatureRule %w", err)
 		}
 
 		obj.SetResourceVersion(nfr.GetResourceVersion())
-		if _, err = cli.NfdV1alpha1().NodeFeatureRules().Update(context.TODO(), obj, metav1.UpdateOptions{}); err != nil {
+		if _, err = cli.NfdV1alpha1().NodeFeatureRules().Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
 			return fmt.Errorf("failed to update NodeFeatureRule %w", err)
 		}
 	}

--- a/test/e2e/utils/node.go
+++ b/test/e2e/utils/node.go
@@ -40,22 +40,22 @@ const (
 )
 
 // GetWorkerNodes returns all nodes labeled as worker
-func GetWorkerNodes(f *framework.Framework) ([]corev1.Node, error) {
-	return GetNodesByRole(f, RoleWorker)
+func GetWorkerNodes(ctx context.Context, f *framework.Framework) ([]corev1.Node, error) {
+	return GetNodesByRole(ctx, f, RoleWorker)
 }
 
 // GetByRole returns all nodes with the specified role
-func GetNodesByRole(f *framework.Framework, role string) ([]corev1.Node, error) {
+func GetNodesByRole(ctx context.Context, f *framework.Framework, role string) ([]corev1.Node, error) {
 	selector, err := labels.Parse(fmt.Sprintf("%s/%s=", LabelRole, role))
 	if err != nil {
 		return nil, err
 	}
-	return GetNodesBySelector(f, selector)
+	return GetNodesBySelector(ctx, f, selector)
 }
 
 // GetBySelector returns all nodes with the specified selector
-func GetNodesBySelector(f *framework.Framework, selector labels.Selector) ([]corev1.Node, error) {
-	nodes, err := f.ClientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+func GetNodesBySelector(ctx context.Context, f *framework.Framework, selector labels.Selector) ([]corev1.Node, error) {
+	nodes, err := f.ClientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/utils/pod/pod.go
+++ b/test/e2e/utils/pod/pod.go
@@ -464,12 +464,12 @@ func newHostPathType(typ corev1.HostPathType) *corev1.HostPathType {
 // WaitForReady waits for the pods to become ready.
 // NOTE: copied from k8s v1.22 after which is was removed from there.
 // Convenient for checking that all pods of a daemonset are ready.
-func WaitForReady(c clientset.Interface, ns, name string, minReadySeconds int) error {
+func WaitForReady(ctx context.Context, c clientset.Interface, ns, name string, minReadySeconds int) error {
 	const poll = 2 * time.Second
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"name": name}))
 	options := metav1.ListOptions{LabelSelector: label.String()}
 	return wait.Poll(poll, 5*time.Minute, func() (bool, error) {
-		pods, err := c.CoreV1().Pods(ns).List(context.TODO(), options)
+		pods, err := c.CoreV1().Pods(ns).List(ctx, options)
 		if err != nil {
 			return false, nil
 		}

--- a/test/e2e/utils/rbac.go
+++ b/test/e2e/utils/rbac.go
@@ -31,48 +31,48 @@ var (
 )
 
 // ConfigureRBAC creates required RBAC configuration
-func ConfigureRBAC(cs clientset.Interface, ns string) error {
-	_, err := createServiceAccount(cs, "nfd-master-e2e", ns)
+func ConfigureRBAC(ctx context.Context, cs clientset.Interface, ns string) error {
+	_, err := createServiceAccount(ctx, cs, "nfd-master-e2e", ns)
 	if err != nil {
 		return err
 	}
 
-	_, err = createServiceAccount(cs, "nfd-worker-e2e", ns)
+	_, err = createServiceAccount(ctx, cs, "nfd-worker-e2e", ns)
 	if err != nil {
 		return err
 	}
 
-	_, err = createServiceAccount(cs, "nfd-topology-updater-e2e", ns)
+	_, err = createServiceAccount(ctx, cs, "nfd-topology-updater-e2e", ns)
 	if err != nil {
 		return err
 	}
 
-	_, err = createClusterRoleMaster(cs)
+	_, err = createClusterRoleMaster(ctx, cs)
 	if err != nil {
 		return err
 	}
 
-	_, err = createRoleWorker(cs, ns)
+	_, err = createRoleWorker(ctx, cs, ns)
 	if err != nil {
 		return err
 	}
 
-	_, err = createClusterRoleTopologyUpdater(cs)
+	_, err = createClusterRoleTopologyUpdater(ctx, cs)
 	if err != nil {
 		return err
 	}
 
-	_, err = createClusterRoleBindingMaster(cs, ns)
+	_, err = createClusterRoleBindingMaster(ctx, cs, ns)
 	if err != nil {
 		return err
 	}
 
-	_, err = createRoleBindingWorker(cs, ns)
+	_, err = createRoleBindingWorker(ctx, cs, ns)
 	if err != nil {
 		return err
 	}
 
-	_, err = createClusterRoleBindingTopologyUpdater(cs, ns)
+	_, err = createClusterRoleBindingTopologyUpdater(ctx, cs, ns)
 	if err != nil {
 		return err
 	}
@@ -81,40 +81,40 @@ func ConfigureRBAC(cs clientset.Interface, ns string) error {
 }
 
 // DeconfigureRBAC removes RBAC configuration
-func DeconfigureRBAC(cs clientset.Interface, ns string) error {
-	err := cs.RbacV1().ClusterRoleBindings().Delete(context.TODO(), "nfd-topology-updater-e2e", metav1.DeleteOptions{})
+func DeconfigureRBAC(ctx context.Context, cs clientset.Interface, ns string) error {
+	err := cs.RbacV1().ClusterRoleBindings().Delete(ctx, "nfd-topology-updater-e2e", metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
-	err = cs.RbacV1().ClusterRoleBindings().Delete(context.TODO(), "nfd-master-e2e", metav1.DeleteOptions{})
+	err = cs.RbacV1().ClusterRoleBindings().Delete(ctx, "nfd-master-e2e", metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
-	err = cs.RbacV1().RoleBindings(ns).Delete(context.TODO(), "nfd-worker-e2e", metav1.DeleteOptions{})
+	err = cs.RbacV1().RoleBindings(ns).Delete(ctx, "nfd-worker-e2e", metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
-	err = cs.RbacV1().ClusterRoles().Delete(context.TODO(), "nfd-topology-updater-e2e", metav1.DeleteOptions{})
+	err = cs.RbacV1().ClusterRoles().Delete(ctx, "nfd-topology-updater-e2e", metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
-	err = cs.RbacV1().ClusterRoles().Delete(context.TODO(), "nfd-master-e2e", metav1.DeleteOptions{})
+	err = cs.RbacV1().ClusterRoles().Delete(ctx, "nfd-master-e2e", metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
-	err = cs.RbacV1().Roles(ns).Delete(context.TODO(), "nfd-worker-e2e", metav1.DeleteOptions{})
+	err = cs.RbacV1().Roles(ns).Delete(ctx, "nfd-worker-e2e", metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
-	err = cs.CoreV1().ServiceAccounts(ns).Delete(context.TODO(), "nfd-topology-updater-e2e", metav1.DeleteOptions{})
+	err = cs.CoreV1().ServiceAccounts(ns).Delete(ctx, "nfd-topology-updater-e2e", metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
-	err = cs.CoreV1().ServiceAccounts(ns).Delete(context.TODO(), "nfd-master-e2e", metav1.DeleteOptions{})
+	err = cs.CoreV1().ServiceAccounts(ns).Delete(ctx, "nfd-master-e2e", metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
-	err = cs.CoreV1().ServiceAccounts(ns).Delete(context.TODO(), "nfd-worker-e2e", metav1.DeleteOptions{})
+	err = cs.CoreV1().ServiceAccounts(ns).Delete(ctx, "nfd-worker-e2e", metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -122,18 +122,18 @@ func DeconfigureRBAC(cs clientset.Interface, ns string) error {
 }
 
 // Configure service account
-func createServiceAccount(cs clientset.Interface, name, ns string) (*corev1.ServiceAccount, error) {
+func createServiceAccount(ctx context.Context, cs clientset.Interface, name, ns string) (*corev1.ServiceAccount, error) {
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
 		},
 	}
-	return cs.CoreV1().ServiceAccounts(ns).Create(context.TODO(), sa, metav1.CreateOptions{})
+	return cs.CoreV1().ServiceAccounts(ns).Create(ctx, sa, metav1.CreateOptions{})
 }
 
 // Configure cluster role required by NFD Master
-func createClusterRoleMaster(cs clientset.Interface) (*rbacv1.ClusterRole, error) {
+func createClusterRoleMaster(ctx context.Context, cs clientset.Interface) (*rbacv1.ClusterRole, error) {
 	cr := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "nfd-master-e2e",
@@ -161,11 +161,11 @@ func createClusterRoleMaster(cs clientset.Interface) (*rbacv1.ClusterRole, error
 				Verbs:         []string{"use"},
 			})
 	}
-	return cs.RbacV1().ClusterRoles().Update(context.TODO(), cr, metav1.UpdateOptions{})
+	return cs.RbacV1().ClusterRoles().Update(ctx, cr, metav1.UpdateOptions{})
 }
 
 // Configure role required by NFD Worker
-func createRoleWorker(cs clientset.Interface, ns string) (*rbacv1.Role, error) {
+func createRoleWorker(ctx context.Context, cs clientset.Interface, ns string) (*rbacv1.Role, error) {
 	cr := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "nfd-worker-e2e",
@@ -179,11 +179,11 @@ func createRoleWorker(cs clientset.Interface, ns string) (*rbacv1.Role, error) {
 			},
 		},
 	}
-	return cs.RbacV1().Roles(ns).Update(context.TODO(), cr, metav1.UpdateOptions{})
+	return cs.RbacV1().Roles(ns).Update(ctx, cr, metav1.UpdateOptions{})
 }
 
 // Configure cluster role required by NFD Topology Updater
-func createClusterRoleTopologyUpdater(cs clientset.Interface) (*rbacv1.ClusterRole, error) {
+func createClusterRoleTopologyUpdater(ctx context.Context, cs clientset.Interface) (*rbacv1.ClusterRole, error) {
 	cr := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "nfd-topology-updater-e2e",
@@ -218,11 +218,11 @@ func createClusterRoleTopologyUpdater(cs clientset.Interface) (*rbacv1.ClusterRo
 				Verbs:         []string{"use"},
 			})
 	}
-	return cs.RbacV1().ClusterRoles().Update(context.TODO(), cr, metav1.UpdateOptions{})
+	return cs.RbacV1().ClusterRoles().Update(ctx, cr, metav1.UpdateOptions{})
 }
 
 // Configure cluster role binding required by NFD Master
-func createClusterRoleBindingMaster(cs clientset.Interface, ns string) (*rbacv1.ClusterRoleBinding, error) {
+func createClusterRoleBindingMaster(ctx context.Context, cs clientset.Interface, ns string) (*rbacv1.ClusterRoleBinding, error) {
 	crb := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "nfd-master-e2e",
@@ -241,11 +241,11 @@ func createClusterRoleBindingMaster(cs clientset.Interface, ns string) (*rbacv1.
 		},
 	}
 
-	return cs.RbacV1().ClusterRoleBindings().Update(context.TODO(), crb, metav1.UpdateOptions{})
+	return cs.RbacV1().ClusterRoleBindings().Update(ctx, crb, metav1.UpdateOptions{})
 }
 
 // Configure role binding required by NFD Master
-func createRoleBindingWorker(cs clientset.Interface, ns string) (*rbacv1.RoleBinding, error) {
+func createRoleBindingWorker(ctx context.Context, cs clientset.Interface, ns string) (*rbacv1.RoleBinding, error) {
 	crb := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "nfd-worker-e2e",
@@ -265,11 +265,11 @@ func createRoleBindingWorker(cs clientset.Interface, ns string) (*rbacv1.RoleBin
 		},
 	}
 
-	return cs.RbacV1().RoleBindings(ns).Update(context.TODO(), crb, metav1.UpdateOptions{})
+	return cs.RbacV1().RoleBindings(ns).Update(ctx, crb, metav1.UpdateOptions{})
 }
 
 // Configure cluster role binding required by NFD Topology Updater
-func createClusterRoleBindingTopologyUpdater(cs clientset.Interface, ns string) (*rbacv1.ClusterRoleBinding, error) {
+func createClusterRoleBindingTopologyUpdater(ctx context.Context, cs clientset.Interface, ns string) (*rbacv1.ClusterRoleBinding, error) {
 	crb := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "nfd-topology-updater-e2e",
@@ -288,5 +288,5 @@ func createClusterRoleBindingTopologyUpdater(cs clientset.Interface, ns string) 
 		},
 	}
 
-	return cs.RbacV1().ClusterRoleBindings().Update(context.TODO(), crb, metav1.UpdateOptions{})
+	return cs.RbacV1().ClusterRoleBindings().Update(ctx, crb, metav1.UpdateOptions{})
 }

--- a/test/e2e/utils/service.go
+++ b/test/e2e/utils/service.go
@@ -25,7 +25,7 @@ import (
 )
 
 // CreateService creates nfd-master Service
-func CreateService(cs clientset.Interface, ns string) (*corev1.Service, error) {
+func CreateService(ctx context.Context, cs clientset.Interface, ns string) (*corev1.Service, error) {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "nfd-master-e2e",
@@ -41,5 +41,5 @@ func CreateService(cs clientset.Interface, ns string) (*corev1.Service, error) {
 			Type: corev1.ServiceTypeClusterIP,
 		},
 	}
-	return cs.CoreV1().Services(ns).Create(context.TODO(), svc, metav1.CreateOptions{})
+	return cs.CoreV1().Services(ns).Create(ctx, svc, metav1.CreateOptions{})
 }


### PR DESCRIPTION
Eliminate all context.TODO() from the e2e tests and use ginkgo context instead. This ensures that calls involving context are properly cancelled and return fast in case the tests get aborted.