### PR TITLE
topology-updater: use node IP in the default configz URI

### DIFF
--- a/cmd/nfd-topology-updater/main.go
+++ b/cmd/nfd-topology-updater/main.go
@@ -112,12 +112,13 @@ func parseArgs(flags *flag.FlagSet, osArgs ...string) (*topology.Args, *resource
 	}
 
 	if len(resourcemonitorArgs.KubeletConfigURI) == 0 {
-		if len(utils.NodeName()) == 0 {
-			fmt.Fprintf(flags.Output(), "unable to determine the default kubelet config endpoint 'https://${NODE_NAME}:%d/configz' due to empty NODE_NAME environment, "+
-				"please either define the NODE_NAME environment variable or specify endpoint with the -kubelet-config-uri flag\n", kubeletSecurePort)
+		nodeAddress := os.Getenv("NODE_ADDRESS")
+		if len(nodeAddress) == 0 {
+			fmt.Fprintf(flags.Output(), "unable to determine the default kubelet config endpoint 'https://${NODE_ADDRESS}:%d/configz' due to empty NODE_ADDRESS environment, "+
+				"please either define the NODE_ADDRESS environment variable or specify endpoint with the -kubelet-config-uri flag\n", kubeletSecurePort)
 			os.Exit(1)
 		}
-		resourcemonitorArgs.KubeletConfigURI = fmt.Sprintf("https://%s:%d/configz", utils.NodeName(), kubeletSecurePort)
+		resourcemonitorArgs.KubeletConfigURI = fmt.Sprintf("https://%s:%d/configz", nodeAddress, kubeletSecurePort)
 	}
 
 	return args, resourcemonitorArgs

--- a/deployment/components/topology-updater/env.yaml
+++ b/deployment/components/topology-updater/env.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: "/spec/template/spec/containers/0/env/-"
+  value:
+      name: NODE_ADDRESS
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP

--- a/deployment/components/topology-updater/kustomization.yaml
+++ b/deployment/components/topology-updater/kustomization.yaml
@@ -14,3 +14,7 @@ patches:
   target:
     labelSelector: app=nfd
     name: nfd-topology-updater
+- path: env.yaml
+  target:
+    labelSelector: app=nfd
+    name: nfd-topology-updater

--- a/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
+++ b/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
@@ -37,6 +37,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODE_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         command:
           - "nfd-topology-updater"
         args:

--- a/docs/reference/topology-updater-commandline-reference.md
+++ b/docs/reference/topology-updater-commandline-reference.md
@@ -109,7 +109,7 @@ nfd-topology-updater -watch-namespace=rte
 The `-kubelet-config-uri` specifies the path to the Kubelet's configuration.
 Note that the URi could either be a local host file or an HTTP endpoint.
 
-Default:  `https://${NODE_NAME}:10250/configz`
+Default:  `https://${NODE_ADDRESS}:10250/configz`
 
 Example:
 


### PR DESCRIPTION
Use a separate NODE_ADDRESS environment variable in the default value of -kubelet-config-uri (instead of NODE_NAME that was previously used). Also change the kustomize and Helm deployments to set this variable to node IP address. This should make the default deployment more robust, making it work in scenarios where node name does not resolve to the node ip, e.g. nodename != hostname.