### PR TITLE
cpu: advertise AVX10 version

### DIFF
--- a/deployment/nodefeaturerule/samples/nodefeaturerule-cpu.yaml
+++ b/deployment/nodefeaturerule/samples/nodefeaturerule-cpu.yaml
@@ -41,6 +41,17 @@ spec:
               - "SSE42"
               - "SSSE3"
 
+    - name: "nfd built-in cpu-cpuid non-bool labels"
+      labelsTemplate: |
+        {{ range .cpu.cpuid }}cpu-cpuid.{{ .Name }}={{ .Value }}
+        {{ end }}
+      matchFeatures:
+        - feature: cpu.cpuid
+          matchName:
+            op: In
+            value:
+              - "AVX10_VERSION"
+
     - name: "nfd built-in cpu-hardware_multithreading label"
       labelsTemplate: |
         {{ range .cpu.topology }}cpu-{{ .Name }}={{ .Value }}

--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -959,6 +959,8 @@ The following features are available for matching:
 | ---------------- | ------------ | -------- | ---------- | ----------- |
 | **`cpu.cpuid`**  | flag         |          |            | Supported CPU capabilities |
 |                  |              | **`<cpuid-flag>`** |  | CPUID flag is present |
+|                  | attribute    |          |            | CPU capability attributes |
+|                  |              | **AVX10_VERSION** | int | AVX10 vector ISA version (if supported) |
 | **`cpu.cstate`** | attribute    |          |            | Status of cstates in the intel_idle cpuidle driver |
 |                  |              | **`enabled`** | bool  | 'true' if cstates are set, otherwise 'false'. Does not exist of intel_idle driver is not active. |
 | **`cpu.model`**  | attribute    |          |            | CPU model related attributes |

--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -47,6 +47,7 @@ feature.node.kubernetes.io/<feature> = <value>
 | Feature name                        | Value  | Description                                                                 |
 | ----------------------------------- | ------ | --------------------------------------------------------------------------- |
 | **`cpu-cpuid.<cpuid-flag>`**        | true   | CPU capability is supported. **NOTE:** the capability might be supported but not enabled. |
+| **`cpu-cpuid.<cpuid-attribute>`**   | string | CPU attribute value |
 | **`cpu-hardware_multithreading`**   | true   | Hardware multithreading, such as Intel HTT, enabled (number of logical CPUs is greater than physical CPUs) |
 | **`cpu-coprocessor.nx_gzip`**       | true   | Nest Accelerator for GZIP is supported(Power). |
 | **`cpu-power.sst_bf.enabled`**      | true   | Intel SST-BF ([Intel Speed Select Technology][intel-sst] - Base frequency) enabled |
@@ -122,6 +123,12 @@ RDTSCP, SGX, SSE, SSE2, SSE3, SSE4, SSE42, SSSE3 and TDX_GUEST. See
 configuration options to change the behavior.
 
 See the full list in [github.com/klauspost/cpuid][klauspost-cpuid].
+
+#### X86 CPUID attributes
+
+| Attribute          | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| AVX10_VERSION      | AVX10 vector ISA version (if supported)                 |
 
 #### Arm CPUID flags (partial list)
 

--- a/source/cpu/cpu.go
+++ b/source/cpu/cpu.go
@@ -149,6 +149,9 @@ func (s *cpuSource) GetLabels() (source.FeatureLabels, error) {
 			labels["cpuid."+f] = true
 		}
 	}
+	for f, v := range features.Attributes[CpuidFeature].Elements {
+		labels["cpuid."+f] = v
+	}
 
 	// CPU model
 	for k, v := range features.Attributes[Cpumodel].Elements {
@@ -203,6 +206,9 @@ func (s *cpuSource) Discover() error {
 
 	// Detect CPUID
 	s.features.Flags[CpuidFeature] = nfdv1alpha1.NewFlagFeatures(getCpuidFlags()...)
+	if cpuidAttrs := getCpuidAttributes(); cpuidAttrs != nil {
+		s.features.Attributes[CpuidFeature] = nfdv1alpha1.NewAttributeFeatures(cpuidAttrs)
+	}
 
 	// Detect CPU model
 	s.features.Attributes[Cpumodel] = nfdv1alpha1.NewAttributeFeatures(getCPUModel())

--- a/source/cpu/cpuid_amd64.go
+++ b/source/cpu/cpuid_amd64.go
@@ -17,10 +17,22 @@ limitations under the License.
 package cpu
 
 import (
+	"strconv"
+
 	"github.com/klauspost/cpuid/v2"
 )
 
 // getCpuidFlags returns feature names for all the supported CPU features.
 func getCpuidFlags() []string {
 	return cpuid.CPU.FeatureSet()
+}
+
+func getCpuidAttributes() map[string]string {
+	ret := map[string]string{}
+
+	if cpuid.CPU.AVX10Level > 0 {
+		ret["AVX10_VERSION"] = strconv.Itoa(int(cpuid.CPU.AVX10Level))
+	}
+
+	return ret
 }

--- a/source/cpu/cpuid_linux_arm.go
+++ b/source/cpu/cpuid_linux_arm.go
@@ -119,3 +119,5 @@ func getCpuidFlags() []string {
 	}
 	return r
 }
+
+func getCpuidAttributes() map[string]string { return nil }

--- a/source/cpu/cpuid_linux_arm64.go
+++ b/source/cpu/cpuid_linux_arm64.go
@@ -199,3 +199,5 @@ func getCpuidFlags() []string {
 	}
 	return r
 }
+
+func getCpuidAttributes() map[string]string { return nil }

--- a/source/cpu/cpuid_linux_ppc64le.go
+++ b/source/cpu/cpuid_linux_ppc64le.go
@@ -153,3 +153,5 @@ func getCpuidFlags() []string {
 	}
 	return r
 }
+
+func getCpuidAttributes() map[string]string { return nil }

--- a/source/cpu/cpuid_linux_s390x.go
+++ b/source/cpu/cpuid_linux_s390x.go
@@ -95,3 +95,5 @@ func getCpuidFlags() []string {
 	}
 	return r
 }
+
+func getCpuidAttributes() map[string]string { return nil }

--- a/source/cpu/cpuid_stub.go
+++ b/source/cpu/cpuid_stub.go
@@ -20,3 +20,5 @@ limitations under the License.
 package cpu
 
 func getCpuidFlags() []string { return nil }
+
+func getCpuidAttributes() map[string]string { return nil }


### PR DESCRIPTION
Add new cpuid label "feature.node.kubernetes.io/cpu-cpuid.AVX10_VERSION" that advertises the supported version of AVX10 vector ISA. Correspondingly, the patch adds AVX10_VERSION to the "cpu.cpuid" feature for NodeFeatureRules to consume.

This makes cpu.cpuid on amd64 architecture a "multi-type" feature in that it contains "flags" and potentially also "attributes" (the only cpuid attribute so far is the AVX10_VERSION).