### PR TITLE
docs: document -metrics flag in command line reference

### DIFF
--- a/docs/reference/master-commandline-reference.md
+++ b/docs/reference/master-commandline-reference.md
@@ -48,6 +48,20 @@ Example:
 nfd-master -port=443
 ```
 
+### -metrics
+
+The `-metrics` flag specifies the port on which to expose
+[Prometheus](https://prometheus.io/) metrics. Setting this to 0 disables the
+metrics server on nfd-master.
+
+Default: 8081
+
+Example:
+
+```bash
+nfd-master -metrics=12345
+```
+
 ### -instance
 
 The `-instance` flag makes it possible to run multiple NFD deployments in

--- a/docs/reference/worker-commandline-reference.md
+++ b/docs/reference/worker-commandline-reference.md
@@ -212,6 +212,20 @@ Example:
 nfd-worker -enable-nodefeature-api
 ```
 
+### -metrics
+
+The `-metrics` flag specifies the port on which to expose
+[Prometheus](https://prometheus.io/) metrics. Setting this to 0 disables the
+metrics server on nfd-worker.
+
+Default: 8081
+
+Example:
+
+```bash
+nfd-worker -metrics=12345
+```
+
 ### -no-publish
 
 The `-no-publish` flag disables all communication with the nfd-master and the


### PR DESCRIPTION
Document the -metrics command line flag in the command line reference of nfd-master and nfd-worker.