### PR TITLE
docs: remove outdated instructions for minimal image

### DIFF
--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -49,13 +49,6 @@ helm install node-feature-discovery ./node-feature-discovery/ --namespace $NFD_N
 See the [configuration](#configuration) section below for instructions how to
 alter the deployment parameters.
 
-To deploy the [minimal](image-variants.md#minimal) image you need to
-override the image tag:
-
-```bash
-helm install node-feature-discovery ./node-feature-discovery/ --set image.tag={{ site.release }}-minimal --namespace $NFD_NS --create-namespace
-```
-
 ## Configuration
 
 You can override values from `values.yaml` and provide a file with custom values:

--- a/docs/deployment/kustomize.md
+++ b/docs/deployment/kustomize.md
@@ -37,9 +37,8 @@ nfd-worker (as daemonset) in the `node-feature-discovery` namespace.
 > and [Topologyupdater](#topologyupdater) below.
 
 Alternatively you can clone the repository and customize the deployment by
-creating your own overlays. For example, to deploy the
-[minimal](image-variants.md#minimal) image. See [kustomize][kustomize] for more
-information about managing deployment configurations.
+creating your own overlays. See [kustomize][kustomize] for more information
+about managing deployment configurations.
 
 ## Overlays
 

--- a/docs/deployment/operator.md
+++ b/docs/deployment/operator.md
@@ -59,14 +59,6 @@ is recommended to be done via
    EOF
    ```
 
-To deploy the [minimal](image-variants.md#minimal) image you need to use
-
-```yaml
-  image: {{ site.container_image }}-minimal
-```
-
-in the `NodeFeatureDiscovery` object above.
-
 ## Uninstallation
 
 If you followed the deployment instructions above you can uninstall NFD with:


### PR DESCRIPTION
The "minimal" image variant has been the default since v0.13.