### PR TITLE
nfd-master: mark the -crd-controller flag as deprecated

### DIFF
--- a/cmd/nfd-master/main.go
+++ b/cmd/nfd-master/main.go
@@ -55,6 +55,8 @@ func main() {
 		switch f.Name {
 		case "featurerules-controller":
 			klog.InfoS("-featurerules-controller is deprecated, use '-crd-controller' flag instead")
+		case "crd-controller":
+			klog.InfoS("-crd-controller is deprecated, will be removed in a future release along with the deprecated gRPC API")
 		case "extra-label-ns":
 			args.Overrides.ExtraLabelNs = overrides.ExtraLabelNs
 		case "deny-label-ns":
@@ -138,7 +140,8 @@ func initFlags(flagset *flag.FlagSet) (*master.Args, *master.ConfigOverrideArgs)
 	flagset.BoolVar(&args.CrdController, "featurerules-controller", true,
 		"Enable NFD CRD API controller. DEPRECATED: use -crd-controller instead")
 	flagset.BoolVar(&args.CrdController, "crd-controller", true,
-		"Enable NFD CRD API controller for processing NodeFeature and NodeFeatureRule objects.")
+		"Enable NFD CRD API controller for processing NodeFeature and NodeFeatureRule objects."+
+			" DEPRECATED: will be removed in a future release along with the deprecated gRPC API.")
 	flagset.IntVar(&args.Port, "port", 8080,
 		"Port on which to listen for gRPC connections."+
 			" DEPRECATED: will be removed in a future release along with the deprecated gRPC API.")

--- a/docs/reference/master-commandline-reference.md
+++ b/docs/reference/master-commandline-reference.md
@@ -223,6 +223,9 @@ nfd-master -no-publish
 
 ### -crd-controller
 
+> **NOTE** This flag will be removed in a future release at the same time with
+> the deprecated gRPC API.
+
 The `-crd-controller` flag specifies whether the NFD CRD API controller is
 enabled or not. The controller is responsible for processing
 [NodeFeature](../usage/custom-resources.md#nodefeature) and


### PR DESCRIPTION
Plan the removal of the -crd-controller flag along with the gRPC API. This flag does not make much sense after that as all communication with nfd-worker is based on CRDs - with the CRD controller disabled nfd-master is virtually a functionless stub.