### PR TITLE
nfd-master: check nfd api informer cache sync result

### DIFF
--- a/pkg/nfd-master/nfd-api-controller.go
+++ b/pkg/nfd-master/nfd-api-controller.go
@@ -161,7 +161,15 @@ func newNfdController(config *restclient.Config, nfdApiControllerOptions nfdApiC
 
 	// Start informers
 	informerFactory.Start(c.stopChan)
-	informerFactory.WaitForCacheSync(c.stopChan)
+	now := time.Now()
+	ret := informerFactory.WaitForCacheSync(c.stopChan)
+	for res, ok := range ret {
+		if !ok {
+			return nil, fmt.Errorf("informer cache failed to sync resource %s", res)
+		}
+	}
+
+	klog.InfoS("informer caches synced", "duration", time.Since(now))
 
 	return c, nil
 }


### PR DESCRIPTION
Bail out if there were errors in syncing the cache of any resource.