### PR TITLE
ensure post-delete-job's service account matches ref in job spec

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/post-delete-job.yaml
+++ b/deployment/helm/node-feature-discovery/templates/post-delete-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "node-feature-discovery.master.serviceAccountName" . }}-prune
+  name: {{ include "node-feature-discovery.fullname" . }}-prune
   namespace: {{ include "node-feature-discovery.namespace" . }}
   labels:
     {{- include "node-feature-discovery.labels" . | nindent 4 }}


### PR DESCRIPTION
The Service account name must match the referenced service account in the job spec

With helm chart as-is, the gpu-operator e2e tests fail as the `helm uninstall` operation fails and times out. On further analysis, we found that the delete hook job can't find the service account it looks for, so the job remains unprovisioned until the helm uninstall times out

This change fixes the above issue. I've tested this locally and our gpu-operator e2e tests now pass 