### PR TITLE
[release-0.12] nfd-master: add validation of label names and values

### DIFF
--- a/pkg/nfd-master/nfd-master-internal_test.go
+++ b/pkg/nfd-master/nfd-master-internal_test.go
@@ -361,8 +361,10 @@ func TestSetLabels(t *testing.T) {
 			mockLabels := map[string]string{"feature-1": "val-1",
 				"valid.ns/feature-2":   "val-2",
 				"invalid.ns/feature-3": "val-3",
-				vendorFeatureLabel:     " val-4",
-				vendorProfileLabel:     " val-5"}
+				vendorFeatureLabel:     "val-4",
+				vendorProfileLabel:     "val-5",
+				"--invalid-name--":     "valid-val",
+				"valid-name":           "--invalid-val--"}
 			expectedPatches := []apihelper.JsonPatch{
 				apihelper.NewJsonPatch("add", "/metadata/annotations", instance+"."+nfdv1alpha1.WorkerVersionAnnotation, workerVer),
 				apihelper.NewJsonPatch("add", "/metadata/annotations",

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -38,6 +38,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	label "k8s.io/apimachinery/pkg/labels"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -409,6 +410,12 @@ func filterFeatureLabels(labels Labels, extraLabelNs map[string]struct{}, labelW
 		// Add possibly missing default ns
 		label := addNs(label, nfdv1alpha1.FeatureLabelNs)
 
+		//Validate label name
+		if errs := k8svalidation.IsQualifiedName(label); len(errs) > 0 {
+			klog.Errorf("ignoring label %q, invalid name: %s", label, strings.Join(errs, "; "))
+			continue
+		}
+
 		ns, name := splitNs(label)
 
 		// Check label namespace, filter out if ns is not whitelisted
@@ -423,6 +430,12 @@ func filterFeatureLabels(labels Labels, extraLabelNs map[string]struct{}, labelW
 		// Skip if label doesn't match labelWhiteList
 		if !labelWhiteList.MatchString(name) {
 			klog.Errorf("%s (%s) does not match the whitelist (%s) and will not be published.", name, label, labelWhiteList.String())
+			continue
+		}
+
+		// Validate the label value
+		if errs := k8svalidation.IsValidLabelValue(value); len(errs) > 0 {
+			klog.Errorf("ignoring label %q, invalid value %q: %s", label, value, strings.Join(errs, "; "))
 			continue
 		}
 		outLabels[label] = value


### PR DESCRIPTION
Validate labels before trying to update the node. Makes us fail early nad prevent useless retries in case invalid labels are tried.

(backported from commit 2a3c7e4c9357b5426c1203ba7684e6f966a0d65f)