### PR TITLE
scripts/test-infra: bump golangci-lint to v1.54.0

### DIFF
--- a/scripts/test-infra/verify.sh
+++ b/scripts/test-infra/verify.sh
@@ -4,7 +4,7 @@ this_dir=`dirname $0`
 
 # Install deps
 gobinpath="$(go env GOPATH)/bin"
-curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b "$gobinpath" v1.52.2
+curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b "$gobinpath" v1.54.0
 export PATH=$PATH:$(go env GOPATH)/bin
 
 curl -sfL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash -s -- --version v3.7.1


### PR DESCRIPTION
Brings e.g. support for Go v1.21.