### PR TITLE
metrics: additional metrics for nfd-master

### DIFF
--- a/docs/deployment/metrics.md
+++ b/docs/deployment/metrics.md
@@ -20,6 +20,7 @@ The exposed metrics are
 | `nfd_node_updates_total`                          | Counter   | Number of nodes updated
 | `nfd_node_update_failures_total`                  | Counter   | Number of nodes update failures
 | `nfd_nodefeaturerule_processing_duration_seconds` | Histogram | Time taken to process NodeFeatureRule objects
+| `nfd_nodefeaturerule_processing_errors_total`     | Counter   | Number or errors encountered while processing NodeFeatureRule objects
 | `nfd_feature_discovery_duration_seconds`          | Histogram | Time taken to discover features on a node
 
 ## Via Kustomize

--- a/docs/deployment/metrics.md
+++ b/docs/deployment/metrics.md
@@ -18,6 +18,7 @@ The exposed metrics are
 | `nfd_master_build_info`                           | Gauge     | Version from which nfd-master was built
 | `nfd_worker_build_info`                           | Gauge     | Version from which nfd-worker was built
 | `nfd_node_updates_total`                          | Counter   | Number of nodes updated
+| `nfd_node_update_failures_total`                  | Counter   | Number of nodes update failures
 | `nfd_nodefeaturerule_processing_duration_seconds` | Histogram | Time taken to process NodeFeatureRule objects
 | `nfd_feature_discovery_duration_seconds`          | Histogram | Time taken to discover features on a node
 

--- a/docs/deployment/metrics.md
+++ b/docs/deployment/metrics.md
@@ -19,6 +19,9 @@ The exposed metrics are
 | `nfd_worker_build_info`                           | Gauge     | Version from which nfd-worker was built
 | `nfd_node_updates_total`                          | Counter   | Number of nodes updated
 | `nfd_node_update_failures_total`                  | Counter   | Number of nodes update failures
+| `nfd_node_labels_rejected_total`                  | Counter   | Number of nodes labels rejected by nfd-master
+| `nfd_node_extendedresources_rejected_total`       | Counter   | Number of nodes extended resources rejected by nfd-master
+| `nfd_node_taints_rejected_total`                  | Counter   | Number of nodes taints rejected by nfd-master
 | `nfd_nodefeaturerule_processing_duration_seconds` | Histogram | Time taken to process NodeFeatureRule objects
 | `nfd_nodefeaturerule_processing_errors_total`     | Counter   | Number or errors encountered while processing NodeFeatureRule objects
 | `nfd_feature_discovery_duration_seconds`          | Histogram | Time taken to discover features on a node

--- a/docs/deployment/metrics.md
+++ b/docs/deployment/metrics.md
@@ -17,6 +17,7 @@ The exposed metrics are
 | ------------------------------------------------- | --------- | ---------------------------------------
 | `nfd_master_build_info`                           | Gauge     | Version from which nfd-master was built
 | `nfd_worker_build_info`                           | Gauge     | Version from which nfd-worker was built
+| `nfd_node_update_requests_total`                  | Counter   | Number of node update requests processed by the master
 | `nfd_node_updates_total`                          | Counter   | Number of nodes updated
 | `nfd_node_update_failures_total`                  | Counter   | Number of nodes update failures
 | `nfd_node_labels_rejected_total`                  | Counter   | Number of nodes labels rejected by nfd-master

--- a/pkg/nfd-master/metrics.go
+++ b/pkg/nfd-master/metrics.go
@@ -31,6 +31,9 @@ const (
 	buildInfoQuery           = "nfd_master_build_info"
 	nodeUpdatesQuery         = "nfd_node_updates_total"
 	nodeUpdateFailuresQuery  = "nfd_node_update_failures_total"
+	nodeLabelsRejectedQuery  = "nfd_node_labels_rejected_total"
+	nodeERsRejectedQuery     = "nfd_node_extendedresources_rejected_total"
+	nodeTaintsRejectedQuery  = "nfd_node_taints_rejected_total"
 	nfrProcessingTimeQuery   = "nfd_nodefeaturerule_processing_duration_seconds"
 	nfrProcessingErrorsQuery = "nfd_nodefeaturerule_processing_errors_total"
 )
@@ -52,6 +55,18 @@ var (
 	nodeUpdateFailures = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: nodeUpdateFailuresQuery,
 		Help: "Number of node update failures.",
+	})
+	nodeLabelsRejected = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: nodeLabelsRejectedQuery,
+		Help: "Number of node labels that were rejected by nfd-master.",
+	})
+	nodeERsRejected = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: nodeERsRejectedQuery,
+		Help: "Number of node extended resources that were rejected by nfd-master.",
+	})
+	nodeTaintsRejected = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: nodeTaintsRejectedQuery,
+		Help: "Number of node taints that were rejected by nfd-master.",
 	})
 	nfrProcessingTime = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -78,9 +93,13 @@ func registerVersion(version string) {
 // runMetricsServer starts a http server to expose metrics
 func runMetricsServer(port int) {
 	r := prometheus.NewRegistry()
-	r.MustRegister(buildInfo,
+	r.MustRegister(
+		buildInfo,
 		nodeUpdates,
 		nodeUpdateFailures,
+		nodeLabelsRejected,
+		nodeERsRejected,
+		nodeTaintsRejected,
 		nfrProcessingTime,
 		nfrProcessingErrors)
 

--- a/pkg/nfd-master/metrics.go
+++ b/pkg/nfd-master/metrics.go
@@ -28,9 +28,10 @@ import (
 
 // When adding metric names, see https://prometheus.io/docs/practices/naming/#metric-names
 const (
-	buildInfoQuery         = "nfd_master_build_info"
-	nodeUpdatesQuery       = "nfd_node_updates_total"
-	nfrProcessingTimeQuery = "nfd_nodefeaturerule_processing_duration_seconds"
+	buildInfoQuery          = "nfd_master_build_info"
+	nodeUpdatesQuery        = "nfd_node_updates_total"
+	nodeUpdateFailuresQuery = "nfd_node_update_failures_total"
+	nfrProcessingTimeQuery  = "nfd_nodefeaturerule_processing_duration_seconds"
 )
 
 var (
@@ -46,6 +47,10 @@ var (
 	nodeUpdates = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: nodeUpdatesQuery,
 		Help: "Number of nodes updated by the master.",
+	})
+	nodeUpdateFailures = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: nodeUpdateFailuresQuery,
+		Help: "Number of node update failures.",
 	})
 	nfrProcessingTime = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -70,6 +75,7 @@ func runMetricsServer(port int) {
 	r := prometheus.NewRegistry()
 	r.MustRegister(buildInfo,
 		nodeUpdates,
+		nodeUpdateFailures,
 		nfrProcessingTime)
 
 	mux := http.NewServeMux()

--- a/pkg/nfd-master/metrics.go
+++ b/pkg/nfd-master/metrics.go
@@ -28,10 +28,11 @@ import (
 
 // When adding metric names, see https://prometheus.io/docs/practices/naming/#metric-names
 const (
-	buildInfoQuery          = "nfd_master_build_info"
-	nodeUpdatesQuery        = "nfd_node_updates_total"
-	nodeUpdateFailuresQuery = "nfd_node_update_failures_total"
-	nfrProcessingTimeQuery  = "nfd_nodefeaturerule_processing_duration_seconds"
+	buildInfoQuery           = "nfd_master_build_info"
+	nodeUpdatesQuery         = "nfd_node_updates_total"
+	nodeUpdateFailuresQuery  = "nfd_node_update_failures_total"
+	nfrProcessingTimeQuery   = "nfd_nodefeaturerule_processing_duration_seconds"
+	nfrProcessingErrorsQuery = "nfd_nodefeaturerule_processing_errors_total"
 )
 
 var (
@@ -63,6 +64,10 @@ var (
 			"node",
 		},
 	)
+	nfrProcessingErrors = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: nfrProcessingErrorsQuery,
+		Help: "Number of errors encountered while processing NodeFeatureRule objects.",
+	})
 )
 
 // registerVersion exposes the Operator build version.
@@ -76,7 +81,8 @@ func runMetricsServer(port int) {
 	r.MustRegister(buildInfo,
 		nodeUpdates,
 		nodeUpdateFailures,
-		nfrProcessingTime)
+		nfrProcessingTime,
+		nfrProcessingErrors)
 
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.HandlerFor(r, promhttp.HandlerOpts{}))

--- a/pkg/nfd-master/metrics.go
+++ b/pkg/nfd-master/metrics.go
@@ -29,6 +29,7 @@ import (
 // When adding metric names, see https://prometheus.io/docs/practices/naming/#metric-names
 const (
 	buildInfoQuery           = "nfd_master_build_info"
+	nodeUpdateRequestsQuery  = "nfd_node_update_requests_total"
 	nodeUpdatesQuery         = "nfd_node_updates_total"
 	nodeUpdateFailuresQuery  = "nfd_node_update_failures_total"
 	nodeLabelsRejectedQuery  = "nfd_node_labels_rejected_total"
@@ -47,6 +48,10 @@ var (
 		ConstLabels: map[string]string{
 			"version": version.Get(),
 		},
+	})
+	nodeUpdateRequests = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: nodeUpdateRequestsQuery,
+		Help: "Number of node update requests processed by the master.",
 	})
 	nodeUpdates = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: nodeUpdatesQuery,
@@ -95,6 +100,7 @@ func runMetricsServer(port int) {
 	r := prometheus.NewRegistry()
 	r.MustRegister(
 		buildInfo,
+		nodeUpdateRequests,
 		nodeUpdates,
 		nodeUpdateFailures,
 		nodeLabelsRejected,

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -654,6 +654,7 @@ func isNamespaceDenied(labelNs string, wildcardDeniedNs map[string]struct{}, nor
 
 // SetLabels implements LabelerServer
 func (m *nfdMaster) SetLabels(c context.Context, r *pb.SetLabelsRequest) (*pb.SetLabelsReply, error) {
+	nodeUpdateRequests.Inc()
 	err := authorizeClient(c, m.args.VerifyNodeName, r.NodeName)
 	if err != nil {
 		klog.ErrorS(err, "gRPC client authorization failed", "nodeName", r.NodeName)

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -510,6 +510,7 @@ func (m *nfdMaster) filterFeatureLabels(labels Labels, features *nfdv1alpha1.Fea
 
 		if value, err := m.filterFeatureLabel(name, value, features); err != nil {
 			klog.ErrorS(err, "ignoring label", "labelKey", name, "labelValue", value)
+			nodeLabelsRejected.Inc()
 		} else {
 			outLabels[name] = value
 		}
@@ -523,6 +524,7 @@ func (m *nfdMaster) filterFeatureLabels(labels Labels, features *nfdv1alpha1.Fea
 		if value, ok := outLabels[extendedResourceName]; ok {
 			if _, err := strconv.Atoi(value); err != nil {
 				klog.ErrorS(err, "bad label value encountered for extended resource", "labelKey", extendedResourceName, "labelValue", value)
+				nodeERsRejected.Inc()
 				continue // non-numeric label can't be used
 			}
 
@@ -603,6 +605,7 @@ func filterTaints(taints []corev1.Taint) []corev1.Taint {
 	for _, taint := range taints {
 		if err := filterTaint(&taint); err != nil {
 			klog.ErrorS(err, "ignoring taint", "taint", taint)
+			nodeTaintsRejected.Inc()
 		} else {
 			outTaints = append(outTaints, taint)
 		}
@@ -786,6 +789,7 @@ func filterExtendedResources(features *nfdv1alpha1.Features, extendedResources E
 		capacity, err := filterExtendedResource(name, value, features)
 		if err != nil {
 			klog.ErrorS(err, "failed to create extended resources", "extendedResourceName", name, "extendedResourceValue", value)
+			nodeERsRejected.Inc()
 		} else {
 			outExtendedResources[name] = capacity
 		}

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -991,6 +991,7 @@ func (m *nfdMaster) processNodeFeatureRule(nodeName string, features *nfdv1alpha
 			ruleOut, err := rule.Execute(features)
 			if err != nil {
 				klog.ErrorS(err, "failed to process rule", "ruleName", rule.Name, "nodefeaturerule", klog.KObj(spec), "nodeName", nodeName)
+				nfrProcessingErrors.Inc()
 				continue
 			}
 			taints = append(taints, ruleOut.Taints...)

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -452,6 +452,7 @@ func (m *nfdMaster) prune() error {
 		// Prune labels and extended resources
 		err := m.updateNodeObject(cli, node.Name, Labels{}, Annotations{}, ExtendedResources{}, []corev1.Taint{})
 		if err != nil {
+			nodeUpdateFailures.Inc()
 			return fmt.Errorf("failed to prune node %q: %v", node.Name, err)
 		}
 
@@ -675,6 +676,7 @@ func (m *nfdMaster) SetLabels(c context.Context, r *pb.SetLabelsRequest) (*pb.Se
 
 		// Create labels et al
 		if err := m.refreshNodeFeatures(cli, r.NodeName, annotations, r.GetLabels(), r.GetFeatures()); err != nil {
+			nodeUpdateFailures.Inc()
 			return &pb.SetLabelsReply{}, err
 		}
 	}

--- a/pkg/nfd-master/node-updater-pool.go
+++ b/pkg/nfd-master/node-updater-pool.go
@@ -53,6 +53,7 @@ func (u *nodeUpdaterPool) processNodeUpdateRequest(queue workqueue.RateLimitingI
 			return true
 		} else {
 			klog.ErrorS(err, "failed to update node", "nodeName", nodeName)
+			nodeUpdateFailures.Inc()
 		}
 	}
 	queue.Forget(nodeName)

--- a/pkg/nfd-master/node-updater-pool.go
+++ b/pkg/nfd-master/node-updater-pool.go
@@ -46,6 +46,7 @@ func (u *nodeUpdaterPool) processNodeUpdateRequest(queue workqueue.RateLimitingI
 
 	defer queue.Done(nodeName)
 
+	nodeUpdateRequests.Inc()
 	if err := u.nfdMaster.nfdAPIUpdateOneNode(nodeName.(string)); err != nil {
 		if queue.NumRequeues(nodeName) < 5 {
 			klog.InfoS("retrying node update", "nodeName", nodeName)


### PR DESCRIPTION
Add new metrics for nfd-master for better observability:
- add nfd_node_update_failures_total counter
  Add a new counter for tracking node update failures from nfd-master.
This tracks both normal feature updates and the --prune sub-command.
This is a simple counter without any additional labels - nfd-master logs
can be used for further diagnostics.
- add nfd_nodefeaturerule_processing_errors_total counter
  Add a counter for errors encountered when processing NodeFeatureRules.
Another simple counter without any additional prometheus labels -
nfd-master logs can provide further details.
- counters for rejected labels, extended resources and taints
  Add counters for labels, extended resources and taints rejected/filtered
out by nfd-master.
- add nfd_node_update_requests_total counter
  Add a counter for total number of node update/sync requests. In
practice, this counts the number of gRPC requests received if the gRPC
API is in use. If the NodeFeature API is enabled, this counts the
requests initiated by the NFD API controller, i.e. updates triggered by
changes in NodeFeature or NodeFeatureRule objects plus updates initiated
by the controller resync period.

Fixes #1275 