### PR TITLE
fix hook issue

### DIFF
--- a/source/local/local.go
+++ b/source/local/local.go
@@ -164,7 +164,7 @@ func (s *localSource) Discover() error {
 			if old, ok := labelsFromFiles[k]; ok {
 				klog.InfoS("overriding label value", "labelKey", k, "oldValue", old, "newValue", v)
 			}
-			labelsFromHooks[k] = v
+			labelsFromFiles[k] = v
 		}
 	}
 


### PR DESCRIPTION
Fix issue: https://github.com/kubernetes-sigs/node-feature-discovery/issues/1603

Root cause:
In the following code block, NFD wants to merge `labelsFromHooks` to `labelsFromFiles`, but in it uses `labelsFromHooks` incorrectly in Line 167
https://github.com/kubernetes-sigs/node-feature-discovery/blob/b984db0a163af61240d5dbd0913fc137e5d1ecfa/source/local/local.go#L162-L168