### PR TITLE
helm: add post-delete hook that cleans up the node

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/post-delete-job.yaml
+++ b/deployment/helm/node-feature-discovery/templates/post-delete-job.yaml
@@ -1,0 +1,94 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "node-feature-discovery.master.serviceAccountName" . }}-prune
+  namespace: {{ include "node-feature-discovery.namespace" . }}
+  labels:
+    {{- include "node-feature-discovery.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "node-feature-discovery.fullname" . }}-prune
+  labels:
+    {{- include "node-feature-discovery.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - nodes/status
+  verbs:
+  - get
+  - patch
+  - update
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "node-feature-discovery.fullname" . }}-prune
+  labels:
+    {{- include "node-feature-discovery.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "node-feature-discovery.fullname" . }}-prune
+subjects:
+- kind: ServiceAccount
+  name: {{ include "node-feature-discovery.fullname" . }}-prune
+  namespace: {{ include "node-feature-discovery.namespace" .  }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name:  {{ include "node-feature-discovery.fullname" . }}-prune
+  namespace: {{ include "node-feature-discovery.namespace" . }}
+  labels:
+    {{- include "node-feature-discovery.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "node-feature-discovery.labels" . | nindent 8 }}
+        role: prune
+    spec:
+      serviceAccountName: {{ include "node-feature-discovery.fullname" . }}-prune
+      containers:
+        - name: nfd-master
+          securityContext:
+            {{- toYaml .Values.master.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - "nfd-master"
+          args:
+            - "-prune"
+            {{- if .Values.master.instance | empty | not }}
+            - "-instance={{ .Values.master.instance }}"
+            {{- end }}
+      restartPolicy: Never
+      {{- with .Values.master.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.master.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.master.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -75,7 +75,9 @@ helm uninstall node-feature-discovery --namespace $NFD_NS
 ```
 
 The command removes all the Kubernetes components associated with the chart and
-deletes the release.
+deletes the release. It also runs a post-delete hook that cleans up the nodes
+of all labels, annotations, taints and extended resources that were created by
+NFD.
 
 ## Chart parameters
 

--- a/docs/deployment/uninstallation.md
+++ b/docs/deployment/uninstallation.md
@@ -16,6 +16,9 @@ Follow the uninstallation instructions of the deployment method used
 
 ## Removing feature labels
 
+> **NOTE:** This is unnecessary when using the Helm chart for deployment as it
+> will clean up the nodes when NFD is uninstalled.
+
 NFD-Master has a special `-prune` command line flag for removing all
 nfd-related node labels, annotations, extended resources and taints from the
 cluster.


### PR DESCRIPTION
This patch adds a post-delete hook to the Helm chart that runs "nfd-master --prune" in the cluster. This cleans up the node of labels, annotations, taints and extended resources that were created by NFD.