### PR TITLE
chore(nfd-worker): fix minor typo in wrong label value format error

### DIFF
--- a/pkg/nfd-worker/nfd-worker.go
+++ b/pkg/nfd-worker/nfd-worker.go
@@ -604,7 +604,7 @@ func getFeatureLabels(source source.LabelSource, labelWhiteList regexp.Regexp) (
 		// Validate label value
 		errs = validation.IsValidLabelValue(value)
 		if len(errs) > 0 {
-			klog.InfoS("ignoring label with invalide value", "labelKey", name, "labelValue", value, "errors", errs)
+			klog.InfoS("ignoring label with invalid value", "labelKey", name, "labelValue", value, "errors", errs)
 			continue
 		}
 


### PR DESCRIPTION
Address the following warning error message:

> I1218 10:06:33.826912       1 nfd-worker.go:626] "ignoring label with invalide value" labelKey="nvidia.com/gpu.machine" labelValue="..." errors=["a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')"]