### PR TITLE
Fixed typo in Header under deployment/kustomize.md

### DIFF
--- a/docs/deployment/kustomize.md
+++ b/docs/deployment/kustomize.md
@@ -4,7 +4,7 @@ layout: default
 sort: 2
 ---
 
-# Deploymenet with Kustomize
+# Deployment with Kustomize
 {: .no_toc}
 
 ## Table of contents


### PR DESCRIPTION
A small typo is fixed in the header of the page https://kubernetes-sigs.github.io/node-feature-discovery/v0.13/deployment/kustomize.html