### PR TITLE
Helm: Add revision history limit for worker daemonset

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
+++ b/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  revisionHistoryLimit: {{ .Values.topologyUpdater.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "node-feature-discovery.selectorLabels" . | nindent 6 }}

--- a/deployment/helm/node-feature-discovery/templates/worker.yaml
+++ b/deployment/helm/node-feature-discovery/templates/worker.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  revisionHistoryLimit: {{ .Values.worker.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "node-feature-discovery.selectorLabels" . | nindent 6 }}

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -471,6 +471,10 @@ topologyUpdater:
     create: true
     annotations: {}
     name:
+
+  # specify how many old ControllerRevisions for the DaemonSet to retain.
+  revisionHistoryLimit:
+
   rbac:
     create: true
 

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -425,6 +425,9 @@ worker:
     # If not set and create is true, a name is generated using the fullname template
     name:
 
+  # specify how many old ControllerRevisions for the DaemonSet to retain.
+  revisionHistoryLimit:
+
   rbac:
     create: true
 

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -168,6 +168,7 @@ API's you need to install the prometheus operator in your cluster.
 | `worker.annotations`                | dict   | {}                      | NFD worker pod [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)                                                                                         |
 | `worker.daemonsetAnnotations`       | dict   | {}                      | NFD worker daemonset [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)                                                                                   |
 | `worker.args`                       | array  | []                      | Additional [command line arguments](../reference/worker-commandline-reference.md) to pass to nfd-worker                                                                                              |
+| `worker.revisionHistoryLimit`       | integer |                                  | Specify how many old ControllerRevisions for this DaemonSet you want to retain. [revisionHistoryLimit](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec)          |
 
 ### Topology updater parameters
 

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -168,7 +168,7 @@ API's you need to install the prometheus operator in your cluster.
 | `worker.annotations`                | dict   | {}                      | NFD worker pod [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)                                                                                         |
 | `worker.daemonsetAnnotations`       | dict   | {}                      | NFD worker daemonset [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)                                                                                   |
 | `worker.args`                       | array  | []                      | Additional [command line arguments](../reference/worker-commandline-reference.md) to pass to nfd-worker                                                                                              |
-| `worker.revisionHistoryLimit`       | integer |                                  | Specify how many old ControllerRevisions for this DaemonSet you want to retain. [revisionHistoryLimit](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec)          |
+| `worker.revisionHistoryLimit`       | integer |                        | Specify how many old ControllerRevisions for this DaemonSet you want to retain. [revisionHistoryLimit](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec)          |
 
 ### Topology updater parameters
 
@@ -199,7 +199,7 @@ API's you need to install the prometheus operator in your cluster.
 | `topologyUpdater.podSetFingerprint`           | bool    | true                     | Enables compute and report of pod fingerprint in NRT objects.                                                                                                                                    |
 | `topologyUpdater.kubeletStateDir`             | string  | /var/lib/kubelet         | Specifies kubelet state directory path for watching state and checkpoint files. Empty value disables kubelet state tracking.                                                                     |
 | `topologyUpdater.args`                        | array   | []                       | Additional [command line arguments](../reference/topology-updater-commandline-reference.md) to pass to nfd-topology-updater                                                                      |
-| `topologyUpdater.revisionHistoryLimit`       | integer |                                  | Specify how many old ControllerRevisions for this DaemonSet you want to retain. [revisionHistoryLimit](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec)          |
+| `topologyUpdater.revisionHistoryLimit`       | integer |                           | Specify how many old ControllerRevisions for this DaemonSet you want to retain. [revisionHistoryLimit](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec)          |
 
 ### Garbage collector parameters
 

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -199,6 +199,7 @@ API's you need to install the prometheus operator in your cluster.
 | `topologyUpdater.podSetFingerprint`           | bool    | true                     | Enables compute and report of pod fingerprint in NRT objects.                                                                                                                                    |
 | `topologyUpdater.kubeletStateDir`             | string  | /var/lib/kubelet         | Specifies kubelet state directory path for watching state and checkpoint files. Empty value disables kubelet state tracking.                                                                     |
 | `topologyUpdater.args`                        | array   | []                       | Additional [command line arguments](../reference/topology-updater-commandline-reference.md) to pass to nfd-topology-updater                                                                      |
+| `topologyUpdater.revisionHistoryLimit`       | integer |                                  | Specify how many old ControllerRevisions for this DaemonSet you want to retain. [revisionHistoryLimit](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec)          |
 
 ### Garbage collector parameters
 


### PR DESCRIPTION
#1782 added support for setting revision history limit for master and gc replicas. This PR adds the same for worker replicas.

Fix #1759