### PR TITLE
feature-gates: mark NodeFeatureAPI as GA

### DIFF
--- a/docs/reference/feature-gates.md
+++ b/docs/reference/feature-gates.md
@@ -17,6 +17,7 @@ The feature gates are set using the `-feature-gates` command line flag or
 | Name                  | Default | Stage  | Since   | Until  |
 | --------------------- | ------- | ------ | ------- | ------ |
 | `NodeFeatureAPI`      | true    | Beta   | V0.14   |        |
+| `NodeFeatureAPI`      | true    | GA     | V0.17   |        |
 | `DisableAutoPrefix`   | false   | Alpha  | V0.16   |        |
 | `NodeFeatureGroupAPI` | false   | Alpha  | V0.16   |        |
 

--- a/docs/reference/master-commandline-reference.md
+++ b/docs/reference/master-commandline-reference.md
@@ -39,7 +39,7 @@ documentation](../feature-gates.md).
 Example:
 
 ```bash
-nfd-master -feature-gates NodeFeatureAPI=false
+nfd-master -feature-gates NodeFeatureGroupAPI=true
 ```
 
 ### -prune
@@ -180,9 +180,6 @@ nfd-master -verify-node-name -ca-file=/opt/nfd/ca.crt \
 The `-enable-leader-election` flag enables leader election for NFD-Master.
 It is advised to turn on this flag when running more than one instance of
 NFD-Master.
-
-Does not have effect if the [NodeFeatureAPI](feature-gates.md#nodefeatureapi)
-feature gate is disabled.
 
 Default: false
 
@@ -347,9 +344,6 @@ nfd-master -options='{"noPublish": true}'
 The `-nfd-api-parallelism` flag can be used to specify the maximum
 number of concurrent node updates.
 
-Does not have effect if the [NodeFeatureAPI](feature-gates.md#nodefeatureapi)
-feature gate is disabled.
-
 Default: 10
 
 Example:
@@ -442,9 +436,6 @@ The `-resync-period` flag specifies the NFD API controller resync period.
 The resync means nfd-master replaying all NodeFeature and NodeFeatureRule objects,
 thus effectively re-syncing all nodes in the cluster (i.e. ensuring labels, annotations,
 extended resources and taints are in place).
-
-Does not have effect if the [NodeFeatureAPI](feature-gates.md#nodefeatureapi)
-feature gate is disabled.
 
 Default: 1 hour.
 

--- a/docs/reference/master-configuration-reference.md
+++ b/docs/reference/master-configuration-reference.md
@@ -156,9 +156,6 @@ The resync means nfd-master replaying all NodeFeature and NodeFeatureRule object
 thus effectively re-syncing all nodes in the cluster (i.e. ensuring labels, annotations,
 extended resources and taints are in place).
 
-Does not have effect if the [NodeFeatureAPI](feature-gates.md#nodefeatureapi)
-feature gate is disabled.
-
 Default: 1 hour.
 
 Example:
@@ -230,9 +227,6 @@ leaderElection:
 
 The `nfdApiParallelism` option can be used to specify the maximum
 number of concurrent node updates.
-
-Does not have effect if the [NodeFeatureAPI](feature-gates.md#nodefeatureapi)
-feature gate is disabled.
 
 Default: 10
 

--- a/docs/reference/worker-commandline-reference.md
+++ b/docs/reference/worker-commandline-reference.md
@@ -39,7 +39,7 @@ documentation](../feature-gates.md).
 Example:
 
 ```bash
-nfd-master -feature-gates NodeFeatureAPI=false
+nfd-master -feature-gates NodeFeatureGroupAPI=true
 ```
 
 ### -config
@@ -152,9 +152,6 @@ The `-kubeconfig` flag specifies the kubeconfig to use for connecting to the
 Kubernetes API server. It is needed for manipulating
 [NodeFeature](../usage/custom-resources.md#nodefeature) objects. An empty value
 (which is also the default) implies in-cluster kubeconfig.
-
-Does not have effect if the [NodeFeatureAPI](feature-gates.md#nodefeatureapi)
-feature gate is disabled.
 
 Default: *empty*
 

--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -40,14 +40,6 @@ labels directly.
 Note that RBAC rules must be created for each extension for them to be able to
 create and manipulate NodeFeature objects in their namespace.
 
-The NodeFeature CRD API can be disabled with the
-[NodeFeatureAPI](../reference/feature-gates.md#nodefeatureapi) feature gate
-(`-feature-gates NodeFeatureAPI=false` on command line). The `-feature-gates`
-command line flag must be specified for both nfd-master and nfd-worker as it
-will enable the gRPC communication between them. Note that the gRPC API is
-**DEPRECATED** and will be removed in a future release, at which point the
-NodeFeature API cannot be disabled.
-
 ### A NodeFeature example
 
 Consider the following referential example:

--- a/docs/usage/nfd-gc.md
+++ b/docs/usage/nfd-gc.md
@@ -24,7 +24,6 @@ default garbage collector interval is set to 1h which is the value when no
 
 ## Configuration
 
-In Helm deployments (see
-[garbage collector parameters](../deployment/helm.md#garbage-collector-parameters))
-NFD-GC will only be deployed when `featureGates.NodeFeatureAPI` or
-`topologyUpdater.enable` is set to true.
+In Helm deployments see
+[garbage collector parameters](../deployment/helm.md#garbage-collector-parameters)
+for altering the nfd-gc configuration.

--- a/docs/usage/nfd-master.md
+++ b/docs/usage/nfd-master.md
@@ -30,20 +30,6 @@ and creates node labels accordingly. The feature data used as the input is
 received from nfd-worker instances through
 [NodeFeature](custom-resources.md#nodefeature-custom-resource) objects.
 
-> **NOTE**: when gRPC (**DEPRECATED**)  is used for communicating
-> the features (by setting the flag `-feature-gates NodeFeatureAPI=false` on both
-> nfd-master and nfd-worker, or via Helm values.featureGates.NodeFeatureAPI=false),
-> (re-)labelling only happens when a request is received from nfd-worker.
-> That is, in practice rules are evaluated and labels for each node are created
-> on intervals specified by the
-> [`core.sleepInterval`](../reference/worker-configuration-reference.md#coresleepinterval)
-> configuration option of nfd-worker instances. This means that modification or
-> creation of NodeFeatureRule objects does not instantly cause the node
-> labels to be updated.  Instead, the changes only come visible in node labels
-> as nfd-worker instances send their labelling requests. This limitation is not
-> present when gRPC interface is disabled
-> and [NodeFeature](custom-resources.md#nodefeature-custom-resource) API is used.
-
 ## Master configuration
 
 NFD-Master supports dynamic configuration through a configuration file. The

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -35,7 +35,7 @@ var (
 )
 
 var DefaultNFDFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	NodeFeatureAPI:      {Default: true, PreRelease: featuregate.Beta},
+	NodeFeatureAPI:      {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	DisableAutoPrefix:   {Default: false, PreRelease: featuregate.Alpha},
 	NodeFeatureGroupAPI: {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/nfd-worker/nfd-worker_test.go
+++ b/pkg/nfd-worker/nfd-worker_test.go
@@ -208,7 +208,10 @@ func TestRun(t *testing.T) {
 	})
 }
 
+// TODO: remove this test with the rest of the TLS code and docs.
+// Also drop the certs from test/data/.
 func TestRunTls(t *testing.T) {
+	t.Skip("gRPC cannot be enabled, NodeFeatureAPI GA")
 	masterArgs := &master.Args{
 		CaFile:         data.FilePath("ca.crt"),
 		CertFile:       data.FilePath("nfd-test-master.crt"),


### PR DESCRIPTION
The feature gate is locked to true. That is, it is not possible to revert back to the gPRC-based communication which makes the gRPC API ready for removal.