### PR TITLE
deployment/helm: fix namespace of nfd-worker role and rolebinding

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/role.yaml
+++ b/deployment/helm/node-feature-discovery/templates/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "node-feature-discovery.fullname" . }}-worker
+  namespace: {{ include "node-feature-discovery.namespace" . }}
   labels:
     {{- include "node-feature-discovery.labels" . | nindent 4 }}
 rules:

--- a/deployment/helm/node-feature-discovery/templates/rolebinding.yaml
+++ b/deployment/helm/node-feature-discovery/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "node-feature-discovery.fullname" . }}-worker
+  namespace: {{ include "node-feature-discovery.namespace" . }}
   labels:
     {{- include "node-feature-discovery.labels" . | nindent 4 }}
 roleRef:


### PR DESCRIPTION
Put nfd-worker role and rolebinding in the correct namespace if namespaceOverride parameter is used.

Fixes: #1363