### PR TITLE
test/e2e: set topology-updater sleep-interval in podfingerprint test

### DIFF
--- a/test/e2e/topology_updater_test.go
+++ b/test/e2e/topology_updater_test.go
@@ -474,6 +474,7 @@ excludeList:
 			podSpecOpts := []testpod.SpecOption{
 				testpod.SpecWithContainerImage(dockerImage()),
 				testpod.SpecWithContainerExtraArgs("-pods-fingerprint"),
+				testpod.SpecWithContainerExtraArgs("-sleep-interval=5s"),
 			}
 			topologyUpdaterDaemonSet = testds.NFDTopologyUpdater(kcfg, podSpecOpts...)
 		})


### PR DESCRIPTION
Attempt to eliminate flakiness in CI.