### PR TITLE
docs: add missing .md suffix to internal references

### DIFF
--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -6,14 +6,14 @@ sort: 2
 
 # Deployment
 
-See [Image variants](image-variants) for description of the different NFD
+See [Image variants](image-variants.md) for description of the different NFD
 container images available.
 
-[Using Kustomize](kustomize) provides straightforward deployment with
+[Using Kustomize](kustomize.md) provides straightforward deployment with
 `kubectl` integration and declarative customization.
 
-[Using Helm](helm) provides easy management of NFD deployments with nice
+[Using Helm](helm.md) provides easy management of NFD deployments with nice
 configuration management and easy upgrades.
 
-[Using Operator](operator) provides deployment and configuration management via
+[Using Operator](operator.md) provides deployment and configuration management via
 CRDs.

--- a/docs/deployment/kustomize.md
+++ b/docs/deployment/kustomize.md
@@ -63,7 +63,7 @@ scenarios under
 - [`samples/cert-manager`](https://github.com/kubernetes-sigs/node-feature-discovery/blob/{{site.release}}/deployment/overlays/samples/cert-manager):
   an example for supplementing the default deployment with cert-manager for TLS
   authentication, see
-  [Automated TLS certificate management using cert-manager](tls)
+  [Automated TLS certificate management using cert-manager](tls.md)
   for details
 - [`samples/custom-rules`](https://github.com/kubernetes-sigs/node-feature-discovery/blob/{{site.release}}/deployment/overlays/samples/custom-rules):
   an example for spicing up the default deployment with a separately managed

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -11,10 +11,10 @@ features and system configuration!
 
 Continue to:
 
-- **[Introduction](introduction)** for more details on the
+- **[Introduction](introduction.md)** for more details on the
   project.
 
-- **[Quick start](quick-start)** for quick step-by-step
+- **[Quick start](quick-start.md)** for quick step-by-step
   instructions on how to get NFD running on your cluster.
 
 ## Quick-start -- the short-short version

--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -247,7 +247,7 @@ defined built-in labels:
 ## User defined labels
 
 NFD has many extension points for creating vendor and application specific
-labels. See the [customization guide](customization-guide) for
+labels. See the [customization guide](customization-guide.md) for
 detailed documentation.
 
 ## Extended resources


### PR DESCRIPTION
Commit bfbc47f55e460ec80bfb8f57125ee3a0d2967486 added a lot of those and this patch tries to cover all that we missed there. Having .md suffixes in references to internal files makes it convenient to browse the document locally, just as text files as the references work correctly.