### PR TITLE
docs: describe Kubernetes version compatibility in versions page

### DIFF
--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -7,7 +7,7 @@ sort: 2
 # Deployment
 
 Node Feature Discovery can be deployed on any recent version of Kubernetes
-(v1.21+).
+(v1.24+).
 
 See [Image variants](image-variants.md) for description of the different NFD
 container images available.

--- a/docs/deployment/kustomize.md
+++ b/docs/deployment/kustomize.md
@@ -20,7 +20,7 @@ deploy NFD. Customization of the deployment is done by maintaining
 declarative overlays on top of the base overlays in NFD.
 
 To follow the deployment instructions here,
-[kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) v1.21 or
+[kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) v1.24 or
 later is required.
 
 The kustomize overlays provided in the repo can be used directly:

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -238,13 +238,6 @@ the Kubernetes API, pass the `-no-publish` flag to nfd-topology-updater.
 > run stand-alone directly with `docker run`. See
 > the [template spec](https://github.com/kubernetes-sigs/node-feature-discovery/blob/{{site.release}}/deployment/components/topology-updater/topologyupdater-mounts.yaml)
 > for up-to-date information about the required volume mounts.
->
-> [PodResource API][podresource-api] is a prerequisite for
-> nfd-topology-updater.  Preceding Kubernetes v1.23, the `kubelet` must be
-> started with the following flag:
-> `--feature-gates=KubeletPodResourcesGetAllocatable=true`. Starting
-> Kubernetes v1.23, the `GetAllocatableResources` is enabled by default through
-> `KubeletPodResourcesGetAllocatable` [feature gate][feature-gate].
 
 ## Running with Tilt
 

--- a/docs/get-started/introduction.md
+++ b/docs/get-started/introduction.md
@@ -19,7 +19,7 @@ This software enables node feature discovery for Kubernetes. It detects
 hardware features available on each node in a Kubernetes cluster, and
 advertises those features using node labels and optionally node extended
 resources, annotations and node taints. Node Feature Discovery is compatible
-with any recent version of Kubernetes (v1.21+).
+with any recent version of Kubernetes (v1.24+).
 
 NFD consists of four software components:
 

--- a/docs/reference/versions.md
+++ b/docs/reference/versions.md
@@ -37,3 +37,7 @@ in **X+2**.
 
 The same policy (support for 1 release after deprecation) also applies to Helm
 chart parameters.
+
+## Kubernetes compatibility
+
+Node Feature Discovery is compatible with Kubernetes v1.24 and later.


### PR DESCRIPTION
Bump the required Kubernetes version to v1.24. In practice this is the
minimum Kubernetes version as our deployment (both kustomize and Helm)
depend on the gRPC container probes feature of Kubernetes.