### PR TITLE
topology-updater: initialize properly with -no-publish

### DIFF
--- a/pkg/nfd-topology-updater/nfd-topology-updater.go
+++ b/pkg/nfd-topology-updater/nfd-topology-updater.go
@@ -131,13 +131,12 @@ func (w *nfdTopologyUpdater) Run() error {
 		return fmt.Errorf("failed to get PodResource Client: %w", err)
 	}
 
-	if !w.args.NoPublish {
-		kubeconfig, err := apihelper.GetKubeconfig(w.args.KubeConfigFile)
-		if err != nil {
-			return err
-		}
-		w.apihelper = apihelper.K8sHelpers{Kubeconfig: kubeconfig}
+	kubeconfig, err := apihelper.GetKubeconfig(w.args.KubeConfigFile)
+	if err != nil {
+		return err
 	}
+	w.apihelper = apihelper.K8sHelpers{Kubeconfig: kubeconfig}
+
 	if err := w.configure(); err != nil {
 		return fmt.Errorf("faild to configure Node Feature Discovery Topology Updater: %w", err)
 	}


### PR DESCRIPTION
We need to parse kubeconfig (and initialize the apihelper) even with -no-publish as the PodResourcesScanner accesses the k8s API even if we're not publishing/updating NRTs.