### PR TITLE
Revert "build(deps): bump actions/checkout from 1 to 4"

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,7 +22,7 @@ jobs:
         curl -sfL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash -s -- --version v3.5.2
 
     - name: Check out repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v1
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
Checkout v4 does some strange mangling of tags, basically overwrites our signed/annotated tag with something like:

  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune \
    --no-recurse-submodules origin \
    +2e93c3fd478b6631dd7bda9c6ec66a9f99cafaa8:refs/tags/v0.16.0

Which breaks our gh-pages build on release branches/tags.

This reverts commit 130ef1070d4f90e2a44959a68a576ef11ad93c4f.