### PR TITLE
topology-updater: get topology api client directly

### DIFF
--- a/pkg/nfd-topology-updater/nfd-topology-updater.go
+++ b/pkg/nfd-topology-updater/nfd-topology-updater.go
@@ -30,6 +30,7 @@ import (
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 
 	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+	topologyclientset "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned"
 	"sigs.k8s.io/node-feature-discovery/pkg/apihelper"
 	"sigs.k8s.io/node-feature-discovery/pkg/nfd-topology-updater/kubeletnotifier"
 	"sigs.k8s.io/node-feature-discovery/pkg/podres"
@@ -74,6 +75,7 @@ type nfdTopologyUpdater struct {
 	nodeName            string
 	args                Args
 	apihelper           apihelper.APIHelpers
+	topoClient          topologyclientset.Interface
 	resourcemonitorArgs resourcemonitor.Args
 	stop                chan struct{} // channel for signaling stop
 	eventSource         <-chan kubeletnotifier.Info
@@ -136,6 +138,11 @@ func (w *nfdTopologyUpdater) Run() error {
 		return err
 	}
 	w.apihelper = apihelper.K8sHelpers{Kubeconfig: kubeconfig}
+	topoClient, err := topologyclientset.NewForConfig(kubeconfig)
+	if err != nil {
+		return nil
+	}
+	w.topoClient = topoClient
 
 	if err := w.configure(); err != nil {
 		return fmt.Errorf("faild to configure Node Feature Discovery Topology Updater: %w", err)
@@ -215,12 +222,7 @@ func (w *nfdTopologyUpdater) Stop() {
 }
 
 func (w *nfdTopologyUpdater) updateNodeResourceTopology(zoneInfo v1alpha2.ZoneList, scanResponse resourcemonitor.ScanResponse, readKubeletConfig bool) error {
-	cli, err := w.apihelper.GetTopologyClient()
-	if err != nil {
-		return err
-	}
-
-	nrt, err := cli.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), w.nodeName, metav1.GetOptions{})
+	nrt, err := w.topoClient.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), w.nodeName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		nrtNew := v1alpha2.NodeResourceTopology{
 			ObjectMeta: metav1.ObjectMeta{
@@ -236,7 +238,7 @@ func (w *nfdTopologyUpdater) updateNodeResourceTopology(zoneInfo v1alpha2.ZoneLi
 
 		updateAttributes(&nrtNew.Attributes, scanResponse.Attributes)
 
-		if _, err := cli.TopologyV1alpha2().NodeResourceTopologies().Create(context.TODO(), &nrtNew, metav1.CreateOptions{}); err != nil {
+		if _, err := w.topoClient.TopologyV1alpha2().NodeResourceTopologies().Create(context.TODO(), &nrtNew, metav1.CreateOptions{}); err != nil {
 			return fmt.Errorf("failed to create NodeResourceTopology: %w", err)
 		}
 		return nil
@@ -257,7 +259,7 @@ func (w *nfdTopologyUpdater) updateNodeResourceTopology(zoneInfo v1alpha2.ZoneLi
 
 	updateAttributes(&nrtMutated.Attributes, attributes)
 
-	nrtUpdated, err := cli.TopologyV1alpha2().NodeResourceTopologies().Update(context.TODO(), nrtMutated, metav1.UpdateOptions{})
+	nrtUpdated, err := w.topoClient.TopologyV1alpha2().NodeResourceTopologies().Update(context.TODO(), nrtMutated, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to update NodeResourceTopology: %w", err)
 	}


### PR DESCRIPTION
Stop using apihelper for getting the noderesourcetopology-api client.

Next separate, self-contained step of dropping the apihelper package (i.e. this PR is part of #1561).