### PR TITLE
topology-gc: fix Stop

### DIFF
--- a/pkg/nfd-topology-gc/nfd-nrt-gc.go
+++ b/pkg/nfd-topology-gc/nfd-nrt-gc.go
@@ -188,8 +188,5 @@ func (n *topologyGC) Run() error {
 }
 
 func (n *topologyGC) Stop() {
-	select {
-	case n.stopChan <- struct{}{}:
-	default:
-	}
+	close(n.stopChan)
 }


### PR DESCRIPTION
The stop channel has multiple readers to we need to close it so that all of the readers get notified.