### PR TITLE
Use the distroless/base-nossl base image for minimal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ IMAGE_PUSH_CMD ?= docker push
 CONTAINER_RUN_CMD ?= docker run
 BUILDER_IMAGE ?= golang:1.20-bullseye
 BASE_IMAGE_FULL ?= debian:bullseye-slim
-BASE_IMAGE_MINIMAL ?= gcr.io/distroless/base
+BASE_IMAGE_MINIMAL ?= gcr.io/distroless/base-nossl
 
 # Docker base command for working with html documentation.
 # Use host networking because 'jekyll serve' is stupid enough to use the


### PR DESCRIPTION
Smaller footprint. We don't need libssl for anything.