### PR TITLE
deployment/helm: improve handling of topologyUpdater.kubeletStateFiles

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
+++ b/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
@@ -61,6 +61,10 @@ spec:
           {{- if .Values.topologyUpdater.kubeletConfigPath | empty | not }}
           - "-kubelet-config-uri=file:///host-var/kubelet-config"
           {{- end }}
+          {{- if .Values.topologyUpdater.kubeletStateDir | empty }}
+          # Disable kubelet state tracking by giving an empty path
+          - "-kubelet-state-dir="
+          {{- end }}
         volumeMounts:
         {{- if .Values.topologyUpdater.kubeletConfigPath | empty | not }}
         - name: kubelet-config

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -177,7 +177,7 @@ We have introduced the following Chart parameters.
 | `topologyUpdater.affinity`                    | dict   | {}                      | Topology updater pod [affinity](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)                                                                      |
 | `topologyUpdater.config`                      | dict   |                         | [configuration](../reference/topology-updater-configuration-reference)                                                                                                                                |
 | `topologyUpdater.podSetFingerprint`           | bool   | false                   | Enables compute and report of pod fingerprint in NRT objects.                                                                                                                                         |
-| `topologyUpdater.kubeletStateDir`             | string | "/host-var/lib/kubelet" | Specifies kubelet state directory path for watching state and checkpoint files. Empty value disables kubelet state tracking.                                                                          |
+| `topologyUpdater.kubeletStateDir`             | string | /var/lib/kubelet | Specifies kubelet state directory path for watching state and checkpoint files. Empty value disables kubelet state tracking.                                                                          |
 
 ### Topology garbage collector parameters
 


### PR DESCRIPTION
Make it possible to disable kubelet state tracking with --set topologyUpdater.kubeletStateFiles="" as the documentation suggests.

Also, fix the documentation regarding the default value of topologyUpdater.kubeletStateFiles parameter.