### PR TITLE
apis/nfd: drop creation helper functions

### DIFF
--- a/deployment/base/nfd-crds/nfd-api-crds.yaml
+++ b/deployment/base/nfd-crds/nfd-api-crds.yaml
@@ -193,16 +193,11 @@ spec:
                                   type: string
                                 matchExpressions:
                                   additionalProperties:
-                                    description: "MatchExpression specifies an expression
+                                    description: MatchExpression specifies an expression
                                       to evaluate against a set of input values. It
                                       contains an operator that is applied when matching
                                       the input and an array of values that the operator
-                                      evaluates the input against. \n NB: CreateMatchExpression
-                                      or MustCreateMatchExpression() should be used
-                                      for creating new instances. \n NB: Validate()
-                                      must be called if Op or Value fields are modified
-                                      or if a new instance is created from scratch
-                                      without using the helper functions."
+                                      evaluates the input against.
                                     properties:
                                       op:
                                         description: Op is the operator to be applied.
@@ -259,15 +254,11 @@ spec:
                             type: string
                           matchExpressions:
                             additionalProperties:
-                              description: "MatchExpression specifies an expression
+                              description: MatchExpression specifies an expression
                                 to evaluate against a set of input values. It contains
                                 an operator that is applied when matching the input
                                 and an array of values that the operator evaluates
-                                the input against. \n NB: CreateMatchExpression or
-                                MustCreateMatchExpression() should be used for creating
-                                new instances. \n NB: Validate() must be called if
-                                Op or Value fields are modified or if a new instance
-                                is created from scratch without using the helper functions."
+                                the input against.
                               properties:
                                 op:
                                   description: Op is the operator to be applied.

--- a/deployment/helm/node-feature-discovery/crds/nfd-api-crds.yaml
+++ b/deployment/helm/node-feature-discovery/crds/nfd-api-crds.yaml
@@ -193,16 +193,11 @@ spec:
                                   type: string
                                 matchExpressions:
                                   additionalProperties:
-                                    description: "MatchExpression specifies an expression
+                                    description: MatchExpression specifies an expression
                                       to evaluate against a set of input values. It
                                       contains an operator that is applied when matching
                                       the input and an array of values that the operator
-                                      evaluates the input against. \n NB: CreateMatchExpression
-                                      or MustCreateMatchExpression() should be used
-                                      for creating new instances. \n NB: Validate()
-                                      must be called if Op or Value fields are modified
-                                      or if a new instance is created from scratch
-                                      without using the helper functions."
+                                      evaluates the input against.
                                     properties:
                                       op:
                                         description: Op is the operator to be applied.
@@ -259,15 +254,11 @@ spec:
                             type: string
                           matchExpressions:
                             additionalProperties:
-                              description: "MatchExpression specifies an expression
+                              description: MatchExpression specifies an expression
                                 to evaluate against a set of input values. It contains
                                 an operator that is applied when matching the input
                                 and an array of values that the operator evaluates
-                                the input against. \n NB: CreateMatchExpression or
-                                MustCreateMatchExpression() should be used for creating
-                                new instances. \n NB: Validate() must be called if
-                                Op or Value fields are modified or if a new instance
-                                is created from scratch without using the helper functions."
+                                the input against.
                               properties:
                                 op:
                                   description: Op is the operator to be applied.

--- a/pkg/apis/nfd/v1alpha1/expression.go
+++ b/pkg/apis/nfd/v1alpha1/expression.go
@@ -42,23 +42,6 @@ var matchOps = map[MatchOp]struct{}{
 	MatchIsFalse:      {},
 }
 
-// CreateMatchExpression creates a new MatchExpression instance. Returns an
-// error if validation fails.
-func CreateMatchExpression(op MatchOp, values ...string) (*MatchExpression, error) {
-	m := newMatchExpression(op, values...)
-	return m, m.Validate()
-}
-
-// MustCreateMatchExpression creates a new MatchExpression instance. Panics if
-// validation fails.
-func MustCreateMatchExpression(op MatchOp, values ...string) *MatchExpression {
-	m, err := CreateMatchExpression(op, values...)
-	if err != nil {
-		panic(err)
-	}
-	return m
-}
-
 // newMatchExpression returns a new MatchExpression instance.
 func newMatchExpression(op MatchOp, values ...string) *MatchExpression {
 	return &MatchExpression{

--- a/pkg/apis/nfd/v1alpha1/expression_test.go
+++ b/pkg/apis/nfd/v1alpha1/expression_test.go
@@ -29,7 +29,7 @@ type BoolAssertionFunc func(assert.TestingT, bool, ...interface{}) bool
 
 type ValueAssertionFunc func(assert.TestingT, interface{}, ...interface{}) bool
 
-func TestCreateMatchExpression(t *testing.T) {
+func TestMatchExpressionValidate(t *testing.T) {
 	type V = api.MatchValue
 	type TC struct {
 		name   string
@@ -89,7 +89,8 @@ func TestCreateMatchExpression(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := api.CreateMatchExpression(tc.op, tc.values...)
+			me := api.MatchExpression{Op: tc.op, Value: tc.values}
+			err := me.Validate()
 			tc.err(t, err)
 		})
 	}
@@ -157,7 +158,7 @@ func TestMatch(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			me := api.MustCreateMatchExpression(tc.op, tc.values...)
+			me := api.MatchExpression{Op: tc.op, Value: tc.values}
 			res, err := me.Match(tc.valid, tc.input)
 			tc.result(t, res)
 			assert.Nil(t, err)
@@ -251,7 +252,7 @@ func TestMatchKeys(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			me := api.MustCreateMatchExpression(tc.op, tc.values...)
+			me := api.MatchExpression{Op: tc.op, Value: tc.values}
 			res, err := me.MatchKeys(tc.key, tc.input)
 			tc.result(t, res)
 			tc.err(t, err)
@@ -320,7 +321,7 @@ func TestMatchValues(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			me := api.MustCreateMatchExpression(tc.op, tc.values...)
+			me := api.MatchExpression{Op: tc.op, Value: tc.values}
 			res, err := me.MatchValues(tc.key, tc.input)
 			tc.result(t, res)
 			tc.err(t, err)

--- a/pkg/apis/nfd/v1alpha1/rule_test.go
+++ b/pkg/apis/nfd/v1alpha1/rule_test.go
@@ -32,7 +32,7 @@ func TestRule(t *testing.T) {
 			FeatureMatcherTerm{
 				Feature: "domain-1.kf-1",
 				MatchExpressions: MatchExpressionSet{
-					"key-1": MustCreateMatchExpression(MatchExists),
+					"key-1": newMatchExpression(MatchExists),
 				},
 			},
 		},
@@ -109,7 +109,7 @@ func TestRule(t *testing.T) {
 			FeatureMatcherTerm{
 				Feature: "domain-1.vf-1",
 				MatchExpressions: MatchExpressionSet{
-					"key-1": MustCreateMatchExpression(MatchIn, "val-1"),
+					"key-1": newMatchExpression(MatchIn, "val-1"),
 				},
 			},
 		},
@@ -130,7 +130,7 @@ func TestRule(t *testing.T) {
 			FeatureMatcherTerm{
 				Feature: "domain-1.if-1",
 				MatchExpressions: MatchExpressionSet{
-					"attr-1": MustCreateMatchExpression(MatchIn, "val-1"),
+					"attr-1": newMatchExpression(MatchIn, "val-1"),
 				},
 			},
 		},
@@ -151,13 +151,13 @@ func TestRule(t *testing.T) {
 			FeatureMatcherTerm{
 				Feature: "domain-1.vf-1",
 				MatchExpressions: MatchExpressionSet{
-					"key-1": MustCreateMatchExpression(MatchIn, "val-x"),
+					"key-1": newMatchExpression(MatchIn, "val-x"),
 				},
 			},
 			FeatureMatcherTerm{
 				Feature: "domain-1.if-1",
 				MatchExpressions: MatchExpressionSet{
-					"attr-1": MustCreateMatchExpression(MatchIn, "val-1"),
+					"attr-1": newMatchExpression(MatchIn, "val-1"),
 				},
 			},
 		},
@@ -166,7 +166,7 @@ func TestRule(t *testing.T) {
 	assert.Nilf(t, err, "unexpected error: %v", err)
 	assert.Nil(t, m.Labels, "instances should not have matched")
 
-	r5.MatchFeatures[0].MatchExpressions["key-1"] = MustCreateMatchExpression(MatchIn, "val-1")
+	r5.MatchFeatures[0].MatchExpressions["key-1"] = newMatchExpression(MatchIn, "val-1")
 	m, err = r5.Execute(f)
 	assert.Nilf(t, err, "unexpected error: %v", err)
 	assert.Equal(t, r5.Labels, m.Labels, "instances should have matched")
@@ -178,7 +178,7 @@ func TestRule(t *testing.T) {
 				FeatureMatcherTerm{
 					Feature: "domain-1.kf-1",
 					MatchExpressions: MatchExpressionSet{
-						"key-na": MustCreateMatchExpression(MatchExists),
+						"key-na": newMatchExpression(MatchExists),
 					},
 				},
 			},
@@ -194,12 +194,12 @@ func TestRule(t *testing.T) {
 				FeatureMatcherTerm{
 					Feature: "domain-1.kf-1",
 					MatchExpressions: MatchExpressionSet{
-						"key-1": MustCreateMatchExpression(MatchExists),
+						"key-1": newMatchExpression(MatchExists),
 					},
 				},
 			},
 		})
-	r5.MatchFeatures[0].MatchExpressions["key-1"] = MustCreateMatchExpression(MatchIn, "val-1")
+	r5.MatchFeatures[0].MatchExpressions["key-1"] = newMatchExpression(MatchIn, "val-1")
 	m, err = r5.Execute(f)
 	assert.Nilf(t, err, "unexpected error: %v", err)
 	assert.Equal(t, r5.Labels, m.Labels, "instances should have matched")
@@ -279,30 +279,30 @@ var-2=
 			FeatureMatcherTerm{
 				Feature: "domain_1.kf_1",
 				MatchExpressions: MatchExpressionSet{
-					"key-a": MustCreateMatchExpression(MatchExists),
-					"key-c": MustCreateMatchExpression(MatchExists),
-					"foo":   MustCreateMatchExpression(MatchDoesNotExist),
+					"key-a": newMatchExpression(MatchExists),
+					"key-c": newMatchExpression(MatchExists),
+					"foo":   newMatchExpression(MatchDoesNotExist),
 				},
 			},
 			FeatureMatcherTerm{
 				Feature: "domain_1.vf_1",
 				MatchExpressions: MatchExpressionSet{
-					"key-1": MustCreateMatchExpression(MatchIn, "val-1", "val-2"),
-					"bar":   MustCreateMatchExpression(MatchDoesNotExist),
+					"key-1": newMatchExpression(MatchIn, "val-1", "val-2"),
+					"bar":   newMatchExpression(MatchDoesNotExist),
 				},
 			},
 			FeatureMatcherTerm{
 				Feature: "domain_1.if_1",
 				MatchExpressions: MatchExpressionSet{
-					"attr-1": MustCreateMatchExpression(MatchLt, "100"),
+					"attr-1": newMatchExpression(MatchLt, "100"),
 				},
 			},
 			FeatureMatcherTerm{
 				Feature: "domain_1.if_1",
 				MatchExpressions: MatchExpressionSet{
-					"attr-1": MustCreateMatchExpression(MatchExists),
-					"attr-2": MustCreateMatchExpression(MatchExists),
-					"attr-3": MustCreateMatchExpression(MatchExists),
+					"attr-1": newMatchExpression(MatchExists),
+					"attr-2": newMatchExpression(MatchExists),
+					"attr-3": newMatchExpression(MatchExists),
 				},
 			},
 		},
@@ -357,7 +357,7 @@ var-2=
 			FeatureMatcherTerm{
 				Feature: "domain_1.kf_1",
 				MatchExpressions: MatchExpressionSet{
-					"key-a": MustCreateMatchExpression(MatchExists),
+					"key-a": newMatchExpression(MatchExists),
 				},
 			},
 		},

--- a/pkg/apis/nfd/v1alpha1/types.go
+++ b/pkg/apis/nfd/v1alpha1/types.go
@@ -209,12 +209,6 @@ type MatchExpressionSet map[string]*MatchExpression
 // MatchExpression specifies an expression to evaluate against a set of input
 // values. It contains an operator that is applied when matching the input and
 // an array of values that the operator evaluates the input against.
-//
-// NB: CreateMatchExpression or MustCreateMatchExpression() should be used for
-// creating new instances.
-//
-// NB: Validate() must be called if Op or Value fields are modified or if a new
-// instance is created from scratch without using the helper functions.
 type MatchExpression struct {
 	// Op is the operator to be applied.
 	Op MatchOp `json:"op"`

--- a/source/custom/static_features.go
+++ b/source/custom/static_features.go
@@ -32,7 +32,9 @@ func getStaticFeatureConfig() []CustomRule {
 					nfdv1alpha1.FeatureMatcherTerm{
 						Feature: "pci.device",
 						MatchExpressions: nfdv1alpha1.MatchExpressionSet{
-							"vendor": nfdv1alpha1.MustCreateMatchExpression(nfdv1alpha1.MatchIn, "15b3"),
+							"vendor": &nfdv1alpha1.MatchExpression{
+								Op:    nfdv1alpha1.MatchIn,
+								Value: nfdv1alpha1.MatchValue{"15b3"}},
 						},
 					},
 				},
@@ -46,8 +48,12 @@ func getStaticFeatureConfig() []CustomRule {
 					nfdv1alpha1.FeatureMatcherTerm{
 						Feature: "kernel.loadedmodule",
 						MatchExpressions: nfdv1alpha1.MatchExpressionSet{
-							"ib_uverbs": nfdv1alpha1.MustCreateMatchExpression(nfdv1alpha1.MatchExists),
-							"rdma_ucm":  nfdv1alpha1.MustCreateMatchExpression(nfdv1alpha1.MatchExists),
+							"ib_uverbs": &nfdv1alpha1.MatchExpression{
+								Op: nfdv1alpha1.MatchExists,
+							},
+							"rdma_ucm": &nfdv1alpha1.MatchExpression{
+								Op: nfdv1alpha1.MatchExists,
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Drop the creation helper functions as one step in an effort to tidy up the api package. These functions were not much used outside unit tests anyway, the static rules of the nfd-worker custom feature source being the only exception (and if those happened to be invalid we'd catch that e.g. in the e2e-tests).