### PR TITLE
source/cpu: disable AVX10 label

### DIFF
--- a/deployment/components/worker-config/nfd-worker.conf.example
+++ b/deployment/components/worker-config/nfd-worker.conf.example
@@ -24,6 +24,7 @@
 #    cpuid:
 ##     NOTE: whitelist has priority over blacklist
 #      attributeBlacklist:
+#        - "AVX10"
 #        - "BMI1"
 #        - "BMI2"
 #        - "CLMUL"

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -169,6 +169,7 @@ worker:
     #    cpuid:
     ##     NOTE: whitelist has priority over blacklist
     #      attributeBlacklist:
+    #        - "AVX10"
     #        - "BMI1"
     #        - "BMI2"
     #        - "CLMUL"

--- a/deployment/nodefeaturerule/samples/nodefeaturerule-cpu.yaml
+++ b/deployment/nodefeaturerule/samples/nodefeaturerule-cpu.yaml
@@ -16,6 +16,7 @@ spec:
           matchName:
             op: NotIn
             value:
+              - "AVX10"
               - "BMI1"
               - "BMI2"
               - "CLMUL"

--- a/docs/reference/worker-configuration-reference.md
+++ b/docs/reference/worker-configuration-reference.md
@@ -266,7 +266,7 @@ Prevent publishing cpuid features listed in this option.
 
 > **NOTE:** overridden by `sources.cpu.cpuid.attributeWhitelist` (if specified)
 
-Default: `[BMI1, BMI2, CLMUL, CMOV, CX16, ERMS, F16C, HTT, LZCNT, MMX, MMXEXT,
+Default: `[AVX10, BMI1, BMI2, CLMUL, CMOV, CX16, ERMS, F16C, HTT, LZCNT, MMX, MMXEXT,
 NX, POPCNT, RDRAND, RDSEED, RDTSCP, SGX, SGXLC, SSE, SSE2, SSE3, SSE4.1,
 SSE4.2, SSSE3, TDX_GUEST]`
 

--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -115,9 +115,10 @@ configuration options for details.
 | VPCLMULQDQ         | Carry-less multiplication quadword |
 | WRMSRNS            | Non-Serializing Write to Model Specific Register |
 
-By default, the following CPUID flags have been blacklisted: BMI1, BMI2, CLMUL,
-CMOV, CX16, ERMS, F16C, HTT, LZCNT, MMX, MMXEXT, NX, POPCNT, RDRAND, RDSEED,
-RDTSCP, SGX, SSE, SSE2, SSE3, SSE4, SSE42, SSSE3 and TDX_GUEST. See
+By default, the following CPUID flags have been blacklisted: AVX10 (use
+AVX10_VERSION instead), BMI1, BMI2, CLMUL, CMOV, CX16, ERMS, F16C, HTT, LZCNT,
+MMX, MMXEXT, NX, POPCNT, RDRAND, RDSEED, RDTSCP, SGX, SSE, SSE2, SSE3, SSE4,
+SSE42, SSSE3 and TDX_GUEST. See
 [`sources.cpu`](../reference/worker-configuration-reference.md#sourcescpu)
 configuration options to change the behavior.
 

--- a/source/cpu/cpu.go
+++ b/source/cpu/cpu.go
@@ -64,6 +64,7 @@ func newDefaultConfig() *Config {
 	return &Config{
 		cpuidConfig{
 			AttributeBlacklist: []string{
+				"AVX10",
 				"BMI1",
 				"BMI2",
 				"CLMUL",


### PR DESCRIPTION
Disable AVX10 as unnecessary as AVX10_LEVEL is better suited for checking AVX10 compatibility. There is not yet any hardware with the feature so disabling it shouldn't cause problems for users.