### PR TITLE
nfd-master: use term node update instead of labeling

### DIFF
--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -821,7 +821,6 @@ func filterExtendedResource(name, value string, features *nfdv1alpha1.Features) 
 }
 
 func (m *nfdMaster) refreshNodeFeatures(cli *kubernetes.Clientset, nodeName string, annotations Annotations, labels map[string]string, features *nfdv1alpha1.Features) error {
-
 	if labels == nil {
 		labels = make(map[string]string)
 	}


### PR DESCRIPTION
Rename symbols and reword log messages to correlate with the
functionality (we may do other updates than just modify labels
nowadays).

This PR also containers a oneliner patch for removing one stale empty line from the codebase.