### PR TITLE
Helm - Move remaining gPRC related flags to conditional

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/master.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master.yaml
@@ -69,8 +69,8 @@ spec:
             {{- if .Values.master.instance | empty | not }}
             - "-instance={{ .Values.master.instance }}"
             {{- end }}
-            - "-port={{ .Values.master.port | default "8080" }}"
             {{- if not .Values.enableNodeFeatureApi }}
+            - "-port={{ .Values.master.port | default "8080" }}"
             - "-enable-nodefeature-api=false"
             {{- else if gt (int .Values.master.replicaCount) 1 }}
             - "-enable-leader-election"

--- a/deployment/helm/node-feature-discovery/templates/worker.yaml
+++ b/deployment/helm/node-feature-discovery/templates/worker.yaml
@@ -49,8 +49,8 @@ spec:
         command:
         - "nfd-worker"
         args:
-        - "-server={{ include "node-feature-discovery.fullname" . }}-master:{{ .Values.master.service.port }}"
         {{- if not .Values.enableNodeFeatureApi }}
+        - "-server={{ include "node-feature-discovery.fullname" . }}-master:{{ .Values.master.service.port }}"
         - "-enable-nodefeature-api=false"
         {{- end }}
 {{- if .Values.tls.enable }}

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -45,6 +45,8 @@ master:
     # nfdApiParallelism: 10
   ### <NFD-MASTER-CONF-END-DO-NOT-REMOVE>
   # The TCP port that nfd-master listens for incoming requests. Default: 8080
+  # Deprecated this parameter is related to the deprecated gRPC API and will
+  # be removed with it in a future release  
   port: 8080
   metricsPort: 8081
   instance:


### PR DESCRIPTION
This patch continues to clean up after gRPC deprecation, by moving remaining flags in Helm charts under conditional of enableNodeFeatureAPI being set to false 