### PR TITLE
docs: remove useless TOCs

### DIFF
--- a/docs/deployment/image-variants.md
+++ b/docs/deployment/image-variants.md
@@ -7,12 +7,6 @@ sort: 1
 # Image variants
 {: .no_toc}
 
-## Table of contents
-{: .no_toc .text-delta}
-
-1. TOC
-{:toc}
-
 ---
 
 NFD currently offers two variants of the container image. The "minimal" variant is

--- a/docs/deployment/uninstallation.md
+++ b/docs/deployment/uninstallation.md
@@ -7,12 +7,6 @@ sort: 6
 # Uninstallation
 {: .no_toc}
 
-## Table of contents
-{: .no_toc .text-delta}
-
-1. TOC
-{:toc}
-
 ---
 
 Follow the uninstallation instructions of the deployment method used

--- a/docs/usage/nfd-worker.md
+++ b/docs/usage/nfd-worker.md
@@ -7,12 +7,6 @@ sort: 4
 # NFD-Worker
 {: .no_toc}
 
-## Table of contents
-{: .no_toc .text-delta}
-
-1. TOC
-{:toc}
-
 ---
 
 NFD-Worker is preferably run as a Kubernetes DaemonSet. This assures


### PR DESCRIPTION
Drop table of contents from short pages where it is only cluttering the page.