### PR TITLE
nfd-master: check for nil references in nfdAPIUpdateAllNodes

### DIFF
--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -693,6 +693,10 @@ func (m *nfdMaster) nfdAPIUpdateAllNodes() error {
 }
 
 func (m *nfdMaster) nfdAPIUpdateOneNode(nodeName string) error {
+	if m.nfdController == nil || m.nfdController.featureLister == nil {
+		return nil
+	}
+
 	sel := k8sLabels.SelectorFromSet(k8sLabels.Set{nfdv1alpha1.NodeFeatureObjNodeNameLabel: nodeName})
 	objs, err := m.nfdController.featureLister.List(sel)
 	if err != nil {


### PR DESCRIPTION
Just a safeguard.