### PR TITLE
cloudbuild.yaml: change machine type to e1-highcpu-32

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,4 +12,4 @@ substitutions:
   _PULL_BASE_REF: 'master'
 options:
   substitution_option: ALLOW_LOOSE
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_32'


### PR DESCRIPTION
Mitigate the big increase of build time after enabling armv7 builds.