### PR TITLE
hooks: disable hooks by default from v0.14

### DIFF
--- a/deployment/components/worker-config/nfd-worker.conf.example
+++ b/deployment/components/worker-config/nfd-worker.conf.example
@@ -76,7 +76,7 @@
 #      - "vendor"
 #      - "device"
 #  local:
-#    hooksEnabled: true
+#    hooksEnabled: false
 #  custom:
 #    # The following feature demonstrates the capabilities of the matchFeatures
 #    - name: "my custom rule"

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -191,7 +191,7 @@ worker:
     #      - "vendor"
     #      - "device"
     #  local:
-    #    hooksEnabled: true
+    #    hooksEnabled: false
     #  custom:
     #    # The following feature demonstrates the capabilities of the matchFeatures
     #    - name: "my custom rule"

--- a/docs/reference/worker-configuration-reference.md
+++ b/docs/reference/worker-configuration-reference.md
@@ -347,12 +347,14 @@ Related tracking issues:
 1. Disable hook support by default [#855](https://github.com/kubernetes-sigs/node-feature-discovery/issues/855).
 1. Drop support for hooks [#856](https://github.com/kubernetes-sigs/node-feature-discovery/issues/856).
 
+Default: false
+
 Example:
 
 ```yaml
 sources:
   local:
-    hooksEnabled: true  # true by default
+    hooksEnabled: true
 ```
 
 ### sources.pci

--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -278,8 +278,8 @@ trying to execute them. A subdirectory under the hooks directory can be used,
 for example `/etc/kubernetes/node-feature-discovery/source.d/conf/`.
 
 **NOTE:** Hooks are being DEPRECATED and will be removed in a future release.
-For backward compatibility, currently hooks are enabled by default and can be
-disabled via `sources.local.hooksEnabled` field in the worker configuration.
+Starting from release v0.14 hooks are disabled by default and can be enabled
+via `sources.local.hooksEnabled` field in the worker configuration.
 
 ```yaml
 sources:

--- a/source/local/local.go
+++ b/source/local/local.go
@@ -97,7 +97,7 @@ func (s *localSource) GetLabels() (source.FeatureLabels, error) {
 // newDefaultConfig returns a new config with pre-populated defaults
 func newDefaultConfig() *Config {
 	return &Config{
-		HooksEnabled: true,
+		HooksEnabled: false,
 	}
 }
 
@@ -113,6 +113,7 @@ func (s *localSource) Discover() error {
 	if s.config.HooksEnabled {
 
 		klog.InfoS("starting hooks...")
+		klog.InfoS("NOTE: hooks are deprecated and will be completely removed in a future release.")
 
 		featuresFromHooks, err := getFeaturesFromHooks()
 		if err != nil {


### PR DESCRIPTION
We have deprecated hooks in v0.12.0 but kept it enabled by default. Starting from v0.13.x we are starting to disable it by default and plan to fully remove it in v0.14.x if there are no objections from the community.