### PR TITLE
topology-gc: rename run()

### DIFF
--- a/pkg/nfd-topology-gc/nfd-nrt-gc.go
+++ b/pkg/nfd-topology-gc/nfd-nrt-gc.go
@@ -158,7 +158,7 @@ func (n *topologyGC) periodicGC(gcPeriod time.Duration) {
 	}
 }
 
-func (n *topologyGC) run() error {
+func (n *topologyGC) startNodeInformer() error {
 	nodeInformer := n.factory.Core().V1().Nodes().Informer()
 
 	if _, err := nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -178,7 +178,7 @@ func (n *topologyGC) run() error {
 
 // Run is a blocking function that removes stale NRT objects when Node is deleted and runs periodic GC to make sure any obsolete objects are removed
 func (n *topologyGC) Run() error {
-	if err := n.run(); err != nil {
+	if err := n.startNodeInformer(); err != nil {
 		return err
 	}
 	// run periodic GC

--- a/pkg/nfd-topology-gc/nfd-nrt-gc_test.go
+++ b/pkg/nfd-topology-gc/nfd-nrt-gc_test.go
@@ -51,7 +51,7 @@ func TestNRTGC(t *testing.T) {
 			gcPeriod:   10 * time.Minute,
 		}
 
-		err := gc.run()
+		err := gc.startNodeInformer()
 		So(err, ShouldBeNil)
 
 		nrts, err := fakeClient.TopologyV1alpha2().NodeResourceTopologies().List(context.TODO(), metav1.ListOptions{})
@@ -90,7 +90,7 @@ func TestNRTGC(t *testing.T) {
 			gcPeriod:   10 * time.Minute,
 		}
 
-		err := gc.run()
+		err := gc.startNodeInformer()
 		So(err, ShouldBeNil)
 
 		nrts, err := fakeClient.TopologyV1alpha2().NodeResourceTopologies().List(context.TODO(), metav1.ListOptions{})
@@ -136,7 +136,7 @@ func TestNRTGC(t *testing.T) {
 			gcPeriod:   10 * time.Minute,
 		}
 
-		err := gc.run()
+		err := gc.startNodeInformer()
 		So(err, ShouldBeNil)
 
 		nrts, err := fakeClient.TopologyV1alpha2().NodeResourceTopologies().List(context.TODO(), metav1.ListOptions{})
@@ -197,7 +197,7 @@ func TestNRTGC(t *testing.T) {
 			gcPeriod:   time.Second,
 		}
 
-		err := gc.run()
+		err := gc.startNodeInformer()
 		So(err, ShouldBeNil)
 
 		nrts, err := fakeClient.TopologyV1alpha2().NodeResourceTopologies().List(context.TODO(), metav1.ListOptions{})


### PR DESCRIPTION
Too many run methods here.