### PR TITLE
Stop ticker in time to avoid memory leak

### DIFF
--- a/pkg/nfd-topology-gc/nfd-nrt-gc.go
+++ b/pkg/nfd-topology-gc/nfd-nrt-gc.go
@@ -146,6 +146,7 @@ func (n *topologyGC) runGC() {
 // periodicGC runs garbage collector at every gcPeriod to make sure we haven't missed any node
 func (n *topologyGC) periodicGC(gcPeriod time.Duration) {
 	gcTrigger := time.NewTicker(gcPeriod)
+	defer gcTrigger.Stop()
 	for {
 		select {
 		case <-gcTrigger.C:

--- a/pkg/nfd-topology-updater/kubeletnotifier/kubeletnotifier.go
+++ b/pkg/nfd-topology-updater/kubeletnotifier/kubeletnotifier.go
@@ -70,6 +70,7 @@ func (n *Notifier) Run() {
 	timeEvents := make(<-chan time.Time)
 	if n.sleepInterval > 0 {
 		ticker := time.NewTicker(n.sleepInterval)
+		defer ticker.Stop()
 		timeEvents = ticker.C
 	}
 


### PR DESCRIPTION
Clean `ticker` in time.
Because it will cause memory leak if we do not stop `ticker` when the function has completed.
