### PR TITLE
[release-0.13] nfd-master: fix node updates on config change

### DIFF
--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -244,7 +244,7 @@ func (m *nfdMaster) Run() error {
 				return err
 			}
 			// Update all nodes when the configuration changes
-			if m.nfdController != nil {
+			if m.nfdController != nil && m.args.EnableNodeFeatureApi {
 				m.nfdController.updateAllNodesChan <- struct{}{}
 			}
 		case <-m.stop:


### PR DESCRIPTION
Don't try to update all nodes on config change when the NodeFeature API is disabled. In this case we rely on gRPC and only act on gRPC requests from the worker.