### PR TITLE
scripts/update-gh-pages: sync OWNERS from master to gh-pages

### DIFF
--- a/scripts/github/update-gh-pages.sh
+++ b/scripts/github/update-gh-pages.sh
@@ -181,6 +181,11 @@ else
     commit_hash=`git describe --tags --dirty --always`
 fi
 
+# Sync OWNERS file from master branch
+if [ "$GITHUB_REF" = "refs/heads/master" ]; then
+    cp OWNERS "$build_dir"/OWNERS
+fi
+
 # Switch to work in the gh-pages worktree
 pushd "$build_dir" > /dev/null
 


### PR DESCRIPTION
The gh-pages branch is normally automatically managed by the GitHub workflow. However, on really rare occasions there may beed to contribute something manually via a PR. Thus, this patch updates the update-gh-pages script to sync the OWNERS from master the gh-pages branch branch, to enable the usual prow-based workflow for PRs in gh-pages branch.