### PR TITLE
cpu: drop the deprecated sgx and se labels

### DIFF
--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -755,12 +755,8 @@ The following features are available for matching:
 |                  |              | **`sev.enabled`** | bool | `true` if AMD SEV (Secure Encrypted Virtualization) is available on the host and has been enabled, otherwise does not exist
 |                  |              | **`sev.es.enabled`** | bool | `true` if AMD SEV-ES (Encrypted State supported) is available on the host and has been enabled, otherwise does not exist
 |                  |              | **`sev.snp.enabled`** | bool | `true` if AMD SEV-SNP (Secure Nested Paging supported) is available on the host and has been enabled, otherwise does not exist
-| **`cpu.sgx`**    | attribute    |          |            | **DEPRECATED**: replaced by **`cpu.security`** feature
-|                  |              | **`enabled`** | bool  | **DEPRECATED**: use **`sgx.enabled`** from **`cpu.security`** instead
 | **`cpu.sst`**    | attribute    |          |            | Intel SST (Speed Select Technology) capabilities
 |                  |              | **`bf.enabled`** | bool | `true` if Intel SST-BF (Intel Speed Select Technology - Base frequency) has been enabled, otherwise does not exist
-| **`cpu.se`**     | attribute    |          |            | **DEPRECATED**: replaced by **`cpu.security`** feature
-|                  |              | **`enabled`** | bool  | **DEPRECATED**: use **`se.enabled`** from **`cpu.security`** instead
 | **`cpu.topology`** | attribute  |          |            | CPU topology related features
 | | |          **`hardware_multithreading`** | bool       | Hardware multithreading, such as Intel HTT, is enabled
 | **`cpu.coprocessor`** | attribute |        |            | CPU Coprocessor related features

--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -64,8 +64,6 @@ feature.node.kubernetes.io/<feature> = <value>
 | **`cpu-security.sev.snp.enabled`**| true   | Set to 'true' if ADM SEV-SNP is available on the host and has been enabled (requires `/sys/module/kvm_amd/parameters/sev_snp`).
 | **`cpu-security.sex.asids`** | int    | The total amount of AMD SEV address-space identifiers (ASIDs), based on the `/sys/fs/cgroup/misc.capacity` information.
 | **`cpu-security.sex.encrypted_state_ids`** | int    | The total amount of AMD SEV-ES and SEV-SNP supported, based on the `/sys/fs/cgroup/misc.capacity` information.
-| **`cpu-sgx.enabled`**             | true   | **DEPRECATED**: use **`cpu-security.sgx.enabled`** instead.
-| **`cpu-se.enabled`**              | true   | **DEPRECATED**: use **`cpu-security.se.enabled`** instead.
 | **`cpu-model.vendor_id`**         | string | Comparable CPU vendor ID.
 | **`cpu-model.family`**            | int    | CPU family.
 | **`cpu-model.id`**                | int    | CPU model number.

--- a/source/cpu/cpu.go
+++ b/source/cpu/cpu.go
@@ -41,9 +41,7 @@ const (
 	CstateFeature      = "cstate"
 	PstateFeature      = "pstate"
 	RdtFeature         = "rdt"
-	SeFeature          = "se" // DEPRECATED in v0.12: will be removed in the future
 	SecurityFeature    = "security"
-	SgxFeature         = "sgx" // DEPRECATED in v0.12: will be removed in the future
 	SstFeature         = "sst"
 	TopologyFeature    = "topology"
 	CoprocessorFeature = "coprocessor"
@@ -189,16 +187,6 @@ func (s *cpuSource) GetLabels() (source.FeatureLabels, error) {
 		}
 	}
 
-	// SGX
-	for k, v := range features.Attributes[SgxFeature].Elements {
-		labels["sgx."+k] = v
-	}
-
-	// Secure Execution
-	for k, v := range features.Attributes[SeFeature].Elements {
-		labels["se."+k] = v
-	}
-
 	// SST
 	for k, v := range features.Attributes[SstFeature].Elements {
 		labels["power.sst_"+k] = v
@@ -247,20 +235,6 @@ func (s *cpuSource) Discover() error {
 
 	// Detect available guest protection(SGX,TDX,SEV) features
 	s.features.Attributes[SecurityFeature] = nfdv1alpha1.NewAttributeFeatures(discoverSecurity())
-
-	// Detect SGX features
-	//
-	// DEPRECATED in v0.12: will be removed in the future
-	if val, ok := s.features.Attributes[SecurityFeature].Elements["sgx.enabled"]; ok {
-		s.features.Attributes[SgxFeature] = nfdv1alpha1.NewAttributeFeatures(map[string]string{"enabled": val})
-	}
-
-	// Detect Secure Execution features
-	//
-	// DEPRECATED in v0.12: will be removed in the future
-	if val, ok := s.features.Attributes[SecurityFeature].Elements["se.enabled"]; ok {
-		s.features.Attributes[SeFeature] = nfdv1alpha1.NewAttributeFeatures(map[string]string{"enabled": val})
-	}
 
 	// Detect SST features
 	s.features.Attributes[SstFeature] = nfdv1alpha1.NewAttributeFeatures(discoverSST())


### PR DESCRIPTION
Drop the deprecated cpu-sgx.enabled and cpu-se.enabled labels and the corresponding "raw" features. These have been replaced by cpu-security.sgx.enabled and cpu-security.se.enabled.

Fixes: #832 