### PR TITLE
nfd-master: reject malformed extended resource dynamic capacity assignment

### DIFF
--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -713,6 +713,10 @@ func (m *nfdMaster) filterExtendedResources(features *nfdv1alpha1.Features, exte
 		if strings.HasPrefix(capacity, "@") {
 			// capacity is a string in the form of attribute.featureset.elements
 			split := strings.SplitN(capacity[1:], ".", 3)
+			if len(split) != 3 {
+				klog.Errorf("capacity %s is not in the form of '@domain.feature.element',. Ignoring Extended Resource %q", capacity, extendedResource)
+				continue
+			}
 			featureName := split[0] + "." + split[1]
 			elementName := split[2]
 			attrFeatureSet, ok := features.Attributes[featureName]


### PR DESCRIPTION
on _filterExtendedResources_ check if capacity is in the form `@domain.feature.element`

Fixes #1168 