### PR TITLE
[release-0.13] nfd-master: add validation of label names and values

### DIFF
--- a/pkg/nfd-master/nfd-master-internal_test.go
+++ b/pkg/nfd-master/nfd-master-internal_test.go
@@ -367,8 +367,10 @@ func TestSetLabels(t *testing.T) {
 				"random.denied.ns/feature-3":     "val-3",
 				"kubernetes.io/feature-4":        "val-4",
 				"sub.ns.kubernetes.io/feature-5": "val-5",
-				vendorFeatureLabel:               " val-6",
-				vendorProfileLabel:               " val-7"}
+				vendorFeatureLabel:               "val-6",
+				vendorProfileLabel:               "val-7",
+				"--invalid-name--":               "valid-val",
+				"valid-name":                     "--invalid-val--"}
 			expectedPatches := []apihelper.JsonPatch{
 				apihelper.NewJsonPatch("add", "/metadata/annotations", instance+"."+nfdv1alpha1.WorkerVersionAnnotation, workerVer),
 				apihelper.NewJsonPatch("add", "/metadata/annotations",


### PR DESCRIPTION
Validate labels before trying to update the node. Makes us fail early nad prevent useless retries in case invalid labels are tried.

(backported from commit 2a3c7e4c9357b5426c1203ba7684e6f966a0d65f)