### PR TITLE
nfd-master: fix memory leak in nfd api-controller

### DIFF
--- a/pkg/nfd-master/nfd-api-controller.go
+++ b/pkg/nfd-master/nfd-api-controller.go
@@ -123,10 +123,7 @@ func newNfdController(config *restclient.Config, nfdApiControllerOptions nfdApiC
 }
 
 func (c *nfdController) stop() {
-	select {
-	case c.stopChan <- struct{}{}:
-	default:
-	}
+	close(c.stopChan)
 }
 
 func (c *nfdController) updateOneNode(typ string, obj metav1.Object) {


### PR DESCRIPTION
Fixes a memory leak that happened when stopping (and then re-starting) the nfd api controller. The stop channel was not used properly which caused the underlying informer to keep on running.