### PR TITLE
add ARMv7 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ BUILD_FLAGS = -tags osusergo,netgo \
               -ldflags "-s -w -extldflags=-static -X sigs.k8s.io/node-feature-discovery/pkg/version.version=$(VERSION) -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=$(HOSTMOUNT_PREFIX)"
 
 # multi-arch build with buildx
-IMAGE_ALL_PLATFORMS ?= linux/amd64,linux/arm64
+IMAGE_ALL_PLATFORMS ?= linux/amd64,linux/arm64,linux/arm/v7
 
 # enable buildx
 ensure-buildx:

--- a/scripts/test-infra/build-image-cross.sh
+++ b/scripts/test-infra/build-image-cross.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
 # cross build
-make image-all
+IMAGE_ALL_PLATFORMS=linux/amd64,linux/arm64 make image-all


### PR DESCRIPTION
this allows the nfd to run on arm devices like the Raspberry Pi >= 2 
with ARMv7 core or ARMv8 in 32Bit mode

see #426
