### PR TITLE
e2e: delete CRs only if found

### DIFF
--- a/test/e2e/node_feature_discovery_test.go
+++ b/test/e2e/node_feature_discovery_test.go
@@ -150,19 +150,23 @@ func cleanupCRs(ctx context.Context, cli *nfdclient.Clientset, namespace string)
 	nfrs, err := cli.NfdV1alpha1().NodeFeatureRules().List(ctx, metav1.ListOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
-	By("Deleting NodeFeatureRule objects from the cluster")
-	for _, nfr := range nfrs.Items {
-		err = cli.NfdV1alpha1().NodeFeatureRules().Delete(ctx, nfr.Name, metav1.DeleteOptions{})
-		Expect(err).NotTo(HaveOccurred())
+	if len(nfrs.Items) != 0 {
+		By("Deleting NodeFeatureRule objects from the cluster")
+		for _, nfr := range nfrs.Items {
+			err = cli.NfdV1alpha1().NodeFeatureRules().Delete(ctx, nfr.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}
 	}
 
 	nfs, err := cli.NfdV1alpha1().NodeFeatures(namespace).List(ctx, metav1.ListOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
-	By("Deleting NodeFeature objects from namespace " + namespace)
-	for _, nf := range nfs.Items {
-		err = cli.NfdV1alpha1().NodeFeatures(namespace).Delete(ctx, nf.Name, metav1.DeleteOptions{})
-		Expect(err).NotTo(HaveOccurred())
+	if len(nfs.Items) != 0 {
+		By("Deleting NodeFeature objects from namespace " + namespace)
+		for _, nf := range nfs.Items {
+			err = cli.NfdV1alpha1().NodeFeatures(namespace).Delete(ctx, nf.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}
 	}
 }
 


### PR DESCRIPTION
Delete `NodeFeatureRule` and `NodeFeature` CRs only if found.
