### PR TITLE
docs: use ruby docker image for building docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,15 @@ BASE_IMAGE_MINIMAL ?= gcr.io/distroless/base
 # Use host networking because 'jekyll serve' is stupid enough to use the
 # same site url than the "host" it binds to. Thus, all the links will be
 # broken if we'd bind to 0.0.0.0
-JEKYLL_VERSION := 3.8
+RUBY_IMAGE_VERSION := 3.1
 JEKYLL_ENV ?= development
 SITE_BUILD_CMD := $(CONTAINER_RUN_CMD) --rm -i -u "`id -u`:`id -g`" \
+	$(shell [ -t 0 ] && echo '-t') \
 	-e JEKYLL_ENV=$(JEKYLL_ENV) \
-	--volume="$$PWD/docs:/srv/jekyll" \
+	--volume="$$PWD/docs:/work" \
 	--volume="$$PWD/docs/vendor/bundle:/usr/local/bundle" \
-	--network=host jekyll/jekyll:$(JEKYLL_VERSION)
+	-w /work \
+	--network=host ruby:$(RUBY_IMAGE_VERSION)
 SITE_BASEURL ?=
 SITE_DESTDIR ?= _site
 JEKYLL_OPTS := -d '$(SITE_DESTDIR)' $(if $(SITE_BASEURL),-b '$(SITE_BASEURL)',)

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -27,3 +27,5 @@ gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
 # kramdown v2 ships without the gfm parser by default. If you're using
 # kramdown v1, comment out this line.
 #gem "kramdown-parser-gfm"
+
+gem "webrick", "~> 1.8"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,12 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.7.4)
+    activesupport (7.0.7.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     coffee-script (2.4.1)
@@ -212,8 +211,8 @@ GEM
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.19.0)
-    nokogiri (1.13.10)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.15.4)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -253,7 +252,7 @@ GEM
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
     wdm (0.1.1)
-    zeitwerk (2.6.11)
+    webrick (1.8.1)
 
 PLATFORMS
   ruby
@@ -264,6 +263,7 @@ DEPENDENCIES
   tzinfo (~> 2.0)
   tzinfo-data
   wdm (~> 0.1.1)
+  webrick (~> 1.8)
 
 BUNDLED WITH
    2.0.2


### PR DESCRIPTION
Get away with the jekyll:3.8 image which is already four years old.  Use
the ruby instead. The jekyll image did not bring any value (more
problems, if anything) as we install/update jekyll and all other gems
with byndler nevertheless (image was jekyll:3.8 but we use jekyll
v3.9.3).

Also updates docs build dependencies.

Replaces #1316 and #1317