### PR TITLE
deployment/helm: don't deploy topology-updater conf unnecessarily

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/nfd-topologyupdater-conf.yaml
+++ b/deployment/helm/node-feature-discovery/templates/nfd-topologyupdater-conf.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.topologyUpdater.enable -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,3 +9,4 @@ metadata:
 data:
   nfd-topology-updater.conf: |-
     {{- .Values.topologyUpdater.config | toYaml | nindent 4 }}
+{{- end }}


### PR DESCRIPTION
Only deploy the topology-updater config if topology-updater itself (the daemon) is deployed.