### PR TITLE
github: prevent parallel runs of gh-pages update

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,6 +8,10 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
   release:
     types: [published]
+
+concurrency:
+  group: ${{ github.workflow }}
+
 jobs:
   build:
     name: Update gh-pages


### PR DESCRIPTION
Ensure sequential updates to the gh-pages branch. Otherwise, if parallel jobs are triggered, onnly one (the first to complete) will succeed and the others will fail with git push error (because the tip of the gh-pages has moved and their commit doesn't apply anymore).