### PR TITLE
nfd-master: fix node status patching

### DIFF
--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -1419,7 +1419,7 @@ func (m *nfdMaster) patchNode(nodeName string, patches []utils.JsonPatch, subres
 	}
 	data, err := json.Marshal(patches)
 	if err == nil {
-		_, err = m.k8sClient.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.JSONPatchType, data, metav1.PatchOptions{})
+		_, err = m.k8sClient.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.JSONPatchType, data, metav1.PatchOptions{}, subresources...)
 	}
 	return err
 }


### PR DESCRIPTION
Correctly patch the "status" subresource. This got broken when refactoring the code in 7a050e7cf9c2e8f21c2f3ddda0a9745a45de472c and wasn't even catched by the unit tests as the fake kubernetes client doesn't handle subresources as the real apiserver does.