### PR TITLE
Match usage and example for prepare-release.sh

### DIFF
--- a/hack/prepare-release.sh
+++ b/hack/prepare-release.sh
@@ -17,7 +17,7 @@ Options:
 
 Example:
 
-  $this v0.1.2 -k "Jane Doe <jane.doe@example.com>"
+  $this -k "Jane Doe <jane.doe@example.com>" v0.13.1
 
 
 NOTE: The GPG key should be associated with the signer's Github account.


### PR DESCRIPTION
```bash
Usage: $this [-h] [-b] [-k GPG_KEY] {-a|-g GOLANG_VERSION} RELEASE_VERSION

Example:
-  $this v0.1.2 -k "Jane Doe <jane.doe@example.com>"
+ $this -k "Jane Doe <jane.doe@example.com>" v0.13.1
```

Release is the last arg, not the first 