### PR TITLE
Fix the problem with starting the master with empty cache

### DIFF
--- a/pkg/nfd-master/nfd-api-controller.go
+++ b/pkg/nfd-master/nfd-api-controller.go
@@ -161,6 +161,7 @@ func newNfdController(config *restclient.Config, nfdApiControllerOptions nfdApiC
 
 	// Start informers
 	informerFactory.Start(c.stopChan)
+	informerFactory.WaitForCacheSync(c.stopChan)
 
 	return c, nil
 }


### PR DESCRIPTION
We faced the problem when master deleted some of labels on start. Sometimes he doesn't gets NodeFeatures when they are present in cluster because of empty cache in informer