### PR TITLE
apis/nfd: drop one stale comment line

### DIFF
--- a/pkg/apis/nfd/v1alpha1/types.go
+++ b/pkg/apis/nfd/v1alpha1/types.go
@@ -202,8 +202,6 @@ type FeatureMatcherTerm struct {
 // evaluated against a set of input values.
 type MatchExpressionSet map[string]*MatchExpression
 
-// Expressions is a helper type to work around issues with k8s deepcopy-gen
-
 // MatchExpression specifies an expression to evaluate against a set of input
 // values. It contains an operator that is applied when matching the input and
 // an array of values that the operator evaluates the input against.


### PR DESCRIPTION
Drop a leftover "docstring" comment that wasn't removed with the type it refers to.