### PR TITLE
Option to stop implicitly adding default prefix to names

### DIFF
--- a/deployment/components/master-config/nfd-master.conf.example
+++ b/deployment/components/master-config/nfd-master.conf.example
@@ -1,4 +1,5 @@
 # noPublish: false
+# autoDefaultNs: true
 # extraLabelNs: ["added.ns.io","added.kubernets.io"]
 # denyLabelNs: ["denied.ns.io","denied.kubernetes.io"]
 # resourceLabels: ["vendor-1.com/feature-1","vendor-2.io/feature-2"]

--- a/deployment/components/worker-config/nfd-worker.conf.example
+++ b/deployment/components/worker-config/nfd-worker.conf.example
@@ -82,7 +82,7 @@
 #    # The following feature demonstrates the capabilities of the matchFeatures
 #    - name: "my custom rule"
 #      labels:
-#        my-ng-feature: "true"
+#        "vendor.io/my-ng-feature": "true"
 #      # matchFeatures implements a logical AND over all matcher terms in the
 #      # list (i.e. all of the terms, or per-feature matchers, must match)
 #      matchFeatures:
@@ -153,7 +153,7 @@
 #    # The following feature demonstrates the capabilities of the matchAny
 #    - name: "my matchAny rule"
 #      labels:
-#        my-ng-feature-2: "my-value"
+#        "vendor.io/my-ng-feature-2": "my-value"
 #      # matchAny implements a logical IF over all elements (sub-matchers) in
 #      # the list (i.e. at least one feature matcher must match)
 #      matchAny:
@@ -177,7 +177,7 @@
 #    # The following features demonstreate label templating capabilities
 #    - name: "my template rule"
 #      labelsTemplate: |
-#        {{ range .system.osrelease }}my-system-feature.{{ .Name }}={{ .Value }}
+#        {{ range .system.osrelease }}vendor.io/my-system-feature.{{ .Name }}={{ .Value }}
 #        {{ end }}
 #      matchFeatures:
 #        - feature: system.osrelease
@@ -187,7 +187,7 @@
 #
 #    - name: "my template rule 2"
 #      labelsTemplate: |
-#        {{ range .pci.device }}my-pci-device.{{ .class }}-{{ .device }}=with-cpuid
+#        {{ range .pci.device }}vendor.io/my-pci-device.{{ .class }}-{{ .device }}=with-cpuid
 #        {{ end }}
 #      matchFeatures:
 #        - feature: pci.device
@@ -202,7 +202,7 @@
 #    # previous labels and vars
 #    - name: "my dummy kernel rule"
 #      labels:
-#        "my.kernel.feature": "true"
+#        "vendor.io/my.kernel.feature": "true"
 #      matchFeatures:
 #        - feature: kernel.version
 #          matchExpressions:
@@ -217,10 +217,10 @@
 #
 #    - name: "my rule using backrefs"
 #      labels:
-#        "my.backref.feature": "true"
+#        "vendor.io/my.backref.feature": "true"
 #      matchFeatures:
 #        - feature: rule.matched
 #          matchExpressions:
-#            my.kernel.feature: {op: IsTrue}
+#            vendor.io/my.kernel.feature: {op: IsTrue}
 #            my.dummy.var: {op: Gt, value: ["0"]}
 #

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -16,6 +16,7 @@ master:
   enable: true
   config: ### <NFD-MASTER-CONF-START-DO-NOT-REMOVE>
     # noPublish: false
+    # autoDefaultNs: true
     # extraLabelNs: ["added.ns.io","added.kubernets.io"]
     # denyLabelNs: ["denied.ns.io","denied.kubernetes.io"]
     # resourceLabels: ["vendor-1.com/feature-1","vendor-2.io/feature-2"]
@@ -219,7 +220,7 @@ worker:
     #    # The following feature demonstrates the capabilities of the matchFeatures
     #    - name: "my custom rule"
     #      labels:
-    #        my-ng-feature: "true"
+    #        "vendor.io/my-ng-feature": "true"
     #      # matchFeatures implements a logical AND over all matcher terms in the
     #      # list (i.e. all of the terms, or per-feature matchers, must match)
     #      matchFeatures:
@@ -290,7 +291,7 @@ worker:
     #    # The following feature demonstrates the capabilities of the matchAny
     #    - name: "my matchAny rule"
     #      labels:
-    #        my-ng-feature-2: "my-value"
+    #        "vendor.io/my-ng-feature-2": "my-value"
     #      # matchAny implements a logical IF over all elements (sub-matchers) in
     #      # the list (i.e. at least one feature matcher must match)
     #      matchAny:
@@ -314,7 +315,7 @@ worker:
     #    # The following features demonstreate label templating capabilities
     #    - name: "my template rule"
     #      labelsTemplate: |
-    #        {{ range .system.osrelease }}my-system-feature.{{ .Name }}={{ .Value }}
+    #        {{ range .system.osrelease }}vendor.io/my-system-feature.{{ .Name }}={{ .Value }}
     #        {{ end }}
     #      matchFeatures:
     #        - feature: system.osrelease
@@ -324,7 +325,7 @@ worker:
     #
     #    - name: "my template rule 2"
     #      labelsTemplate: |
-    #        {{ range .pci.device }}my-pci-device.{{ .class }}-{{ .device }}=with-cpuid
+    #        {{ range .pci.device }}vendor.io/my-pci-device.{{ .class }}-{{ .device }}=with-cpuid
     #        {{ end }}
     #      matchFeatures:
     #        - feature: pci.device
@@ -339,7 +340,7 @@ worker:
     #    # previous labels and vars
     #    - name: "my dummy kernel rule"
     #      labels:
-    #        "my.kernel.feature": "true"
+    #        "vendor.io/my.kernel.feature": "true"
     #      matchFeatures:
     #        - feature: kernel.version
     #          matchExpressions:
@@ -354,11 +355,11 @@ worker:
     #
     #    - name: "my rule using backrefs"
     #      labels:
-    #        "my.backref.feature": "true"
+    #        "vendor.io/my.backref.feature": "true"
     #      matchFeatures:
     #        - feature: rule.matched
     #          matchExpressions:
-    #            my.kernel.feature: {op: IsTrue}
+    #            vendor.io/my.kernel.feature: {op: IsTrue}
     #            my.dummy.var: {op: Gt, value: ["0"]}
     #
 ### <NFD-WORKER-CONF-END-DO-NOT-REMOVE>

--- a/docs/reference/master-configuration-reference.md
+++ b/docs/reference/master-configuration-reference.md
@@ -70,6 +70,38 @@ Example:
 denyLabelNs: ["denied.ns.io","denied.kubernetes.io"]
 ```
 
+## autoDefaultNs
+
+The `autoDefaultNs` option controls the automatic prefixing of names. When set
+to true (the default in {{ site.version }}) nfd-master automatically adds the
+default `feature.node.kubernetes.io/` prefix to unprefixed labels, annotations
+and extended resources - this is also the default behavior in NFD v0.13 and
+earlier. When the option is set to `false`, no prefix will be prepended to
+unprefixed names, effectively causing them to be filtered out (as NFD does not
+currently allow unprefixed names of labels, annotations or extended resources).
+The default will be changed to `false` in a future release.
+
+For example, with the `autoDefaultNs` set to `true`, a NodeFeatureRule with
+
+```yaml
+  labels:
+    foo: bar
+```
+
+Will turn into `feature.node.kubernetes.io/foo=bar` node label. With
+`autoDefaultNs` set to `false`, no prefix is added and the label will be
+filtered out.
+
+Note that taint keys are not affected by this option.
+
+Default: `true`
+
+Example:
+
+```yaml
+autoDefaultNs: false
+```
+
 ## resourceLabels
 
 **DEPRECATED**: [NodeFeatureRule](../usage/custom-resources.md#nodefeaturerule)

--- a/examples/nodefeaturerule.yaml
+++ b/examples/nodefeaturerule.yaml
@@ -6,7 +6,7 @@ spec:
   rules:
     - name: "my sample rule"
       labels:
-        "my-sample-feature": "true"
+        "vendor.io/my-sample-feature": "true"
       matchFeatures:
         - feature: kernel.loadedmodule
           matchExpressions:

--- a/pkg/nfd-worker/nfd-worker-internal_test.go
+++ b/pkg/nfd-worker/nfd-worker-internal_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/vektra/errors"
 
+	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/pkg/apis/nfd/v1alpha1"
 	"sigs.k8s.io/node-feature-discovery/pkg/labeler"
 	"sigs.k8s.io/node-feature-discovery/pkg/utils"
 	"sigs.k8s.io/node-feature-discovery/source"
@@ -84,7 +85,7 @@ func makeFakeFeatures(names []string) (source.FeatureLabels, Labels) {
 	labels := Labels{}
 	for _, f := range names {
 		features[f] = true
-		labelName := fakeLabelSourceName + "-" + f
+		labelName := nfdv1alpha1.FeatureLabelNs + "/" + fakeLabelSourceName + "-" + f
 		if strings.IndexByte(f, '/') >= 0 {
 			labelName = f
 		}
@@ -352,9 +353,9 @@ func TestCreateFeatureLabels(t *testing.T) {
 
 			Convey("Proper fake labels are returned", func() {
 				So(len(labels), ShouldEqual, 3)
-				So(labels, ShouldContainKey, "fake-fakefeature1")
-				So(labels, ShouldContainKey, "fake-fakefeature2")
-				So(labels, ShouldContainKey, "fake-fakefeature3")
+				So(labels, ShouldContainKey, nfdv1alpha1.FeatureLabelNs+"/"+"fake-fakefeature1")
+				So(labels, ShouldContainKey, nfdv1alpha1.FeatureLabelNs+"/"+"fake-fakefeature2")
+				So(labels, ShouldContainKey, nfdv1alpha1.FeatureLabelNs+"/"+"fake-fakefeature3")
 			})
 		})
 		Convey("When fake feature source is configured with a whitelist that doesn't match", func() {


### PR DESCRIPTION
Add new `autoDefaultNs` (default is `true`) config option to nfd-master.
Setting the config option to false stops NFD from automatically adding
the `feature.node.kubernetes.io` prefix to labels, annotations and
extended resources. Taints are not affected as for them no prefix is
automatically added. The user-visible part of enabling the option change
is that NodeFeatureRules, local feature files, hooks and configuration
of the "custom" may need to be altereda (if the auto-prefixing is
relied on).

For now, the config option defaults to `true`, meaning no change in
default behavior. However, the intent is to change the default to
`false` in a future release, deprecating the option and eventually
removing it (forcing it to `false`).

The goal of stopping doing "auto-prefixing" is to simplify the operation
(of nfd and users). Make the naming more straightforward and easier to
understand and debug (kind of WYSIWYG), eliminating peculiar corner
cases:

1. Make validation simpler and unambiguous
2. Remove "overloading" of names, i.e. the mapping two values to the
   same actual name. E.g. previously something like
    ```yaml
      labels:
        feature.node.kubernetes.io/foo: bar
        foo: baz
    ```
   Could actually result in node label:
    ```
     feature.node.kubernetes.io/foo: baz
    ```
3. Make the processing/usagee of the `rule.matched` and `local.labels`
   feature in NodeFeatureRules unambiguous and more understadable. E.g.
   previously you could have node label
   `feature.node.kubernetes.io/local-foo: bar` but in the NodeFeatureRule
   you'd need to use the unprefixed name `local-foo` or the fully
   prefixed name, depending on what was specified in the feature file (or
   hook) on the node(s).

> NOTE: setting autoDefaultNs to false is a breaking change for users who
> rely on automatic prefixing with the default `feature.node.kubernetes.io/`
> namespace. NodeFeatureRules, feature files, hooks and custom rules
> (configuration of the "custom" source of nfd-worker) will need to be
> altered.  Unprefixed labels, annoations and extended resources will be
> denied by nfd-master.