### PR TITLE
docs: fix documentation on SEV security features

### DIFF
--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -849,6 +849,8 @@ The following features are available for matching:
 |                  |              | **`sev.enabled`** | bool | `true` if AMD SEV (Secure Encrypted Virtualization) is available on the host and has been enabled, otherwise does not exist |
 |                  |              | **`sev.es.enabled`** | bool | `true` if AMD SEV-ES (Encrypted State supported) is available on the host and has been enabled, otherwise does not exist |
 |                  |              | **`sev.snp.enabled`** | bool | `true` if AMD SEV-SNP (Secure Nested Paging supported) is available on the host and has been enabled, otherwise does not exist |
+|                  |              | **`sev.asids`** | int | The total amount of AMD SEV address-space identifiers (ASIDs), based on the `/sys/fs/cgroup/misc.capacity` information. |
+|                  |              | **`sev.encrypted_state_ids`** | int | The total amount of AMD SEV-ES and SEV-SNP supported, based on the `/sys/fs/cgroup/misc.capacity` information. |
 | **`cpu.sst`**    | attribute    |          |            | Intel SST (Speed Select Technology) capabilities |
 |                  |              | **`bf.enabled`** | bool | `true` if Intel SST-BF (Intel Speed Select Technology - Base frequency) has been enabled, otherwise does not exist |
 | **`cpu.topology`** | attribute  |          |            | CPU topology related features |

--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -62,8 +62,6 @@ feature.node.kubernetes.io/<feature> = <value>
 | **`cpu-security.sev.enabled`**      | true   | Set to 'true' if ADM SEV is available on the host and has been enabled (requires `/sys/module/kvm_amd/parameters/sev`). |
 | **`cpu-security.sev.es.enabled`**   | true   | Set to 'true' if ADM SEV-ES is available on the host and has been enabled (requires `/sys/module/kvm_amd/parameters/sev_es`). |
 | **`cpu-security.sev.snp.enabled`**  | true   | Set to 'true' if ADM SEV-SNP is available on the host and has been enabled (requires `/sys/module/kvm_amd/parameters/sev_snp`). |
-| **`cpu-security.sex.asids`**        | int    | The total amount of AMD SEV address-space identifiers (ASIDs), based on the `/sys/fs/cgroup/misc.capacity` information. |
-| **`cpu-security.sex.encrypted_state_ids`** | int | The total amount of AMD SEV-ES and SEV-SNP supported, based on the `/sys/fs/cgroup/misc.capacity` information. |
 | **`cpu-model.vendor_id`**           | string | Comparable CPU vendor ID. |
 | **`cpu-model.family`**              | int    | CPU family. |
 | **`cpu-model.id`**                  | int    | CPU model number. |


### PR DESCRIPTION
First, fix a typo s/sex/sev/. Second, these features are not advertised as node labels but only as "raw" features available for consumption in NodeFeatureRules.