### PR TITLE
deployment/helm: fix default for kubeletStateDir parameter

### DIFF
--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -410,7 +410,7 @@ topologyUpdater:
   kubeletPodResourcesSockPath:
   updateInterval: 60s
   watchNamespace: "*"
-  kubeletStateDir: /host-var/lib/kubelet
+  kubeletStateDir: /var/lib/kubelet
 
   podSecurityContext: {}
   securityContext:


### PR DESCRIPTION
This parameter is a path in the host system, not a mount path inside the container.