### PR TITLE
scripts/test-infra: update logcheck tool to v0.6.0

### DIFF
--- a/scripts/test-infra/verify.sh
+++ b/scripts/test-infra/verify.sh
@@ -17,7 +17,7 @@ curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring 
 curl -Os https://uploader.codecov.io/latest/linux/codecov
 chmod +x codecov
 
-go install sigs.k8s.io/logtools/logcheck@v0.5.0
+go install sigs.k8s.io/logtools/logcheck@v0.6.0
 
 # Run verify steps
 echo "Checking gofmt"


### PR DESCRIPTION
Update logcheck to the latest version. Fixes the flakiness we've been experiencing.

Refs: https://github.com/kubernetes-sigs/logtools/pull/24