### PR TITLE
nfd-master: use close for stop channel

### DIFF
--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -394,10 +394,7 @@ func (m *nfdMaster) Stop() {
 		m.nfdController.stop()
 	}
 
-	select {
-	case m.stop <- struct{}{}:
-	default:
-	}
+	close(m.stop)
 }
 
 // Wait until NfdMaster is able able to accept connections.


### PR DESCRIPTION
Simpler and more reliable (in case of multiple consumers) to just close the channel.