### PR TITLE
nfd-master: use only unbuffered chans in the nfd api-controller

### DIFF
--- a/pkg/nfd-master/nfd-api-controller.go
+++ b/pkg/nfd-master/nfd-api-controller.go
@@ -61,9 +61,9 @@ func init() {
 func newNfdController(config *restclient.Config, nfdApiControllerOptions nfdApiControllerOptions) (*nfdController, error) {
 	c := &nfdController{
 		stopChan:                       make(chan struct{}),
-		updateAllNodesChan:             make(chan struct{}, 1),
+		updateAllNodesChan:             make(chan struct{}),
 		updateOneNodeChan:              make(chan string),
-		updateAllNodeFeatureGroupsChan: make(chan struct{}, 1),
+		updateAllNodeFeatureGroupsChan: make(chan struct{}),
 		updateNodeFeatureGroupChan:     make(chan string),
 	}
 


### PR DESCRIPTION
There's no reason why the "update all" chans should be buffered (while the other are not).