### PR TITLE
Add optional labels to the podmonitor

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/prometheus.yaml
+++ b/deployment/helm/node-feature-discovery/templates/prometheus.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "node-feature-discovery.fullname" . }}
   labels:
     {{- include "node-feature-discovery.selectorLabels" . | nindent 4 }}
+    {{- with .Values.prometheus.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   podMetricsEndpoints:
     - honorLabels: true

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -498,3 +498,4 @@ tls:
 
 prometheus:
   enable: false
+  labels: {}

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -103,6 +103,7 @@ We have introduced the following Chart parameters.
 | `tls.certManager` | bool | false | If enabled, requires [cert-manager](https://cert-manager.io/docs/) to be installed and will automatically create the required TLS certificates |
 | `enableNodeFeatureApi` | bool  | false | Enable the [NodeFeature](../usage/custom-resources.md#nodefeature) CRD API for communicating node features. This will automatically disable the gRPC communication.
 | `prometheus.enable` | bool | false | Specifies whether to expose metrics using prometheus operator |
+| `prometheus.labels` | dict | {} | Specifies labels for use with the prometheus operator to control how it is selected |
 
 Metrics are configured to be exposed using prometheus operator API's by
 default. If you want to expose metrics using the prometheus operator

--- a/docs/deployment/metrics.md
+++ b/docs/deployment/metrics.md
@@ -41,3 +41,6 @@ We recommend setting
 `--set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false`
 when deploying prometheus-operator via Helm to enable the prometheus-operator
 to scrape metrics from any PodMonitor.
+
+or setting labels on the PodMonitor via the helm parameter `prometheus.labels`
+to control which Prometheus instances will scrape this PodMonitor.


### PR DESCRIPTION
Prometheus is able to select monitors based on their labels.  This lets you easily set a label for the newly created monitor.