### PR TITLE
codecov: drop required minimum coverage ratio of a commit to 0%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,8 @@ comment:
   layout: "reach, diff, flags, files"
   behavior: new
   require_changes: false
+coverage:
+  status:
+    project:
+      default:
+        target: 0%


### PR DESCRIPTION
not to block currently open PRs from getting merged and deal with target setting separately.
