### PR TITLE
nfd-master: do nfd API scheme registration in an init function

### DIFF
--- a/pkg/nfd-master/nfd-api-controller.go
+++ b/pkg/nfd-master/nfd-api-controller.go
@@ -49,6 +49,10 @@ type nfdApiControllerOptions struct {
 	ResyncPeriod       time.Duration
 }
 
+func init() {
+	utilruntime.Must(nfdv1alpha1.AddToScheme(nfdscheme.Scheme))
+}
+
 func newNfdController(config *restclient.Config, nfdApiControllerOptions nfdApiControllerOptions) (*nfdController, error) {
 	c := &nfdController{
 		stopChan:           make(chan struct{}, 1),
@@ -118,7 +122,6 @@ func newNfdController(config *restclient.Config, nfdApiControllerOptions nfdApiC
 	// Start informers
 	informerFactory.Start(c.stopChan)
 
-	utilruntime.Must(nfdv1alpha1.AddToScheme(nfdscheme.Scheme))
 	return c, nil
 }
 


### PR DESCRIPTION
Prevents (rare) races on nfd-master reconfigurartion. Previously the scheme was registered at nfd API controller creation/startup time. This caused a race with some lister/informer goroutines of the previous (stoppped) controller still running and accessing (reading) the sceme while we were updating (writing) it.