### PR TITLE
helm: add configurable liveness&readiness probes for master topology-updater and worker

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/master.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master.yaml
@@ -46,16 +46,9 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
-            grpc:
-              port: 8082
-            initialDelaySeconds: 10
-            periodSeconds: 10
+            {{- toYaml .Values.master.livenessProbe | nindent 12 }}
           readinessProbe:
-            grpc:
-              port: 8082
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            failureThreshold: 10
+            {{- toYaml .Values.master.readinessProbe | nindent 12 }}
           ports:
           - containerPort: {{ .Values.master.port | default "8080" }}
             name: grpc

--- a/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
+++ b/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
@@ -43,16 +43,9 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         livenessProbe:
-          grpc:
-            port: 8082
-          initialDelaySeconds: 10
-          periodSeconds: 10
+          {{- toYaml .Values.topologyUpdater.livenessProbe | nindent 10 }}
         readinessProbe:
-          grpc:
-            port: 8082
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          failureThreshold: 10
+          {{- toYaml .Values.topologyUpdater.readinessProbe | nindent 10 }}
         env:
         - name: NODE_NAME
           valueFrom:

--- a/deployment/helm/node-feature-discovery/templates/worker.yaml
+++ b/deployment/helm/node-feature-discovery/templates/worker.yaml
@@ -45,16 +45,9 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         livenessProbe:
-          grpc:
-            port: 8082
-          initialDelaySeconds: 10
-          periodSeconds: 10
+          {{- toYaml .Values.worker.livenessProbe | nindent 12 }}
         readinessProbe:
-          grpc:
-            port: 8082
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          failureThreshold: 10
+          {{- toYaml .Values.worker.readinessProbe | nindent 12 }}
         env:
         - name: NODE_NAME
           valueFrom:

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -140,6 +140,19 @@ master:
               - key: "node-role.kubernetes.io/control-plane"
                 operator: In
                 values: [""]
+                
+  livenessProbe:
+    grpc:
+      port: 8082
+    initialDelaySeconds: 10
+    # failureThreshold: 3
+    # periodSeconds: 10
+  readinessProbe:
+    grpc:
+      port: 8082
+    initialDelaySeconds: 5
+    failureThreshold: 10
+    # periodSeconds: 10
 
 worker:
   enable: true
@@ -401,19 +414,18 @@ worker:
     runAsNonRoot: true
     # runAsUser: 1000
 
-  # livenessProbe: {}
-    ## NOTE: Currently not configurable, defaults are provided for the sake of extra documentation.
-    # grpc:
-    #   port: 8082
-    # initialDelaySeconds: 10
+  livenessProbe:
+    grpc:
+      port: 8082
+    initialDelaySeconds: 10
+    # failureThreshold: 3
     # periodSeconds: 10
-  # readinessProbe: {}
-    ## NOTE: Currently not configurable, defaults are provided for the sake of extra documentation.
-    # grpc:
-    #   port: 8082
-    # initialDelaySeconds: 5
+  readinessProbe:
+    grpc:
+      port: 8082
+    initialDelaySeconds: 5
+    failureThreshold: 10
     # periodSeconds: 10
-    # failureThreshold: 10
 
   serviceAccount:
     # Specifies whether a service account should be created.
@@ -492,20 +504,19 @@ topologyUpdater:
       drop: [ "ALL" ]
     readOnlyRootFilesystem: true
     runAsUser: 0
-
-  # livenessProbe: {}
-    ## NOTE: Currently not configurable, defaults are provided for the sake of extra documentation.
-    # grpc:
-    #   port: 8082
-    # initialDelaySeconds: 10
+  
+  livenessProbe:
+    grpc:
+      port: 8082
+    initialDelaySeconds: 10
+    # failureThreshold: 3
     # periodSeconds: 10
-  # readinessProbe: {}
-    ## NOTE: Currently not configurable, defaults are provided for the sake of extra documentation.
-    # grpc:
-    #   port: 8082
-    # initialDelaySeconds: 5
+  readinessProbe:
+    grpc:
+      port: 8082
+    initialDelaySeconds: 5
+    failureThreshold: 10
     # periodSeconds: 10
-    # failureThreshold: 10
 
   resources:
     limits:

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -144,6 +144,8 @@ API's you need to install the prometheus operator in your cluster.
 | `master.config`                     | dict    |                                  | NFD master [configuration](../reference/master-configuration-reference)                                                                                                                                |
 | `master.args`                       | array   | []                               | Additional [command line arguments](../reference/master-commandline-reference.md) to pass to nfd-master                                                                                                |
 | `master.revisionHistoryLimit`       | integer |                                  | Specify how many old ReplicaSets for this Deployment you want to retain. [revisionHistoryLimit](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit)          |
+| `master.livenessProbe`              | dict    | {"grpc":{"port":8082},"initialDelaySeconds":10}                       | NFD master pod [liveness probe](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/#liveness-probe)  |
+| `master.readinessProbe`             | dict    | {"grpc":{"port":8082},"initialDelaySeconds":5,"failureThreshold": 10} | NFD master pod [readiness probe](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/#readiness-probe)|
 
 ### Worker pod parameters
 
@@ -168,7 +170,9 @@ API's you need to install the prometheus operator in your cluster.
 | `worker.annotations`                | dict   | {}                      | NFD worker pod [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)                                                                                         |
 | `worker.daemonsetAnnotations`       | dict   | {}                      | NFD worker daemonset [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)                                                                                   |
 | `worker.args`                       | array  | []                      | Additional [command line arguments](../reference/worker-commandline-reference.md) to pass to nfd-worker                                                                                              |
-| `worker.revisionHistoryLimit`       | integer |                        | Specify how many old ControllerRevisions for this DaemonSet you want to retain. [revisionHistoryLimit](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec)          |
+| `worker.revisionHistoryLimit`       | integer |                        | Specify how many old ControllerRevisions for this DaemonSet you want to retain. [revisionHistoryLimit](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/ #DaemonSetSpec)          |
+| `worker.livenessProbe`              | dict    | {"grpc":{"port":8082},"initialDelaySeconds":10}                       | NFD worker pod [liveness probe](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/#liveness-probe)  |
+| `worker.readinessProbe`             | dict    | {"grpc":{"port":8082},"initialDelaySeconds":5,"failureThreshold": 10} | NFD worker pod [readiness probe](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/#readiness-probe)|
 
 ### Topology updater parameters
 
@@ -199,7 +203,9 @@ API's you need to install the prometheus operator in your cluster.
 | `topologyUpdater.podSetFingerprint`           | bool    | true                     | Enables compute and report of pod fingerprint in NRT objects.                                                                                                                                    |
 | `topologyUpdater.kubeletStateDir`             | string  | /var/lib/kubelet         | Specifies kubelet state directory path for watching state and checkpoint files. Empty value disables kubelet state tracking.                                                                     |
 | `topologyUpdater.args`                        | array   | []                       | Additional [command line arguments](../reference/topology-updater-commandline-reference.md) to pass to nfd-topology-updater                                                                      |
-| `topologyUpdater.revisionHistoryLimit`       | integer |                           | Specify how many old ControllerRevisions for this DaemonSet you want to retain. [revisionHistoryLimit](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec)          |
+| `topologyUpdater.revisionHistoryLimit`        | integer |                          | Specify how many old ControllerRevisions for this DaemonSet you want to retain. [revisionHistoryLimit](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec)          |
+| `topologyUpdater.livenessProbe`               | dict    | {"grpc":{"port":8082},"initialDelaySeconds":10}                       | Topology updater pod [liveness probe](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/#liveness-probe)  |
+| `topologyUpdater.readinessProbe`              | dict    | {"grpc":{"port":8082},"initialDelaySeconds":5,"failureThreshold": 10} | Topology updater pod [readiness probe](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/#readiness-probe)|
 
 ### Garbage collector parameters
 


### PR DESCRIPTION
Fixes: #1730
The following values.yaml:
```yaml
master:
  enable: true
  args: []
  config: ### <NFD-MASTER-CONF-START-DO-NOT-REMOVE>
    # noPublish: false
    # autoDefaultNs: true
    # extraLabelNs: ["added.ns.io","added.kubernets.io"]
    # denyLabelNs: ["denied.ns.io","denied.kubernetes.io"]
    # resourceLabels: ["vendor-1.com/feature-1","vendor-2.io/feature-2"]
    # enableTaints: false
    # labelWhiteList: "foo"
    # resyncPeriod: "2h"
    # klog:
    #    addDirHeader: false
    #    alsologtostderr: false
    #    logBacktraceAt:
    #    logtostderr: true
    #    skipHeaders: false
    #    stderrthreshold: 2
    #    v: 0
    #    vmodule:
    ##   NOTE: the following options are not dynamically run-time configurable
    ##         and require a nfd-master restart to take effect after being changed
    #    logDir:
    #    logFile:
    #    logFileMaxSize: 1800
    #    skipLogHeaders: false
    # leaderElection:
    #   leaseDuration: 15s
    #   # this value has to be lower than leaseDuration and greater than retryPeriod*1.2
    #   renewDeadline: 10s
    #   # this value has to be greater than 0
    #   retryPeriod: 2s
    # nfdApiParallelism: 10
  ### <NFD-MASTER-CONF-END-DO-NOT-REMOVE>
  # The TCP port that nfd-master listens for incoming requests. Default: 8080
  # Deprecated this parameter is related to the deprecated gRPC API and will
  # be removed with it in a future release
  port: 8080
  metricsPort: 8081
  instance:
  featureApi:
  resyncPeriod:
  denyLabelNs: []
  extraLabelNs: []
  resourceLabels: []
  enableTaints: false
  crdController: null
  featureRulesController: null
  nfdApiParallelism: null
  deploymentAnnotations: {}
  replicaCount: 1

  podSecurityContext: {}
    # fsGroup: 2000

  securityContext:
    allowPrivilegeEscalation: false
    capabilities:
      drop: [ "ALL" ]
    readOnlyRootFilesystem: true
    runAsNonRoot: true
    # runAsUser: 1000

  serviceAccount:
    # Specifies whether a service account should be created
    create: true
    # Annotations to add to the service account
    annotations: {}
    # The name of the service account to use.
    # If not set and create is true, a name is generated using the fullname template
    name:

  # specify how many old ReplicaSets for the Deployment to retain.
  revisionHistoryLimit:

  rbac:
    create: true

  service:
    type: ClusterIP
    port: 8080

  resources:
    limits:
      memory: 4Gi
    requests:
      cpu: 100m
      # You may want to use the same value for `requests.memory` and `limits.memory`. The “requests” value affects scheduling to accommodate pods on nodes.
      # If there is a large difference between “requests” and “limits” and nodes experience memory pressure, the kernel may invoke
      # the OOM Killer, even if the memory does not exceed the “limits” threshold. This can cause unexpected pod evictions. Memory
      # cannot be compressed and once allocated to a pod, it can only be reclaimed by killing the pod.
      # Natan Yellin 22/09/2022 https://home.robusta.dev/blog/kubernetes-memory-limit
      memory: 128Mi

  nodeSelector: {}

  tolerations:
  - key: "node-role.kubernetes.io/master"
    operator: "Equal"
    value: ""
    effect: "NoSchedule"
  - key: "node-role.kubernetes.io/control-plane"
    operator: "Equal"
    value: ""
    effect: "NoSchedule"

  annotations: {}

  affinity:
    nodeAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:
        - weight: 1
          preference:
            matchExpressions:
              - key: "node-role.kubernetes.io/master"
                operator: In
                values: [""]
        - weight: 1
          preference:
            matchExpressions:
              - key: "node-role.kubernetes.io/control-plane"
                operator: In
                values: [""]
                
  livenessProbe:
    grpc:
      port: 8082
    initialDelaySeconds: 10
    periodSeconds: 10
  readinessProbe:
    grpc:
      port: 8082
    initialDelaySeconds: 5
    periodSeconds: 10
    failureThreshold: 10
```

Will generate:
```yaml
---
# Source: node-feature-discovery/templates/master.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name:  release-name-node-feature-discovery-master
  namespace: default
  labels:
    helm.sh/chart: node-feature-discovery-0.2.1
    app.kubernetes.io/name: node-feature-discovery
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "master"
    app.kubernetes.io/managed-by: Helm
    role: master
spec:
  replicas: 1
  revisionHistoryLimit: 
  selector:
    matchLabels:
      app.kubernetes.io/name: node-feature-discovery
      app.kubernetes.io/instance: release-name
      role: master
  template:
    metadata:
      labels:
        app.kubernetes.io/name: node-feature-discovery
        app.kubernetes.io/instance: release-name
        role: master
    spec:
      serviceAccountName: release-name-node-feature-discovery
      enableServiceLinks: false
      securityContext:
        {}
      containers:
        - name: master
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
          image: "gcr.io/k8s-staging-nfd/node-feature-discovery:master"
          imagePullPolicy: Always
          livenessProbe:
            failureThreshold: 10
            grpc:
              port: 8082
            initialDelaySeconds: 5
            periodSeconds: 10
          readinessProbe:
            failureThreshold: 10
            grpc:
              port: 8082
            initialDelaySeconds: 5
            periodSeconds: 10
          ports:
          - containerPort: 8080
            name: grpc
          - containerPort: 8081
            name: metrics
          env:
          - name: NODE_NAME
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
          command:
            - "nfd-master"
          resources:
            limits:
              memory: 4Gi
            requests:
              cpu: 100m
              memory: 128Mi
          args:
            ## By default, disable crd controller for other than the default instances
            - "-crd-controller=true"
            # Go over featureGates and add the feature-gate flag
            - "-feature-gates=NodeFeatureAPI=true"
            - "-feature-gates=NodeFeatureGroupAPI=false"
            - "-metrics=8081"
          volumeMounts:
            - name: nfd-master-conf
              mountPath: "/etc/kubernetes/node-feature-discovery"
              readOnly: true
      volumes:
        - name: nfd-master-conf
          configMap:
            name: release-name-node-feature-discovery-master-conf
            items:
              - key: nfd-master.conf
                path: nfd-master.conf
      affinity:
        nodeAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - preference:
              matchExpressions:
              - key: node-role.kubernetes.io/master
                operator: In
                values:
                - ""
            weight: 1
          - preference:
              matchExpressions:
              - key: node-role.kubernetes.io/control-plane
                operator: In
                values:
                - ""
            weight: 1
      tolerations:
        - effect: NoSchedule
          key: node-role.kubernetes.io/master
          operator: Equal
          value: ""
        - effect: NoSchedule
          key: node-role.kubernetes.io/control-plane
          operator: Equal
          value: ""
---
# Source: node-feature-discovery/templates/worker.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name:  release-name-node-feature-discovery-worker
  namespace: default
  labels:
    helm.sh/chart: node-feature-discovery-0.2.1
    app.kubernetes.io/name: node-feature-discovery
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "master"
    app.kubernetes.io/managed-by: Helm
    role: worker
spec:
  revisionHistoryLimit: 
  selector:
    matchLabels:
      app.kubernetes.io/name: node-feature-discovery
      app.kubernetes.io/instance: release-name
      role: worker
  template:
    metadata:
      labels:
        app.kubernetes.io/name: node-feature-discovery
        app.kubernetes.io/instance: release-name
        role: worker
    spec:
      dnsPolicy: ClusterFirstWithHostNet
      serviceAccountName: release-name-node-feature-discovery-worker
      securityContext:
        {}
      containers:
      - name: worker
        securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
        image: "gcr.io/k8s-staging-nfd/node-feature-discovery:master"
        imagePullPolicy: Always
        livenessProbe:
            grpc:
              port: 8082
            initialDelaySeconds: 10
        readinessProbe:
            failureThreshold: 10
            grpc:
              port: 8082
            initialDelaySeconds: 5
        env:
        - name: NODE_NAME
          valueFrom:
            fieldRef:
              fieldPath: spec.nodeName
        - name: POD_NAME
          valueFrom:
            fieldRef:
              fieldPath: metadata.name
        - name: POD_UID
          valueFrom:
            fieldRef:
              fieldPath: metadata.uid
        resources:
            limits:
              memory: 512Mi
            requests:
              cpu: 5m
              memory: 64Mi
        command:
        - "nfd-worker"
        args:
# Go over featureGate and add the feature-gate flag
        - "-feature-gates=NodeFeatureAPI=true"
        - "-feature-gates=NodeFeatureGroupAPI=false"
        - "-metrics=8081"
        ports:
          - name: metrics
            containerPort: 8081
        volumeMounts:
        - name: host-boot
          mountPath: "/host-boot"
          readOnly: true
        - name: host-os-release
          mountPath: "/host-etc/os-release"
          readOnly: true
        - name: host-sys
          mountPath: "/host-sys"
          readOnly: true
        - name: host-usr-lib
          mountPath: "/host-usr/lib"
          readOnly: true
        - name: host-lib
          mountPath: "/host-lib"
          readOnly: true
        - name: host-proc-swaps
          mountPath: "/host-proc/swaps"
          readOnly: true
        - name: source-d
          mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
          readOnly: true
        - name: features-d
          mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
          readOnly: true
        - name: nfd-worker-conf
          mountPath: "/etc/kubernetes/node-feature-discovery"
          readOnly: true
      volumes:
        - name: host-boot
          hostPath:
            path: "/boot"
        - name: host-os-release
          hostPath:
            path: "/etc/os-release"
        - name: host-sys
          hostPath:
            path: "/sys"
        - name: host-usr-lib
          hostPath:
            path: "/usr/lib"
        - name: host-lib
          hostPath:
            path: "/lib"
        - name: host-proc-swaps
          hostPath:
            path: "/proc/swaps"
        - name: source-d
          hostPath:
            path: "/etc/kubernetes/node-feature-discovery/source.d/"
        - name: features-d
          hostPath:
            path: "/etc/kubernetes/node-feature-discovery/features.d/"
        - name: nfd-worker-conf
          configMap:
            name: release-name-node-feature-discovery-worker-conf
            items:
              - key: nfd-worker.conf
                path: nfd-worker.conf
---
# Source: node-feature-discovery/templates/topologyupdater.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: release-name-node-feature-discovery-topology-updater
  namespace: default
  labels:
    helm.sh/chart: node-feature-discovery-0.2.1
    app.kubernetes.io/name: node-feature-discovery
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "master"
    app.kubernetes.io/managed-by: Helm
    role: topology-updater
spec:
  revisionHistoryLimit: 
  selector:
    matchLabels:
      app.kubernetes.io/name: node-feature-discovery
      app.kubernetes.io/instance: release-name
      role: topology-updater
  template:
    metadata:
      labels:
        app.kubernetes.io/name: node-feature-discovery
        app.kubernetes.io/instance: release-name
        role: topology-updater
    spec:
      serviceAccountName: release-name-node-feature-discovery-topology-updater
      dnsPolicy: ClusterFirstWithHostNet
      securityContext:
        {}
      containers:
      - name: topology-updater
        image: "gcr.io/k8s-staging-nfd/node-feature-discovery:master"
        imagePullPolicy: "Always"
        livenessProbe:
          grpc:
            port: 8082
          initialDelaySeconds: 10
        readinessProbe:
          failureThreshold: 10
          grpc:
            port: 8082
          initialDelaySeconds: 5
        env:
        - name: NODE_NAME
          valueFrom:
            fieldRef:
              fieldPath: spec.nodeName
        - name: NODE_ADDRESS
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
        command:
          - "nfd-topology-updater"
        args:
          - "-podresources-socket=/host-var/lib/kubelet-podresources/kubelet.sock"
          - "-sleep-interval=60s"
          - "-watch-namespace=*"
          - -metrics=8081
        ports:
          - name: metrics
            containerPort: 8081
        volumeMounts:
        - name: kubelet-podresources-sock
          mountPath: /host-var/lib/kubelet-podresources/kubelet.sock
        - name: host-sys
          mountPath: /host-sys
        - name: kubelet-state-files
          mountPath: /host-var/lib/kubelet
          readOnly: true
        - name: nfd-topology-updater-conf
          mountPath: "/etc/kubernetes/node-feature-discovery"
          readOnly: true

        resources:
            limits:
              memory: 60Mi
            requests:
              cpu: 50m
              memory: 40Mi
        securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsUser: 0
      volumes:
      - name: host-sys
        hostPath:
          path: "/sys"
      - name: kubelet-podresources-sock
        hostPath:
          path: /var/lib/kubelet/pod-resources/kubelet.sock
      - name: kubelet-state-files
        hostPath:
          path: /var/lib/kubelet
      - name: nfd-topology-updater-conf
        configMap:
          name: release-name-node-feature-discovery-topology-updater-conf
          items:
            - key: nfd-topology-updater.conf
              path: nfd-topology-updater.conf

```

