### PR TITLE
cloudbuild.yaml: downgrade machine type to e2-highcpu-8

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,4 +12,4 @@ substitutions:
   _PULL_BASE_REF: 'master'
 options:
   substitution_option: ALLOW_LOOSE
-  machineType: 'E2_HIGHCPU_32'
+  machineType: 'E2_HIGHCPU_8'


### PR DESCRIPTION
The higher tier builder didn't give any advantage, especially after armv7 builds were disabled. Let's revert back to highcpu-8.