### PR TITLE
cloudbuild: increase the image build timeout

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 2000s
+timeout: 3000s
 steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90
     entrypoint: scripts/test-infra/push-image.sh

--- a/scripts/test-infra/test-e2e.sh
+++ b/scripts/test-infra/test-e2e.sh
@@ -27,7 +27,7 @@ i=1
 while true; do
     if make poll-images; then
         break
-    elif [ $i -ge 35 ]; then
+    elif [ $i -ge 55 ]; then
         echo "ERROR: too many tries when polling for image"
         exit 1
     fi


### PR DESCRIPTION
Attempt to fix occasional (rare) build failures.