### PR TITLE
nfd-master: fix filtering of extended resources

### DIFF
--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -806,7 +806,7 @@ func filterExtendedResources(features *nfdv1alpha1.Features, extendedResources E
 func filterExtendedResource(name, value string, features *nfdv1alpha1.Features) (string, error) {
 	// Check if given NS is allowed
 	ns, _ := splitNs(name)
-	if ns != nfdv1alpha1.ExtendedResourceNs && !strings.HasPrefix(ns, nfdv1alpha1.ExtendedResourceSubNsSuffix) {
+	if ns != nfdv1alpha1.ExtendedResourceNs && !strings.HasSuffix(ns, nfdv1alpha1.ExtendedResourceSubNsSuffix) {
 		if ns == "kubernetes.io" || strings.HasSuffix(ns, ".kubernetes.io") {
 			return "", fmt.Errorf("namespace %q is not allowed", ns)
 		}

--- a/test/e2e/data/nodefeaturerule-4.yaml
+++ b/test/e2e/data/nodefeaturerule-4.yaml
@@ -23,7 +23,7 @@ spec:
 
     - name: "e2e static rule"
       extendedResources:
-        vendor.io/static: "123"
+        vendor.feature.node.kubernetes.io/static: "123"
       matchFeatures:
 
     - name: "e2e not allowed rule"

--- a/test/e2e/node_feature_discovery_test.go
+++ b/test/e2e/node_feature_discovery_test.go
@@ -771,13 +771,13 @@ core:
 					expectedTaints["*"] = []corev1.Taint{}
 					eventuallyNonControlPlaneNodes(ctx, f.ClientSet).Should(MatchTaints(expectedTaints, nodes, false))
 
-					expectedAnnotations["*"] = k8sAnnotations{"nfd.node.kubernetes.io/extended-resources": "nons,vendor.io/dynamic,vendor.io/static"}
+					expectedAnnotations["*"] = k8sAnnotations{"nfd.node.kubernetes.io/extended-resources": "nons,vendor.feature.node.kubernetes.io/static,vendor.io/dynamic"}
 
 					expectedCapacity := map[string]corev1.ResourceList{
 						"*": {
-							"feature.node.kubernetes.io/nons": resourcev1.MustParse("123"),
-							"vendor.io/dynamic":               resourcev1.MustParse("10"),
-							"vendor.io/static":                resourcev1.MustParse("123"),
+							"feature.node.kubernetes.io/nons":          resourcev1.MustParse("123"),
+							"vendor.io/dynamic":                        resourcev1.MustParse("10"),
+							"vendor.feature.node.kubernetes.io/static": resourcev1.MustParse("123"),
 						},
 					}
 


### PR DESCRIPTION
Fix a bug in checking the allowed ".feature.node.kubernetes.io" ns suffix for extended resources. Also update e2e-tests to cover this case.