### PR TITLE
topology-updater: properly handle IPv6 from NODE_ADDRESS

### DIFF
--- a/cmd/nfd-topology-updater/main.go
+++ b/cmd/nfd-topology-updater/main.go
@@ -19,8 +19,10 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -91,6 +93,10 @@ func parseArgs(flags *flag.FlagSet, osArgs ...string) (*topology.Args, *resource
 				"please either define the NODE_ADDRESS environment variable or specify endpoint with the -kubelet-config-uri flag\n", kubeletSecurePort)
 			os.Exit(1)
 		}
+		if isIPv6(nodeAddress) {
+			// With IPv6 we need to wrap the IP address in brackets as we append :port below
+			nodeAddress = "[" + nodeAddress + "]"
+		}
 		resourcemonitorArgs.KubeletConfigURI = fmt.Sprintf("https://%s:%d/configz", nodeAddress, kubeletSecurePort)
 	}
 
@@ -127,4 +133,9 @@ func initFlags(flagset *flag.FlagSet) (*topology.Args, *resourcemonitor.Args) {
 	klog.InitFlags(flagset)
 
 	return args, resourcemonitorArgs
+}
+
+func isIPv6(addr string) bool {
+	ip := net.ParseIP(addr)
+	return ip != nil && strings.Count(ip.String(), ":") >= 2
 }


### PR DESCRIPTION
Fix the usage of IPv6 addresses for default kubelet configz endpoint.

The default host:port we use for kubelet configz endpoint is ${NODE_ADDRESS}:10250. Previously we errored out if NODE_ADDRESS was an IPv6 address because we used an incorrect notation (without brackets). The (IPv6) needs to be enclosed in brackets if specifying the port.

Fixes #1727