### PR TITLE
test/e2e: cleanup feature annotations

### DIFF
--- a/test/e2e/node_feature_discovery_test.go
+++ b/test/e2e/node_feature_discovery_test.go
@@ -66,6 +66,12 @@ func cleanupNode(ctx context.Context, cs clientset.Interface) {
 				nfdLabels[name] = struct{}{}
 			}
 		}
+		nfdAnnotations := map[string]struct{}{}
+		for _, name := range strings.Split(node.Annotations[nfdv1alpha1.FeatureAnnotationsTrackingAnnotation], ",") {
+			if strings.Contains(name, "/") {
+				nfdAnnotations[name] = struct{}{}
+			}
+		}
 		nfdERs := map[string]struct{}{}
 		for _, name := range strings.Split(node.Annotations[nfdv1alpha1.ExtendedResourceAnnotation], ",") {
 			if strings.Contains(name, "/") {
@@ -84,7 +90,8 @@ func cleanupNode(ctx context.Context, cs clientset.Interface) {
 
 		// Remove annotations
 		for key := range node.Annotations {
-			if strings.HasPrefix(key, nfdv1alpha1.AnnotationNs) {
+			_, ok := nfdAnnotations[key]
+			if ok || strings.HasPrefix(key, nfdv1alpha1.AnnotationNs) || strings.HasPrefix(key, nfdv1alpha1.FeatureAnnotationNs) {
 				delete(node.Annotations, key)
 				update = true
 			}


### PR DESCRIPTION
Delete NFD-managed feature annotations at test setup and teardown