### PR TITLE
pkg/utils: move GetKubeconfig from pkg/apihelper here

### DIFF
--- a/pkg/apihelper/k8shelpers.go
+++ b/pkg/apihelper/k8shelpers.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	k8sclient "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // K8sHelpers implements APIHelpers
@@ -109,12 +108,4 @@ func (h K8sHelpers) GetPod(cli *k8sclient.Clientset, namespace string, podName s
 	}
 
 	return pod, nil
-}
-
-// GetKubeconfig returns the kubeconfig for the cluster
-func GetKubeconfig(path string) (*restclient.Config, error) {
-	if path == "" {
-		return restclient.InClusterConfig()
-	}
-	return clientcmd.BuildConfigFromFlags("", path)
 }

--- a/pkg/nfd-gc/nfd-gc.go
+++ b/pkg/nfd-gc/nfd-gc.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
-	"sigs.k8s.io/node-feature-discovery/pkg/apihelper"
 	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/pkg/apis/nfd/v1alpha1"
 	nfdclientset "sigs.k8s.io/node-feature-discovery/pkg/generated/clientset/versioned"
 	"sigs.k8s.io/node-feature-discovery/pkg/utils"
@@ -59,7 +58,7 @@ type nfdGarbageCollector struct {
 }
 
 func New(args *Args) (NfdGarbageCollector, error) {
-	kubeconfig, err := apihelper.GetKubeconfig(args.Kubeconfig)
+	kubeconfig, err := utils.GetKubeconfig(args.Kubeconfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -1140,7 +1140,7 @@ func (m *nfdMaster) updateNodeObject(cli *kubernetes.Clientset, nodeName string,
 func (m *nfdMaster) getKubeconfig() (*restclient.Config, error) {
 	var err error
 	if m.kubeconfig == nil {
-		m.kubeconfig, err = apihelper.GetKubeconfig(m.args.Kubeconfig)
+		m.kubeconfig, err = utils.GetKubeconfig(m.args.Kubeconfig)
 	}
 	return m.kubeconfig, err
 }

--- a/pkg/nfd-topology-updater/nfd-topology-updater.go
+++ b/pkg/nfd-topology-updater/nfd-topology-updater.go
@@ -131,7 +131,7 @@ func (w *nfdTopologyUpdater) Run() error {
 		return fmt.Errorf("failed to get PodResource Client: %w", err)
 	}
 
-	kubeconfig, err := apihelper.GetKubeconfig(w.args.KubeConfigFile)
+	kubeconfig, err := utils.GetKubeconfig(w.args.KubeConfigFile)
 	if err != nil {
 		return err
 	}

--- a/pkg/nfd-worker/nfd-worker.go
+++ b/pkg/nfd-worker/nfd-worker.go
@@ -42,7 +42,6 @@ import (
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/node-feature-discovery/pkg/apihelper"
 	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/pkg/apis/nfd/v1alpha1"
 	nfdclient "sigs.k8s.io/node-feature-discovery/pkg/generated/clientset/versioned"
 	pb "sigs.k8s.io/node-feature-discovery/pkg/labeler"
@@ -747,7 +746,7 @@ func (m *nfdWorker) getNfdClient() (*nfdclient.Clientset, error) {
 		return m.nfdClient, nil
 	}
 
-	kubeconfig, err := apihelper.GetKubeconfig(m.args.Kubeconfig)
+	kubeconfig, err := utils.GetKubeconfig(m.args.Kubeconfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -19,6 +19,9 @@ package utils
 import (
 	"os"
 	"strings"
+
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var nodeName string
@@ -42,4 +45,12 @@ func GetKubernetesNamespace() string {
 		}
 	}
 	return os.Getenv("KUBERNETES_NAMESPACE")
+}
+
+// GetKubeconfig returns the kubeconfig for the cluster
+func GetKubeconfig(path string) (*restclient.Config, error) {
+	if path == "" {
+		return restclient.InClusterConfig()
+	}
+	return clientcmd.BuildConfigFromFlags("", path)
 }


### PR DESCRIPTION
This change is part of an effort to remove the pkg/apihelper package. GetKubeconfig is useful helper functionality shared accross the codebase so move it into a "safe" location.

Split out from #1561 