### PR TITLE
Change label system-os_release.VERSION_ID to system-os_release.VERSION_ID.full

### DIFF
--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -227,7 +227,7 @@ instructions.
 | Feature                                 | Value  | Description                                                 |
 | --------------------------------------- | ------ | ----------------------------------------------------------- |
 | **`system-os_release.ID`**              | string | Operating system identifier                                  |
-| **`system-os_release.VERSION_ID`**      | string | Operating system version identifier (e.g. '6.7')            |
+| **`system-os_release.VERSION_ID.full`** | string | Operating system version identifier (e.g. '6.7')            |
 | **`system-os_release.VERSION_ID.major`**| string | First component of the OS version id (e.g. '6')             |
 | **`system-os_release.VERSION_ID.minor`**| string | Second component of the OS version id (e.g. '7')            |
 

--- a/source/system/system.go
+++ b/source/system/system.go
@@ -91,7 +91,8 @@ func (s *systemSource) Discover() error {
 	} else {
 		s.features.Attributes[OsReleaseFeature] = nfdv1alpha1.NewAttributeFeatures(release)
 
-		if v, ok := release["VERSION_ID.full"]; ok {
+		if v, ok := release["VERSION_ID"]; ok {
+			release["VERSION_ID.full"] = release["VERSION_ID"]
 			versionComponents := splitVersion(v)
 			for subKey, subValue := range versionComponents {
 				if subValue != "" {

--- a/source/system/system.go
+++ b/source/system/system.go
@@ -32,7 +32,7 @@ import (
 
 var osReleaseFields = [...]string{
 	"ID",
-	"VERSION_ID",
+	"VERSION_ID.full",
 	"VERSION_ID.major",
 	"VERSION_ID.minor",
 }
@@ -91,7 +91,7 @@ func (s *systemSource) Discover() error {
 	} else {
 		s.features.Attributes[OsReleaseFeature] = nfdv1alpha1.NewAttributeFeatures(release)
 
-		if v, ok := release["VERSION_ID"]; ok {
+		if v, ok := release["VERSION_ID.full"]; ok {
 			versionComponents := splitVersion(v)
 			for subKey, subValue := range versionComponents {
 				if subValue != "" {

--- a/test/e2e/e2e-test-config.example.yaml
+++ b/test/e2e/e2e-test-config.example.yaml
@@ -69,7 +69,7 @@ defaultFeatures:
     - "feature.node.kubernetes.io/pci-0300_1a03.present"
     - "feature.node.kubernetes.io/storage-nonrotationaldisk"
     - "feature.node.kubernetes.io/system-os_release.ID"
-    - "feature.node.kubernetes.io/system-os_release.VERSION_ID"
+    - "feature.node.kubernetes.io/system-os_release.VERSION_ID.full"
     - "feature.node.kubernetes.io/system-os_release.VERSION_ID.major"
     - "feature.node.kubernetes.io/system-os_release.VERSION_ID.minor"
   annotationWhitelist:
@@ -105,7 +105,7 @@ defaultFeatures:
         - "feature.node.kubernetes.io/kernel-version.major"
         - "feature.node.kubernetes.io/kernel-version.minor"
         - "feature.node.kubernetes.io/kernel-version.revision"
-        - "feature.node.kubernetes.io/system-os_release.VERSION_ID"
+        - "feature.node.kubernetes.io/system-os_release.VERSION_ID.full"
         - "feature.node.kubernetes.io/system-os_release.VERSION_ID.minor"
       expectedAnnotationKeys:
         - "nfd.node.kubernetes.io/worker.version"


### PR DESCRIPTION
In this PR, I changed the label name from `feature.node.kubernetes.io/system-os_release.VERSION_ID` to `feature.node.kubernetes.io/system-os_release.VERSION_ID.full`.

The issue arises from the fact that I am collecting logs from the pods to Elasticsearch. When gathering meta-information about the pod, all node labels are also collected. As a result, the following labels are gathered:
```
"feature.node.kubernetes.io/system-os_release.VERSION_ID": "22.04",
"feature.node.kubernetes.io/system-os_release.VERSION_ID.major": "22",
"feature.node.kubernetes.io/system-os_release.VERSION_ID.minor": "04"
```

However, attempting to write this information to the Elasticsearch index will result in an error because the field `feature.node.kubernetes.io/system-os_release.VERSION_ID` simultaneously serves as a string with the value `22.04` and as an object with nested `major` and `minor` fields. Elasticsearch will reject such logs with a mapping error.

To fix this issue, I changed the label name from `feature.node.kubernetes.io/system-os_release.VERSION_ID` to `feature.node.kubernetes.io/system-os_release.VERSION_ID.full` (similar to what is done, for example, in the kernel source).



P.S. I build and test it in my K8s:
```bash
$ kubectl get no -o json | jq '.items[].metadata.labels' | grep "system-os_release"
  "feature.node.kubernetes.io/system-os_release.ID": "ubuntu",
  "feature.node.kubernetes.io/system-os_release.VERSION_ID.full": "22.04",
  "feature.node.kubernetes.io/system-os_release.VERSION_ID.major": "22",
  "feature.node.kubernetes.io/system-os_release.VERSION_ID.minor": "04",
  ...
```