### PR TITLE
nfd-master: protect node updater pool queueing with a lock

### DIFF
--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -442,7 +442,7 @@ func (m *nfdMaster) nfdAPIUpdateHandler() {
 				}
 			} else {
 				for nodeName := range updateNodes {
-					m.nodeUpdaterPool.queue.Add(nodeName)
+					m.nodeUpdaterPool.addNode(nodeName)
 				}
 			}
 
@@ -710,7 +710,7 @@ func (m *nfdMaster) nfdAPIUpdateAllNodes() error {
 	}
 
 	for _, node := range nodes.Items {
-		m.nodeUpdaterPool.queue.Add(node.Name)
+		m.nodeUpdaterPool.addNode(node.Name)
 	}
 
 	return nil

--- a/pkg/nfd-master/node-updater-pool.go
+++ b/pkg/nfd-master/node-updater-pool.go
@@ -28,7 +28,7 @@ import (
 
 type nodeUpdaterPool struct {
 	queue workqueue.RateLimitingInterface
-	sync.Mutex
+	sync.RWMutex
 
 	wg        sync.WaitGroup
 	nfdMaster *nfdMaster
@@ -113,4 +113,10 @@ func (u *nodeUpdaterPool) stop() {
 	klog.InfoS("stopping the NFD master node updater pool")
 	u.queue.ShutDown()
 	u.wg.Wait()
+}
+
+func (u *nodeUpdaterPool) addNode(nodeName string) {
+	u.RLock()
+	defer u.RUnlock()
+	u.queue.Add(nodeName)
 }


### PR DESCRIPTION
Prevents races when (re-)starting the queue. There are no reports on issues related to this (and I haven't come up with any actual failure path in the current code) but better to be safe and follow the best practices.