### PR TITLE
codecov: drop required minimum coverage ratio at patch level

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,6 @@ coverage:
     project:
       default:
         target: 0%
+    patch:
+      default:
+        target: 0%


### PR DESCRIPTION
previously in https://github.com/kubernetes-sigs/node-feature-discovery/pull/1200 we added similar to project and this is doing the same but for the patch level.