### PR TITLE
Prevent `nfd-worker` erroring when reading attributes from paravirtual devices

### DIFF
--- a/source/network/network.go
+++ b/source/network/network.go
@@ -148,7 +148,7 @@ func readIfaceInfo(path string, attrFiles []string) nfdv1alpha1.InstanceFeature 
 	for _, attrFile := range attrFiles {
 		data, err := os.ReadFile(filepath.Join(path, attrFile))
 		if err != nil {
-			if !os.IsNotExist(err) {
+			if !os.IsNotExist(err) && !strings.Contains(err.Error(), "invalid argument") {
 				klog.ErrorS(err, "failed to read net iface attribute", "attributeName", attrFile)
 			}
 			continue


### PR DESCRIPTION
PR for issue described here: https://github.com/kubernetes-sigs/node-feature-discovery/issues/1556