### PR TITLE
cpu: Take cgroupsv1 into account when reading misc.capacity

### DIFF
--- a/source/cpu/security_amd64.go
+++ b/source/cpu/security_amd64.go
@@ -122,26 +122,10 @@ func sevParameterEnabled(parameter string) bool {
 	return false
 }
 
-func getCgroupMiscCapacity(resource string) int64 {
+func retrieveCgroupMiscCapacityValue(miscCgroupPath *os.File, resource string) int64 {
 	var totalResources int64 = -1
-	var err error = nil
-	var f *os.File = nil
 
-	miscCgroupsPaths := []string{"fs/cgroup/misc.capacity", "fs/cgroup/misc/misc.capacity"}
-	for _, miscCgroupsPath := range miscCgroupsPaths {
-		miscCgroups := hostpath.SysfsDir.Path(miscCgroupsPath)
-		f, err = os.Open(miscCgroups)
-		if err == nil {
-			defer f.Close()
-			break
-		}
-	}
-
-	if err != nil {
-		return totalResources
-	}
-
-	r := bufio.NewReader(f)
+	r := bufio.NewReader(miscCgroupPath)
 	for {
 		line, _, err := r.ReadLine()
 		if err != nil {
@@ -166,4 +150,19 @@ func getCgroupMiscCapacity(resource string) int64 {
 	}
 
 	return totalResources
+}
+
+func getCgroupMiscCapacity(resource string) int64 {
+	miscCgroupsPaths := []string{"fs/cgroup/misc.capacity", "fs/cgroup/misc/misc.capacity"}
+	for _, miscCgroupsPath := range miscCgroupsPaths {
+		miscCgroups := hostpath.SysfsDir.Path(miscCgroupsPath)
+		f, err := os.Open(miscCgroups)
+		if err == nil {
+			defer f.Close()
+
+			return retrieveCgroupMiscCapacityValue(f, resource)
+		}
+	}
+
+	return -1
 }

--- a/source/cpu/security_amd64.go
+++ b/source/cpu/security_amd64.go
@@ -124,13 +124,22 @@ func sevParameterEnabled(parameter string) bool {
 
 func getCgroupMiscCapacity(resource string) int64 {
 	var totalResources int64 = -1
+	var err error = nil
+	var f *os.File = nil
 
-	miscCgroups := hostpath.SysfsDir.Path("fs/cgroup/misc.capacity")
-	f, err := os.Open(miscCgroups)
+	miscCgroupsPaths := []string{"fs/cgroup/misc.capacity", "fs/cgroup/misc/misc.capacity"}
+	for _, miscCgroupsPath := range miscCgroupsPaths {
+		miscCgroups := hostpath.SysfsDir.Path(miscCgroupsPath)
+		f, err = os.Open(miscCgroups)
+		if err == nil {
+			defer f.Close()
+			break
+		}
+	}
+
 	if err != nil {
 		return totalResources
 	}
-	defer f.Close()
 
 	r := bufio.NewReader(f)
 	for {


### PR DESCRIPTION
We've been only considering cgroupsv2 when trying to read misc.capacity. However, there are still a bunch of systems out there relying on cgroupsv1.