### PR TITLE
deployment/kustomize: use a named port for nfd gRPC service

### DIFF
--- a/deployment/base/master/master-deployment.yaml
+++ b/deployment/base/master/master-deployment.yaml
@@ -34,3 +34,6 @@ spec:
             failureThreshold: 10
           command:
             - "nfd-master"
+          ports:
+            - name: grpc
+              containerPort: 8080

--- a/deployment/base/master/master-service.yaml
+++ b/deployment/base/master/master-service.yaml
@@ -8,4 +8,5 @@ spec:
   ports:
   - protocol: TCP
     port: 8080
+    targetPort: grpc
   type: ClusterIP


### PR DESCRIPTION
Inspired by #1242 