### PR TITLE
Support KUBERNETES_MASTER env variable

### DIFF
--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -49,8 +49,5 @@ func GetKubernetesNamespace() string {
 
 // GetKubeconfig returns the kubeconfig for the cluster
 func GetKubeconfig(path string) (*restclient.Config, error) {
-	if path == "" {
-		return restclient.InClusterConfig()
-	}
-	return clientcmd.BuildConfigFromFlags("", path)
+	return clientcmd.BuildConfigFromFlags(os.Getenv("KUBERNETES_MASTER"), path)
 }


### PR DESCRIPTION
Support (insecure) connections to the Kubernetes API server by setting the KUBERNETES_MASTER environment variable. This is how e.g. kubectl behaves and also matches the error message(s) from client-go package. This patch is targeted for local testing and development.