### PR TITLE
test/e2e: Increase the timeouts to get tests to pass reliably

### DIFF
--- a/test/e2e/gomega.go
+++ b/test/e2e/gomega.go
@@ -39,7 +39,7 @@ type k8sAnnotations map[string]string
 func eventuallyNonControlPlaneNodes(ctx context.Context, cli clientset.Interface) AsyncAssertion {
 	return Eventually(func(g Gomega, ctx context.Context) ([]corev1.Node, error) {
 		return getNonControlPlaneNodes(ctx, cli)
-	}).WithPolling(1 * time.Second).WithTimeout(10 * time.Second).WithContext(ctx)
+	}).WithPolling(1 * time.Second).WithTimeout(60 * time.Second).WithContext(ctx)
 }
 
 // MatchLabels returns a specialized Gomega matcher for checking if a list of

--- a/test/e2e/topology_updater_test.go
+++ b/test/e2e/topology_updater_test.go
@@ -421,7 +421,7 @@ excludeList:
 					}
 				}
 				return memoryFound
-			}, 1*time.Minute, 10*time.Second).Should(BeFalse())
+			}, 2*time.Minute, 10*time.Second).Should(BeFalse())
 		})
 	})
 

--- a/test/e2e/utils/noderesourcetopology.go
+++ b/test/e2e/utils/noderesourcetopology.go
@@ -128,7 +128,7 @@ func GetNodeTopology(ctx context.Context, topologyClient *topologyclientset.Clie
 			return false
 		}
 		return true
-	}).WithPolling(5 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.BeTrue())
+	}).WithPolling(5 * time.Second).WithTimeout(2 * time.Minute).Should(gomega.BeTrue())
 	return nodeTopology
 }
 


### PR DESCRIPTION
A few tests run unreliably due to timeouts that became to small:

- Increase the timeout in eventuallyNonControlPlaneNodes() to 1 minute
- Increase the timeout in GetNodeTopology() to 2 minutes