### PR TITLE
docs: fix toc of topology-updater and topology-gc reference

### DIFF
--- a/docs/reference/topology-gc-commandline-reference.md
+++ b/docs/reference/topology-gc-commandline-reference.md
@@ -5,11 +5,9 @@ sort: 7
 ---
 
 # NFD-Topology-Garbage-Collector Commandline Flags
-
 {: .no_toc }
 
 ## Table of Contents
-
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/reference/topology-updater-commandline-reference.md
+++ b/docs/reference/topology-updater-commandline-reference.md
@@ -5,11 +5,9 @@ sort: 5
 ---
 
 # NFD-Topology-Updater Commandline Flags
-
 {: .no_toc }
 
 ## Table of Contents
-
 {: .no_toc .text-delta }
 
 1. TOC


### PR DESCRIPTION
Exclude the main title from to (with the empty line the "no_toc" directive took no effect).