### PR TITLE
nfd-master: ditch apihelper

### DIFF
--- a/pkg/nfd-master/node-updater-pool_test.go
+++ b/pkg/nfd-master/node-updater-pool_test.go
@@ -22,14 +22,11 @@ import (
 	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
-	"github.com/stretchr/testify/mock"
-	k8sclient "k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/node-feature-discovery/pkg/apihelper"
-	"sigs.k8s.io/node-feature-discovery/pkg/generated/clientset/versioned/fake"
-	"sigs.k8s.io/node-feature-discovery/pkg/utils"
+	fakek8sclient "k8s.io/client-go/kubernetes/fake"
+	fakenfdclient "sigs.k8s.io/node-feature-discovery/pkg/generated/clientset/versioned/fake"
 )
 
-func newMockNodeUpdaterPool(nfdMaster *nfdMaster) *nodeUpdaterPool {
+func newFakeNodeUpdaterPool(nfdMaster *nfdMaster) *nodeUpdaterPool {
 	return &nodeUpdaterPool{
 		nfdMaster: nfdMaster,
 		wg:        sync.WaitGroup{},
@@ -37,65 +34,53 @@ func newMockNodeUpdaterPool(nfdMaster *nfdMaster) *nodeUpdaterPool {
 }
 
 func TestNodeUpdaterStart(t *testing.T) {
-	mockHelper := &apihelper.MockAPIHelpers{}
-	mockMaster := newMockMaster(mockHelper)
-	mockNodeUpdaterPool := newMockNodeUpdaterPool(mockMaster)
+	fakeMaster := newFakeMaster(nil)
+	nodeUpdaterPool := newFakeNodeUpdaterPool(fakeMaster)
 
 	Convey("When starting the node updater pool", t, func() {
-		mockNodeUpdaterPool.start(10)
-		q := mockNodeUpdaterPool.queue
+		nodeUpdaterPool.start(10)
+		q := nodeUpdaterPool.queue
 		Convey("Node updater pool queue properties should change", func() {
 			So(q, ShouldNotBeNil)
 			So(q.ShuttingDown(), ShouldBeFalse)
 		})
 
-		mockNodeUpdaterPool.start(10)
+		nodeUpdaterPool.start(10)
 		Convey("Node updater pool queue should not change", func() {
-			So(mockNodeUpdaterPool.queue, ShouldEqual, q)
+			So(nodeUpdaterPool.queue, ShouldEqual, q)
 		})
 	})
 }
 
 func TestNodeUpdaterStop(t *testing.T) {
-	mockHelper := &apihelper.MockAPIHelpers{}
-	mockMaster := newMockMaster(mockHelper)
-	mockNodeUpdaterPool := newMockNodeUpdaterPool(mockMaster)
+	fakeMaster := newFakeMaster(nil)
+	nodeUpdaterPool := newFakeNodeUpdaterPool(fakeMaster)
 
-	mockNodeUpdaterPool.start(10)
+	nodeUpdaterPool.start(10)
 
 	Convey("When stoping the node updater pool", t, func() {
-		mockNodeUpdaterPool.stop()
+		nodeUpdaterPool.stop()
 		Convey("Node updater pool queue should be removed", func() {
 			// Wait for the wg.Done()
 			So(func() interface{} {
-				return mockNodeUpdaterPool.queue.ShuttingDown()
+				return nodeUpdaterPool.queue.ShuttingDown()
 			}, withTimeout, 2*time.Second, ShouldBeTrue)
 		})
 	})
 }
 
 func TestRunNodeUpdater(t *testing.T) {
-	mockAPIHelper := &apihelper.MockAPIHelpers{}
-	mockMaster := newMockMaster(mockAPIHelper)
-	mockMaster.nfdController = newMockNfdAPIController(fake.NewSimpleClientset())
-	mockClient := &k8sclient.Clientset{}
-	mockNode := newMockNode()
-	mockNodeUpdaterPool := newMockNodeUpdaterPool(mockMaster)
-	statusPatches := []utils.JsonPatch{}
-	metadataPatches := []utils.JsonPatch{}
+	fakeMaster := newFakeMaster(fakek8sclient.NewSimpleClientset())
+	fakeMaster.nfdController = newFakeNfdAPIController(fakenfdclient.NewSimpleClientset())
+	nodeUpdaterPool := newFakeNodeUpdaterPool(fakeMaster)
 
-	mockAPIHelper.On("GetClient").Return(mockClient, nil)
-	mockAPIHelper.On("GetNode", mockClient, mockNodeName).Return(mockNode, nil)
-	mockAPIHelper.On("PatchNodeStatus", mockClient, mockNodeName, mock.MatchedBy(jsonPatchMatcher(statusPatches))).Return(nil)
-	mockAPIHelper.On("PatchNode", mockClient, mockNodeName, mock.MatchedBy(jsonPatchMatcher(metadataPatches))).Return(nil)
-
-	mockNodeUpdaterPool.start(10)
+	nodeUpdaterPool.start(10)
 	Convey("Queue has no element", t, func() {
-		So(mockNodeUpdaterPool.queue.Len(), ShouldEqual, 0)
+		So(nodeUpdaterPool.queue.Len(), ShouldEqual, 0)
 	})
-	mockNodeUpdaterPool.queue.Add(mockNodeName)
+	nodeUpdaterPool.queue.Add(testNodeName)
 	Convey("Added element to the queue should be removed", t, func() {
-		So(func() interface{} { return mockNodeUpdaterPool.queue.Len() },
+		So(func() interface{} { return nodeUpdaterPool.queue.Len() },
 			withTimeout, 2*time.Second, ShouldEqual, 0)
 	})
 }


### PR DESCRIPTION
Implement some of frequently used helper functions inpackage.

This patch also contains big changes to the nfd-master unit tests. Much of this is about migrating from the mocked apihelper interface to fake kubernetes client that provides a bit more apiserver'ish functionality. At the same time there is quite a bit of renaming in the tests, shortening and unifying naming and getting rid of the extensive usage of "mock" everywhere.

This is the last self-contained piece to split out from #1561