### PR TITLE
Reproducible output from expression matching

### DIFF
--- a/pkg/apis/nfd/v1alpha1/expression.go
+++ b/pkg/apis/nfd/v1alpha1/expression.go
@@ -308,6 +308,8 @@ func (m *MatchExpressionSet) MatchGetKeys(keys map[string]Nil) (bool, []MatchedE
 		}
 		ret = append(ret, MatchedElement{"Name": n})
 	}
+	// Sort for reproducible output
+	sort.Slice(ret, func(i, j int) bool { return ret[i]["Name"] < ret[j]["Name"] })
 	return true, ret, nil
 }
 
@@ -333,6 +335,8 @@ func (m *MatchExpressionSet) MatchGetValues(values map[string]string) (bool, []M
 		}
 		ret = append(ret, MatchedElement{"Name": n, "Value": values[n]})
 	}
+	// Sort for reproducible output
+	sort.Slice(ret, func(i, j int) bool { return ret[i]["Name"] < ret[j]["Name"] })
 	return true, ret, nil
 }
 


### PR DESCRIPTION
Fix flakyness of unit tests by adding back the sorting of matched feature elements that was unadvisedly removed in
63c22551df210143c8297f96c65afbafbea8f049. This might help debugging some corner cases in real-life scenarios (when using templating), too.