### PR TITLE
test/e2e: specify -sleep-interval in topology-updater exclude-memory test

### DIFF
--- a/test/e2e/topology_updater_test.go
+++ b/test/e2e/topology_updater_test.go
@@ -402,6 +402,7 @@ excludeList:
 
 			podSpecOpts := []testpod.SpecOption{
 				testpod.SpecWithContainerImage(dockerImage()),
+				testpod.SpecWithContainerExtraArgs("-sleep-interval=5s"),
 				testpod.SpecWithConfigMap(cm.Name, "/etc/kubernetes/node-feature-discovery"),
 			}
 			topologyUpdaterDaemonSet = testds.NFDTopologyUpdater(kcfg, podSpecOpts...)


### PR DESCRIPTION
Make the test finish considerably faster.