### PR TITLE
Build statically linked binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ FROM ${BUILDER_IMAGE} as builder
 
 # Build and install the grpc-health-probe binary
 RUN GRPC_HEALTH_PROBE_VERSION=v0.4.19 && \
-	go install github.com/grpc-ecosystem/grpc-health-probe@${GRPC_HEALTH_PROBE_VERSION} \
+    go install -tags osusergo,netgo -ldflags -extldflags=-static \
+        github.com/grpc-ecosystem/grpc-health-probe@${GRPC_HEALTH_PROBE_VERSION} \
         # Rename it as it's referenced as grpc_health_probe in the deployment yamls
         # and in its own project https://github.com/grpc-ecosystem/grpc-health-probe
         && mv /go/bin/grpc-health-probe /go/bin/grpc_health_probe

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ IMAGE_PUSH_CMD ?= docker push
 CONTAINER_RUN_CMD ?= docker run
 BUILDER_IMAGE ?= golang:1.20-bullseye
 BASE_IMAGE_FULL ?= debian:bullseye-slim
-BASE_IMAGE_MINIMAL ?= gcr.io/distroless/base
+BASE_IMAGE_MINIMAL ?= scratch
 
 # Docker base command for working with html documentation.
 # Use host networking because 'jekyll serve' is stupid enough to use the
@@ -57,7 +57,8 @@ KUBECONFIG ?= ${HOME}/.kube/config
 E2E_TEST_CONFIG ?=
 E2E_PULL_IF_NOT_PRESENT ?= false
 
-LDFLAGS = -ldflags "-s -w -X sigs.k8s.io/node-feature-discovery/pkg/version.version=$(VERSION) -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=$(HOSTMOUNT_PREFIX)"
+BUILD_FLAGS = -tags osusergo,netgo \
+              -ldflags "-s -w -extldflags=-static -X sigs.k8s.io/node-feature-discovery/pkg/version.version=$(VERSION) -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=$(HOSTMOUNT_PREFIX)"
 
 # multi-arch build with buildx
 IMAGE_ALL_PLATFORMS ?= linux/amd64,linux/arm64
@@ -89,10 +90,10 @@ all: image
 
 build:
 	@mkdir -p bin
-	$(GO_CMD) build -v -o bin $(LDFLAGS) ./cmd/...
+	$(GO_CMD) build -v -o bin $(BUILD_FLAGS) ./cmd/...
 
 install:
-	$(GO_CMD) install -v $(LDFLAGS) ./cmd/...
+	$(GO_CMD) install -v $(BUILD_FLAGS) ./cmd/...
 
 image: yamls
 	$(IMAGE_BUILD_CMD) $(IMAGE_BUILD_ARGS) $(IMAGE_BUILD_ARGS_FULL)

--- a/docs/deployment/image-variants.md
+++ b/docs/deployment/image-variants.md
@@ -16,7 +16,7 @@ x86_64 and Arm64 architectures.
 ## Minimal
 
 This is a minimal image based on
-[gcr.io/distroless/base](https://github.com/GoogleContainerTools/distroless/blob/master/base/README.md)
+[scratch](https://hub.docker.com/_/scratch)
 and only supports running statically linked binaries.
 
 For backwards compatibility a container image tag with suffix `-minimal`


### PR DESCRIPTION
Switch to fully statically linked binaries and use scratch as a base image.

Switching to the virtually empty scratch base image means that the default/minimal NFD image only supports running hooks that are truly statically linked (e.g.  normal go binaries that are "almost" statically linked stop working).  The documentation has been already stating this (i.e. that only statically-linked binaries are supported) - i.e. we have had no promise of supporting other than that. Also, hooks are now deprecated and even disabled by default so the possibility of real user impact should be small.