### PR TITLE
Feat: add expiry date for feature files

### DIFF
--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -316,6 +316,14 @@ Label namespace may be specified with `<namespace>/<name>[=<value>]`.
 
 Comment lines (starting with `#`) are ignored.
 
+You can include the following block if you want to define the expiration date 
+of features that are described in the feature files:
+
+```plaintext
+# +expiry-time: 2023-07-29T11:22:33Z
+```
+**Note: The time format that we are supporting is RFC3339.**
+
 ### Mounts
 
 The standard NFD deployments contain `hostPath` mounts for

--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -316,13 +316,37 @@ Label namespace may be specified with `<namespace>/<name>[=<value>]`.
 
 Comment lines (starting with `#`) are ignored.
 
-You can include the following block if you want to define the expiration date 
-of features that are described in the feature files:
+Adding following line anywhere to feature file defines date when
+its content expires / is ignored:
 
 ```plaintext
-# +expiry-time: 2023-07-29T11:22:33Z
+# +expiry-time=2023-07-29T11:22:33Z
 ```
-**Note: The time format that we are supporting is RFC3339.**
+
+Also, the expiry-time value would stay the same during the processing of the
+feature file until another expiry-time directive is encountered.
+Considering the following file:
+
+```plaintext
+# +expiry-time=2012-07-28T11:22:33Z
+featureKey=featureValue
+
+# +expiry-time=2080-07-28T11:22:33Z
+featureKey2=featureValue2
+
+# +expiry-time=2070-07-28T11:22:33Z
+featureKey3=featureValue3
+
+# +expiry-time=2002-07-28T11:22:33Z
+featureKey4=featureValue4
+```
+
+After processing the above file, only `featureKey2` and `featureKey3` would be
+included in the list of accepted features.
+
+> **NOTE:** The time format that we are supporting is RFC3339. Also, the `expiry-time`
+> tag is only evaluated in each re-discovery period, and the expiration of
+> node labels is not tracked.
 
 ### Mounts
 

--- a/source/local/local_test.go
+++ b/source/local/local_test.go
@@ -17,7 +17,11 @@ limitations under the License.
 package local
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -32,4 +36,49 @@ func TestLocalSource(t *testing.T) {
 	assert.Nil(t, err, err)
 	assert.Empty(t, l)
 
+}
+
+func TestGetExpirationDate(t *testing.T) {
+	expectedFeaturesLen := 5
+	pwd, _ := os.Getwd()
+	featureFilesDir = filepath.Join(pwd, "testdata/features.d")
+
+	features, err := getFeaturesFromFiles()
+	fmt.Println(features)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedFeaturesLen, len(features))
+}
+
+func TestParseDirectives(t *testing.T) {
+	testCases := []struct {
+		name      string
+		directive string
+		wantErr   bool
+	}{
+		{
+			name:      "valid directive",
+			directive: "# +expiry-time=2080-07-28T11:22:33Z",
+			wantErr:   false,
+		},
+		{
+			name:      "invalid directive",
+			directive: "# +random-key=random-value",
+			wantErr:   true,
+		},
+		{
+			name:      "invalid directive format",
+			directive: "# + Something",
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsingOpts := parsingOpts{
+				ExpiryTime: time.Now(),
+			}
+			err := parseDirectives(tc.directive, &parsingOpts)
+			assert.Equal(t, err != nil, tc.wantErr)
+		})
+	}
 }

--- a/source/local/testdata/features.d/expired_feature
+++ b/source/local/testdata/features.d/expired_feature
@@ -1,0 +1,2 @@
+# +expiry-time=2012-07-28T11:22:33Z
+featureKeyExpired=featureValue

--- a/source/local/testdata/features.d/feature_with_comments
+++ b/source/local/testdata/features.d/feature_with_comments
@@ -1,0 +1,2 @@
+# Notes: foo bar
+featureKeyRandomComment=featureValue

--- a/source/local/testdata/features.d/multiple_expiration_dates
+++ b/source/local/testdata/features.d/multiple_expiration_dates
@@ -1,0 +1,11 @@
+# +expiry-time=2012-07-28T11:22:33Z
+featureKey=featureValue
+
+# +expiry-time=2080-07-28T11:22:33Z
+featureKey2=featureValue2
+
+# +expiry-time=2070-07-28T11:22:33Z
+featureKey3=featureValue3
+
+# +expiry-time=2002-07-28T11:22:33Z
+featureKey4=featureValue4

--- a/source/local/testdata/features.d/unparsable_expiry_comment
+++ b/source/local/testdata/features.d/unparsable_expiry_comment
@@ -1,0 +1,2 @@
+# +expiry-time=2080-07-28T11:22:33X
+featureKeyUnparsable=featureValue

--- a/source/local/testdata/features.d/valid_feature
+++ b/source/local/testdata/features.d/valid_feature
@@ -1,0 +1,2 @@
+# +expiry-time=2080-07-28T11:22:33Z
+featureKeyValid=featureValue


### PR DESCRIPTION
Resolves #857.

This PR adds the expiration feature of feature files. The implemented solution suggests that the expiration date should follow this format:
```plaintext
# +expiry-time=2023-07-28T11:22:33Z
```