### PR TITLE
Helm: Add revision history limit for master replica

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/master.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master.yaml
@@ -13,6 +13,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.master.replicaCount }}
+  revisionHistoryLimit: {{ .Values.master.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "node-feature-discovery.selectorLabels" . | nindent 6 }}

--- a/deployment/helm/node-feature-discovery/templates/nfd-gc.yaml
+++ b/deployment/helm/node-feature-discovery/templates/nfd-gc.yaml
@@ -13,6 +13,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.gc.replicaCount | default 1 }}
+  revisionHistoryLimit: {{ .Values.gc.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "node-feature-discovery.selectorLabels" . | nindent 6 }}

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -90,6 +90,9 @@ master:
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name:
+  
+  # specify how many old ReplicaSets for the Deployment to retain.
+  revisionHistoryLimit: 
 
   rbac:
     create: true
@@ -543,6 +546,9 @@ gc:
   annotations: {}
   deploymentAnnotations: {}
   affinity: {}
+
+  # specify how many old ReplicaSets for the Deployment to retain.
+  revisionHistoryLimit: 
 
 # Optionally use encryption for worker <--> master comms
 # TODO: verify hostname is not yet supported

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -144,6 +144,7 @@ API's you need to install the prometheus operator in your cluster.
 | `master.nfdApiParallelism` | integer | 10                                      | Specifies the maximum number of concurrent node updates. |
 | `master.config`            | dict    |                                         | NFD master [configuration](../reference/master-configuration-reference) |
 | `master.args`              | array   | []                                      | Additional [command line arguments](../reference/master-commandline-reference.md) to pass to nfd-master |
+| `master.revisionHistoryLimit` | integer |                                      | Specify how many old ReplicaSets for this Deployment you want to retain. [revisionHistoryLimit](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit) |
 
 ### Worker pod parameters
 
@@ -217,9 +218,10 @@ API's you need to install the prometheus operator in your cluster.
 | `gc.nodeSelector`                     | dict   | {}      | Garbage collector pod [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)         |
 | `gc.tolerations`                      | dict   | {}      | Garbage collector pod [node tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)              |
 | `gc.annotations`                      | dict   | {}      | Garbage collector pod [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)                  |
-| `gc.deploymentAnnotations`            | dict   | {}      | Garbage collector deployment [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)          |
+| `gc.deploymentAnnotations`            | dict   | {}      | Garbage collector deployment [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)           |
 | `gc.affinity`                         | dict   | {}      | Garbage collector pod [affinity](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)    |
-| `gc.args`                             | array   | []     | Additional [command line arguments](../reference/gc-commandline-reference.md) to pass to nfd-gc |
+| `gc.args`                             | array  | []      | Additional [command line arguments](../reference/gc-commandline-reference.md) to pass to nfd-gc |
+| `gc.revisionHistoryLimit`             | integer |        | Specify how many old ReplicaSets for this Deployment you want to retain. [revisionHistoryLimit](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit) |
 
 <!-- Links -->
 [rbac]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/


### PR DESCRIPTION
Fixes: #1759 

Tested locally. Output:
```yaml
---
# Source: node-feature-discovery/templates/master.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name:  release-name-node-feature-discovery-master
  namespace: default
  labels:
    helm.sh/chart: node-feature-discovery-0.2.1
    app.kubernetes.io/name: node-feature-discovery
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "master"
    app.kubernetes.io/managed-by: Helm
    role: master
spec:
  replicas: 1
  revisionHistoryLimit: 3
  selector:
    matchLabels:
      app.kubernetes.io/name: node-feature-discovery
      app.kubernetes.io/instance: release-name
      role: master
  template:
    metadata:
      labels:
        app.kubernetes.io/name: node-feature-discovery
        app.kubernetes.io/instance: release-name
        role: master
    spec:
      serviceAccountName: release-name-node-feature-discovery
      enableServiceLinks: false
      securityContext:
        {}
      containers:
        - name: master
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
          image: "gcr.io/k8s-staging-nfd/node-feature-discovery:master"
          imagePullPolicy: Always
          livenessProbe:
            grpc:
              port: 8082
            initialDelaySeconds: 10
            periodSeconds: 10
          readinessProbe:
            grpc:
              port: 8082
            initialDelaySeconds: 5
            periodSeconds: 10
            failureThreshold: 10
          ports:
          - containerPort: 8080
            name: grpc
          - containerPort: 8081
            name: metrics
          env:
          - name: NODE_NAME
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
          command:
            - "nfd-master"
          resources:
            limits:
              memory: 4Gi
            requests:
              cpu: 100m
              memory: 128Mi
          args:
            ## By default, disable crd controller for other than the default instances
            - "-crd-controller=true"
            # Go over featureGates and add the feature-gate flag
            - "-feature-gates=NodeFeatureAPI=true"
            - "-feature-gates=NodeFeatureGroupAPI=false"
            - "-metrics=8081"
          volumeMounts:
            - name: nfd-master-conf
              mountPath: "/etc/kubernetes/node-feature-discovery"
              readOnly: true
      volumes:
        - name: nfd-master-conf
          configMap:
            name: release-name-node-feature-discovery-master-conf
            items:
              - key: nfd-master.conf
                path: nfd-master.conf
      affinity:
        nodeAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - preference:
              matchExpressions:
              - key: node-role.kubernetes.io/master
                operator: In
                values:
                - ""
            weight: 1
          - preference:
              matchExpressions:
              - key: node-role.kubernetes.io/control-plane
                operator: In
                values:
                - ""
            weight: 1
      tolerations:
        - effect: NoSchedule
          key: node-role.kubernetes.io/master
          operator: Equal
          value: ""
        - effect: NoSchedule
          key: node-role.kubernetes.io/control-plane
          operator: Equal
          value: ""
```