### PR TITLE
topology-updater: Set APIVersion, Kind in the OwnerReference explicitly

### DIFF
--- a/pkg/nfd-topology-updater/nfd-topology-updater.go
+++ b/pkg/nfd-topology-updater/nfd-topology-updater.go
@@ -237,8 +237,8 @@ func (w *nfdTopologyUpdater) updateNodeResourceTopology(zoneInfo v1alpha2.ZoneLi
 		} else {
 			w.ownerRefs = []metav1.OwnerReference{
 				{
-					APIVersion: ns.APIVersion,
-					Kind:       ns.Kind,
+					APIVersion: "v1",
+					Kind:       "Namespace",
 					Name:       ns.Name,
 					UID:        types.UID(ns.UID),
 				},


### PR DESCRIPTION
APIVersion and Kind are empty in the returned namespace object and need to be set explicitly.