### PR TITLE
nfd-master: add DisableAutoPrefix feature gate

### DIFF
--- a/docs/reference/feature-gates.md
+++ b/docs/reference/feature-gates.md
@@ -16,7 +16,8 @@ The feature gates are set using the `-feature-gates` command line flag or
 
 | Name                  | Default | Stage  | Since   | Until  |
 | --------------------- | ------- | ------ | ------- | ------ |
-| `NodeFeatureAPI`      | true    | Beta   | V0.14   |   |
+| `NodeFeatureAPI`      | true    | Beta   | V0.14   |        |
+| `DisableAutoPrefix`   | false   | Alpha  | V0.16   |        |
 
 ## NodeFeatureAPI
 
@@ -25,3 +26,27 @@ When enabled, NFD will register the Node Feature API with the Kubernetes API
 server. The Node Feature API is used to expose node-specific hardware and
 software features to the Kubernetes scheduler. The Node Feature API is a beta
 feature and is enabled by default.
+
+## DisableAutoPrefix
+
+The `DisableAutoPrefix` feature gate controls the automatic prefixing of names.
+When enabled nfd-master does not automatically add the default
+`feature.node.kubernetes.io/` prefix to unprefixed labels, annotations and
+extended resources. Automatic prefixing is the default behavior in NFD v0.16
+and earlier.
+
+Note that enabling the feature gate effectively causes unprefixed names to be
+filtered out as NFD does not allow unprefixed names of labels, annotations or
+extended resources. For example, with the `DisableAutoPrefix` feature gate set
+to `false`, a NodeFeatureRule with
+
+```yaml
+  labels:
+    foo: bar
+```
+
+will turn into `feature.node.kubernetes.io/foo=bar` node label. With
+`DisableAutoPrefix` set to `true`, no prefix is added and the label will be
+filtered out.
+
+Note that taint keys are not affected by this feature gate.

--- a/docs/reference/master-configuration-reference.md
+++ b/docs/reference/master-configuration-reference.md
@@ -70,6 +70,9 @@ denyLabelNs: ["denied.ns.io","denied.kubernetes.io"]
 
 ## autoDefaultNs
 
+**DEPRECATED**: Will be removed in NFD v0.17. Use the
+[DisableAutoPrefix](feature-gates.md#disableautoprefix) feature gate instead.
+
 The `autoDefaultNs` option controls the automatic prefixing of names. When set
 to true (the default in NFD version {{ site.version }}) nfd-master
 automatically adds the default `feature.node.kubernetes.io/` prefix to

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	NodeFeatureAPI featuregate.Feature = "NodeFeatureAPI"
+	NodeFeatureAPI    featuregate.Feature = "NodeFeatureAPI"
+	DisableAutoPrefix featuregate.Feature = "DisableAutoPrefix"
 )
 
 var (
@@ -33,5 +34,6 @@ var (
 )
 
 var DefaultNFDFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	NodeFeatureAPI: {Default: true, PreRelease: featuregate.Beta},
+	NodeFeatureAPI:    {Default: true, PreRelease: featuregate.Beta},
+	DisableAutoPrefix: {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/nfd-master/nfd-master-internal_test.go
+++ b/pkg/nfd-master/nfd-master-internal_test.go
@@ -333,6 +333,10 @@ func TestRemovingExtResources(t *testing.T) {
 
 func TestSetLabels(t *testing.T) {
 	Convey("When servicing SetLabels request", t, func() {
+		// Add feature gates as running nfd-master depends on that
+		err := features.NFDMutableFeatureGate.Add(features.DefaultNFDFeatureGates)
+		So(err, ShouldBeNil)
+
 		testNode := newTestNode()
 		// We need to populate the node with some annotations or the patching in the fake client fails
 		testNode.Labels["feature.node.kubernetes.io/foo"] = "bar"

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -801,12 +801,12 @@ func (m *nfdMaster) nfdAPIUpdateOneNode(cli k8sclient.Interface, node *corev1.No
 		// NOTE: changing the rule api to support handle multiple objects instead
 		// of merging would probably perform better with lot less data to copy.
 		features = objs[0].Spec.DeepCopy()
-		if m.config.AutoDefaultNs {
+		if !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.DisableAutoPrefix) && m.config.AutoDefaultNs {
 			features.Labels = addNsToMapKeys(features.Labels, nfdv1alpha1.FeatureLabelNs)
 		}
 		for _, o := range objs[1:] {
 			s := o.Spec.DeepCopy()
-			if m.config.AutoDefaultNs {
+			if !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.DisableAutoPrefix) && m.config.AutoDefaultNs {
 				s.Labels = addNsToMapKeys(s.Labels, nfdv1alpha1.FeatureLabelNs)
 			}
 			s.MergeInto(features)
@@ -864,7 +864,7 @@ func filterExtendedResource(name, value string, features *nfdv1alpha1.Features) 
 }
 
 func (m *nfdMaster) refreshNodeFeatures(cli k8sclient.Interface, node *corev1.Node, labels map[string]string, features *nfdv1alpha1.Features) error {
-	if m.config.AutoDefaultNs {
+	if !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.DisableAutoPrefix) && m.config.AutoDefaultNs {
 		labels = addNsToMapKeys(labels, nfdv1alpha1.FeatureLabelNs)
 	} else if labels == nil {
 		labels = make(map[string]string)
@@ -1041,7 +1041,7 @@ func (m *nfdMaster) processNodeFeatureRule(nodeName string, features *nfdv1alpha
 			l := ruleOut.Labels
 			e := ruleOut.ExtendedResources
 			a := ruleOut.Annotations
-			if m.config.AutoDefaultNs {
+			if !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.DisableAutoPrefix) && m.config.AutoDefaultNs {
 				l = addNsToMapKeys(ruleOut.Labels, nfdv1alpha1.FeatureLabelNs)
 				e = addNsToMapKeys(ruleOut.ExtendedResources, nfdv1alpha1.ExtendedResourceNs)
 				a = addNsToMapKeys(ruleOut.Annotations, nfdv1alpha1.FeatureAnnotationNs)

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -57,7 +57,7 @@ import (
 	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
 	"sigs.k8s.io/node-feature-discovery/pkg/apis/nfd/nodefeaturerule"
 	"sigs.k8s.io/node-feature-discovery/pkg/apis/nfd/validate"
-	"sigs.k8s.io/node-feature-discovery/pkg/features"
+	nfdfeatures "sigs.k8s.io/node-feature-discovery/pkg/features"
 	pb "sigs.k8s.io/node-feature-discovery/pkg/labeler"
 	"sigs.k8s.io/node-feature-discovery/pkg/utils"
 	"sigs.k8s.io/node-feature-discovery/pkg/version"
@@ -318,7 +318,7 @@ func (m *nfdMaster) Run() error {
 	grpcErr := make(chan error)
 	// If the NodeFeature API is enabled, don'tregister the labeler API
 	// server. Otherwise, register the labeler server.
-	if !features.NFDFeatureGate.Enabled(features.NodeFeatureAPI) {
+	if !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.NodeFeatureAPI) {
 		go m.runGrpcServer(grpcErr)
 	}
 
@@ -373,7 +373,7 @@ func (m *nfdMaster) Run() error {
 			m.nodeUpdaterPool.start(m.config.NfdApiParallelism)
 
 			// Update all nodes when the configuration changes
-			if m.nfdController != nil && features.NFDFeatureGate.Enabled(features.NodeFeatureAPI) {
+			if m.nfdController != nil && nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.NodeFeatureAPI) {
 				m.nfdController.updateAllNodesChan <- struct{}{}
 			}
 
@@ -471,7 +471,7 @@ func (m *nfdMaster) runGrpcServer(errChan chan<- error) {
 func (m *nfdMaster) nfdAPIUpdateHandler() {
 	// We want to unconditionally update all nodes at startup if gRPC is
 	// disabled (i.e. NodeFeature API is enabled)
-	updateAll := features.NFDFeatureGate.Enabled(features.NodeFeatureAPI)
+	updateAll := nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.NodeFeatureAPI)
 	updateNodes := make(map[string]struct{})
 	rateLimit := time.After(time.Second)
 	for {
@@ -1363,7 +1363,7 @@ func (m *nfdMaster) startNfdApiController() error {
 	}
 	klog.InfoS("starting the nfd api controller")
 	m.nfdController, err = newNfdController(kubeconfig, nfdApiControllerOptions{
-		DisableNodeFeature: !features.NFDFeatureGate.Enabled(features.NodeFeatureAPI),
+		DisableNodeFeature: !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.NodeFeatureAPI),
 		ResyncPeriod:       m.config.ResyncPeriod.Duration,
 	})
 	if err != nil {


### PR DESCRIPTION
Now that we have support for feature gates deprecate the autoDefaultNs
config option of nfd-master and replace it with a new alpha feature gate
DisableAutoPrefix (defaults to false). Using a feature gate to handle
and communicate these kind of changes, where the default behavior is
intended to be changed in a future release, feels much more natural than
using random flags/options.

The combined logic of the feature gate and the config option is a
logical OR over disabling auto-prefixing. That is, auto-prefixing is
disabled if either the feature gate or the config options is used set to
disable it:

```
                         | DisableAutoPrefix (feature gate)
                         | false | true
    -------------------- | --------------------------------
    autoDefaultNs   true |  ON   | OFF
    (config opt)   false |  OFF  | OFF
```