### PR TITLE
test/e2e: increase timeout for waiting node status

### DIFF
--- a/test/e2e/gomega.go
+++ b/test/e2e/gomega.go
@@ -39,7 +39,7 @@ type k8sAnnotations map[string]string
 func eventuallyNonControlPlaneNodes(ctx context.Context, cli clientset.Interface) AsyncAssertion {
 	return Eventually(func(g Gomega, ctx context.Context) ([]corev1.Node, error) {
 		return getNonControlPlaneNodes(ctx, cli)
-	}).WithPolling(1 * time.Second).WithTimeout(20 * time.Second).WithContext(ctx)
+	}).WithPolling(1 * time.Second).WithTimeout(10 * time.Second).WithContext(ctx)
 }
 
 // MatchLabels returns a specialized Gomega matcher for checking if a list of

--- a/test/e2e/node_feature_discovery_test.go
+++ b/test/e2e/node_feature_discovery_test.go
@@ -799,7 +799,7 @@ core:
 					eventuallyNonControlPlaneNodes(ctx, f.ClientSet).Should(MatchAnnotations(expectedAnnotations, nodes))
 
 					By("Verifying node status capacity from NodeFeatureRules #4")
-					eventuallyNonControlPlaneNodes(ctx, f.ClientSet).Should(MatchCapacity(expectedCapacity, nodes))
+					eventuallyNonControlPlaneNodes(ctx, f.ClientSet).WithTimeout(1 * time.Minute).Should(MatchCapacity(expectedCapacity, nodes))
 
 					By("Deleting NodeFeatureRules #4")
 					err = nfdClient.NfdV1alpha1().NodeFeatureRules().Delete(ctx, "e2e-extened-resource-test", metav1.DeleteOptions{})
@@ -808,7 +808,7 @@ core:
 					By("Verifying node status capacity from NodeFeatureRules #4 was removed")
 					expectedCapacity = map[string]corev1.ResourceList{"*": {}}
 					delete(expectedAnnotations["*"], "nfd.node.kubernetes.io/extended-resources")
-					eventuallyNonControlPlaneNodes(ctx, f.ClientSet).Should(MatchCapacity(expectedCapacity, nodes))
+					eventuallyNonControlPlaneNodes(ctx, f.ClientSet).WithTimeout(1 * time.Minute).Should(MatchCapacity(expectedCapacity, nodes))
 					eventuallyNonControlPlaneNodes(ctx, f.ClientSet).Should(MatchAnnotations(expectedAnnotations, nodes))
 
 					By("Creating NodeFeatureRules #5")


### PR DESCRIPTION
In some occasions the node status (capacity) takes a lot of time to update. Increase the timeout on extended resource tests. Revert the default timeout back to 10s.