### PR TITLE
[release-0.12] Update references to release v0.12.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ IMAGE_BUILD_CMD ?= docker build
 IMAGE_BUILD_EXTRA_OPTS ?=
 IMAGE_PUSH_CMD ?= docker push
 CONTAINER_RUN_CMD ?= docker run
-BUILDER_IMAGE ?= golang:1.19.8-bullseye
+BUILDER_IMAGE ?= golang:1.19.9-bullseye
 BASE_IMAGE_FULL ?= debian:bullseye-slim
 BASE_IMAGE_MINIMAL ?= gcr.io/distroless/base
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ features and system configuration!
 #### Quick-start – the short-short version
 
 ```bash
-$ kubectl apply -k https://github.com/kubernetes-sigs/node-feature-discovery/deployment/overlays/default?ref=v0.12.3
+$ kubectl apply -k https://github.com/kubernetes-sigs/node-feature-discovery/deployment/overlays/default?ref=v0.12.4
   namespace/node-feature-discovery created
   customresourcedefinition.apiextensions.k8s.io/nodefeaturerules.nfd.k8s-sigs.io created
   serviceaccount/nfd-master created

--- a/deployment/base/master-worker-combined/master-worker-daemonset.yaml
+++ b/deployment/base/master-worker-combined/master-worker-daemonset.yaml
@@ -17,7 +17,7 @@ spec:
       tolerations: []
       containers:
       - name: nfd-master
-        image: registry.k8s.io/nfd/node-feature-discovery:v0.12.3
+        image: registry.k8s.io/nfd/node-feature-discovery:v0.12.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -33,7 +33,7 @@ spec:
         command:
         - "nfd-master"
       - name: nfd-worker
-        image: registry.k8s.io/nfd/node-feature-discovery:v0.12.3
+        image: registry.k8s.io/nfd/node-feature-discovery:v0.12.4
         imagePullPolicy: IfNotPresent
         command:
         - "nfd-worker"

--- a/deployment/base/master/master-deployment.yaml
+++ b/deployment/base/master/master-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       tolerations: []
       containers:
         - name: nfd-master
-          image: registry.k8s.io/nfd/node-feature-discovery:v0.12.3
+          image: registry.k8s.io/nfd/node-feature-discovery:v0.12.4
           imagePullPolicy: IfNotPresent
           livenessProbe:
             exec:

--- a/deployment/base/topologyupdater-daemonset/topologyupdater-daemonset.yaml
+++ b/deployment/base/topologyupdater-daemonset/topologyupdater-daemonset.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccount: nfd-topology-updater
       containers:
         - name: nfd-topology-updater
-          image: registry.k8s.io/nfd/node-feature-discovery:v0.12.3
+          image: registry.k8s.io/nfd/node-feature-discovery:v0.12.4
           imagePullPolicy: IfNotPresent
           command:
             - "nfd-topology-updater"

--- a/deployment/base/worker-daemonset/worker-daemonset.yaml
+++ b/deployment/base/worker-daemonset/worker-daemonset.yaml
@@ -17,7 +17,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: nfd-worker
-          image: registry.k8s.io/nfd/node-feature-discovery:v0.12.3
+          image: registry.k8s.io/nfd/node-feature-discovery:v0.12.4
           imagePullPolicy: IfNotPresent
           command:
             - "nfd-worker"

--- a/deployment/base/worker-job/worker-job.yaml
+++ b/deployment/base/worker-job/worker-job.yaml
@@ -27,7 +27,7 @@ spec:
                       - nfd-worker
       containers:
         - name: nfd-worker
-          image: registry.k8s.io/nfd/node-feature-discovery:v0.12.3
+          image: registry.k8s.io/nfd/node-feature-discovery:v0.12.4
           imagePullPolicy: IfNotPresent
           command:
             - "nfd-worker"

--- a/deployment/helm/node-feature-discovery/Chart.yaml
+++ b/deployment/helm/node-feature-discovery/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.12.3
+appVersion: v0.12.4
 description: |
   Detects hardware features available on each node in a Kubernetes cluster, and advertises
   those features using node labels.

--- a/deployment/overlays/prune/master-job.yaml
+++ b/deployment/overlays/prune/master-job.yaml
@@ -15,7 +15,7 @@ spec:
       tolerations: []
       containers:
         - name: nfd-master
-          image: registry.k8s.io/nfd/node-feature-discovery:v0.12.3
+          image: registry.k8s.io/nfd/node-feature-discovery:v0.12.4
           imagePullPolicy: IfNotPresent
           command:
             - "nfd-master"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -57,7 +57,7 @@ scss: |
 # Release is the full released version number. Used to make external links to
 # point to the correct blobs in the Github repo. This is also the version shown
 # in the sidebar (top left corner of the page)
-release: v0.12.3
+release: v0.12.4
 
 # Container image which to point to in the documentation
-container_image: registry.k8s.io/nfd/node-feature-discovery:v0.12.3
+container_image: registry.k8s.io/nfd/node-feature-discovery:v0.12.4


### PR DESCRIPTION
Bump golang to v1.19.9.

Generated with:
  hack/prepare-release.sh -g 1.19.9 v0.12.4