### PR TITLE
Helm: conditionally add annotations if defined

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/master.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master.yaml
@@ -6,8 +6,10 @@ metadata:
   labels:
     {{- include "node-feature-discovery.labels" . | nindent 4 }}
     role: master
+  {{- with .Values.master.deploymentAnnotations }}
   annotations:
-    {{- toYaml .Values.master.deploymentAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.master.replicaCount }}
   selector:
@@ -19,8 +21,10 @@ spec:
       labels:
         {{- include "node-feature-discovery.selectorLabels" . | nindent 8 }}
         role: master
+      {{- with .Values.master.annotations }}
       annotations:
-        {{- toYaml .Values.master.annotations | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deployment/helm/node-feature-discovery/templates/nfd-gc.yaml
+++ b/deployment/helm/node-feature-discovery/templates/nfd-gc.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "node-feature-discovery.labels" . | nindent 4 }}
     role: gc
+  {{- with .Values.gc.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.gc.replicaCount | default 1 }}
   selector:

--- a/deployment/helm/node-feature-discovery/templates/nfd-gc.yaml
+++ b/deployment/helm/node-feature-discovery/templates/nfd-gc.yaml
@@ -18,8 +18,10 @@ spec:
       labels:
         {{- include "node-feature-discovery.selectorLabels" . | nindent 8 }}
         role: gc
+      {{- with .Values.gc.annotations }}
       annotations:
-        {{- toYaml .Values.gc.annotations | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ .Values.gc.serviceAccountName | default "nfd-gc" }}
       dnsPolicy: ClusterFirstWithHostNet

--- a/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
+++ b/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "node-feature-discovery.labels" . | nindent 4 }}
     role: topology-updater
+  {{- with .Values.topologyUpdater.daemonsetAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
+++ b/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
@@ -17,8 +17,10 @@ spec:
       labels:
         {{- include "node-feature-discovery.selectorLabels" . | nindent 8 }}
         role: topology-updater
+      {{- with .Values.topologyUpdater.annotations }}
       annotations:
-        {{- toYaml .Values.topologyUpdater.annotations | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "node-feature-discovery.topologyUpdater.serviceAccountName" . }}
       dnsPolicy: ClusterFirstWithHostNet

--- a/deployment/helm/node-feature-discovery/templates/worker.yaml
+++ b/deployment/helm/node-feature-discovery/templates/worker.yaml
@@ -6,8 +6,10 @@ metadata:
   labels:
     {{- include "node-feature-discovery.labels" . | nindent 4 }}
     role: worker
+  {{- with .Values.worker.daemonsetAnnotations }}
   annotations:
-    {{- toYaml .Values.worker.daemonsetAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -18,8 +20,10 @@ spec:
       labels:
         {{- include "node-feature-discovery.selectorLabels" . | nindent 8 }}
         role: worker
+      {{- with .Values.worker.annotations }}
       annotations:
-        {{- toYaml .Values.worker.annotations | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       dnsPolicy: ClusterFirstWithHostNet
     {{- with .Values.imagePullSecrets }}

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -447,6 +447,7 @@ topologyUpdater:
   nodeSelector: {}
   tolerations: []
   annotations: {}
+  daemonsetAnnotations: {}
   affinity: {}
   podSetFingerprint: true
 
@@ -480,6 +481,7 @@ gc:
   nodeSelector: {}
   tolerations: []
   annotations: {}
+  deploymentAnnotations: {}
   affinity: {}
 
 # Optionally use encryption for worker <--> master comms

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -184,6 +184,7 @@ API's you need to install the prometheus operator in your cluster.
 | `topologyUpdater.nodeSelector`                | dict   | {}                      | Topology updater pod [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)                                                                           |
 | `topologyUpdater.tolerations`                 | dict   | {}                      | Topology updater pod [node tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)                                                                                |
 | `topologyUpdater.annotations`                 | dict   | {}                      | Topology updater pod [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)                                                                                    |
+| `topologyUpdater.daemonsetAnnotations`        | dict   | {}                      | Topology updater daemonset [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)                                                                                    |
 | `topologyUpdater.affinity`                    | dict   | {}                      | Topology updater pod [affinity](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)                                                                      |
 | `topologyUpdater.config`                      | dict   |                         | [configuration](../reference/topology-updater-configuration-reference)                                                                                                                                |
 | `topologyUpdater.podSetFingerprint`           | bool   | false                   | Enables compute and report of pod fingerprint in NRT objects.                                                                                                                                         |
@@ -205,6 +206,7 @@ API's you need to install the prometheus operator in your cluster.
 | `gc.nodeSelector`                     | dict   | {}      | Garbage collector pod [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
 | `gc.tolerations`                      | dict   | {}      | Garbage collector pod [node tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
 | `gc.annotations`                      | dict   | {}      | Garbage collector pod [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+| `gc.deploymentAnnotations`            | dict   | {}      | Garbage collector deployment [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
 | `gc.affinity`                         | dict   | {}      | Garbage collector pod [affinity](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)
 
 <!-- Links -->


### PR DESCRIPTION
With the current implementation, our deployment and daemonset resources are set with an empty set of annotations; versus skipping them like in [other](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/charts/aws-ebs-csi-driver/templates/node.yaml#L24) [helm](https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/charts/aws-efs-csi-driver/templates/controller-deployment.yaml#L26) [charts](https://github.com/kubernetes-sigs/external-dns/blob/master/charts/external-dns/templates/deployment.yaml#L31).

This PR proposes a similar method to the other charts, for consistency with the rest of `kubernetes-sigs`