### PR TITLE
Makefile: add -timeout argument to e2e-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,24 +194,24 @@ test:
 
 e2e-test:
 	@if [ -z ${KUBECONFIG} ]; then echo "[ERR] KUBECONFIG missing, must be defined"; exit 1; fi
-	$(GO_CMD) test -v ./test/e2e/ -args -nfd.repo=$(IMAGE_REPO) -nfd.tag=$(IMAGE_TAG_NAME) \
+	$(GO_CMD) test -timeout=1h -v ./test/e2e/ -args \
+	    -nfd.repo=$(IMAGE_REPO) -nfd.tag=$(IMAGE_TAG_NAME) \
 	    -kubeconfig=$(KUBECONFIG) \
 	    -nfd.e2e-config=$(E2E_TEST_CONFIG) \
 	    -nfd.pull-if-not-present=$(E2E_PULL_IF_NOT_PRESENT) \
 	    -ginkgo.focus="\[k8s-sigs\/node-feature-discovery\]" \
 	    -ginkgo.label-filter=$(E2E_GINKGO_LABEL_FILTER) \
 	    -ginkgo.v \
-	    -test.timeout=1h \
 	    $(if $(OPENSHIFT),-nfd.openshift,)
 	if [ "$(E2E_TEST_FULL_IMAGE)" = "true" ]; then \
-	    $(GO_CMD) test -v ./test/e2e/ -args -nfd.repo=$(IMAGE_REPO) -nfd.tag=$(IMAGE_TAG_NAME)-full \
+	    $(GO_CMD) test -timeout=1h -v ./test/e2e/ -args \
+	        -nfd.repo=$(IMAGE_REPO) -nfd.tag=$(IMAGE_TAG_NAME)-full \
 	        -kubeconfig=$(KUBECONFIG) \
 	        -nfd.e2e-config=$(E2E_TEST_CONFIG) \
 	        -nfd.pull-if-not-present=$(E2E_PULL_IF_NOT_PRESENT) \
 	        -ginkgo.focus="\[k8s-sigs\/node-feature-discovery\]" \
 	        -ginkgo.label-filter=$(E2E_GINKGO_LABEL_FILTER) \
 	        -ginkgo.v \
-	        -test.timeout=1h \
 	        $(if $(OPENSHIFT),-nfd.openshift,); \
 	fi
 


### PR DESCRIPTION
Fixes recently experienced timeouts in e2e-tests. For some reason -test.timeout was not enough (anymore).