### PR TITLE
Use non-exp maps package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/stretchr/testify v1.8.4
 	github.com/vektra/errors v0.0.0-20140903201135-c64d83aba85a
-	golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb
 	golang.org/x/net v0.19.0
 	golang.org/x/time v0.5.0
 	google.golang.org/grpc v1.59.0
@@ -164,6 +163,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.16.0 // indirect
+	golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/oauth2 v0.14.0 // indirect
 	golang.org/x/sync v0.5.0 // indirect

--- a/test/e2e/gomega.go
+++ b/test/e2e/gomega.go
@@ -19,12 +19,12 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
-	"golang.org/x/exp/maps"
 	taintutils "k8s.io/kubernetes/pkg/util/taints"
 
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
The maps package became available as a standard non-experimental package in Go 1.21.