### PR TITLE
Fix missing apostrophe for jq

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ kubectl -n node-feature-discovery get all
   pod/nfd-worker-mjg9f              1/1     Running   0          17s
 ...
 
-$ kubectl get no -o json | jq .items[].metadata.labels
+$ kubectl get no -o json | jq '.items[].metadata.labels'
   {
     "kubernetes.io/arch": "amd64",
     "kubernetes.io/os": "linux",

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -36,7 +36,7 @@ $ kubectl -n node-feature-discovery get all
   pod/nfd-worker-mjg9f              1/1     Running   0          17s
 ...
 
-$ kubectl get nodes -o json | jq .items[].metadata.labels
+$ kubectl get nodes -o json | jq '.items[].metadata.labels'
   {
     "kubernetes.io/arch": "amd64",
     "kubernetes.io/os": "linux",

--- a/docs/get-started/quick-start.md
+++ b/docs/get-started/quick-start.md
@@ -34,7 +34,7 @@ deployment.apps/nfd-master   1/1     1            1           17s
 Check that NFD feature labels have been created
 
 ```bash
-$ kubectl get no -o json | jq .items[].metadata.labels
+$ kubectl get no -o json | jq '.items[].metadata.labels'
 {
   "kubernetes.io/arch": "amd64",
   "kubernetes.io/os": "linux",


### PR DESCRIPTION
There seems to be missing apostrophes in the `jq` calls in the documentation.

jq version:

``` console
> jq --version
jq-1.6
```

current behaviour:

```console
> kubectl get no -o json | jq .items[].metadata.labels
zsh: no matches found: .items[].metadata.labels
```

changed behaviour:

```console
> kubectl get no -o json | jq '.items[].metadata.labels'
{
...
```