### PR TITLE
Drop dynamic run-time reconfiguration

### DIFF
--- a/deployment/components/master-config/kustomization.yaml
+++ b/deployment/components/master-config/kustomization.yaml
@@ -1,9 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
-generatorOptions:
-  disableNameSuffixHash: true
-
 configMapGenerator:
 - files:
   - nfd-master.conf=nfd-master.conf.example

--- a/deployment/components/topology-updater-config/kustomization.yaml
+++ b/deployment/components/topology-updater-config/kustomization.yaml
@@ -1,9 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
-generatorOptions:
-  disableNameSuffixHash: true
-
 configMapGenerator:
 - files:
   - nfd-topology-updater.conf=nfd-topology-updater.conf.example

--- a/deployment/components/worker-config/kustomization.yaml
+++ b/deployment/components/worker-config/kustomization.yaml
@@ -1,9 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
-generatorOptions:
-  disableNameSuffixHash: true
-
 configMapGenerator:
 - files:
   - nfd-worker.conf=nfd-worker.conf.example

--- a/deployment/helm/node-feature-discovery/templates/master.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master.yaml
@@ -23,10 +23,11 @@ spec:
       labels:
         {{- include "node-feature-discovery.selectorLabels" . | nindent 8 }}
         role: master
-      {{- with .Values.master.annotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/nfd-master-conf.yaml") . | sha256sum }}
+        {{- with .Values.master.annotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
     {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}

--- a/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
+++ b/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
@@ -22,10 +22,11 @@ spec:
       labels:
         {{- include "node-feature-discovery.selectorLabels" . | nindent 8 }}
         role: topology-updater
-      {{- with .Values.topologyUpdater.annotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/nfd-topologyupdater-conf.yaml") . | sha256sum }}
+        {{- with .Values.topologyUpdater.annotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "node-feature-discovery.topologyUpdater.serviceAccountName" . }}
       dnsPolicy: ClusterFirstWithHostNet

--- a/deployment/helm/node-feature-discovery/templates/worker.yaml
+++ b/deployment/helm/node-feature-discovery/templates/worker.yaml
@@ -22,10 +22,11 @@ spec:
       labels:
         {{- include "node-feature-discovery.selectorLabels" . | nindent 8 }}
         role: worker
-      {{- with .Values.worker.annotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/nfd-worker-conf.yaml") . | sha256sum }}
+        {{- with .Values.worker.annotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       dnsPolicy: ClusterFirstWithHostNet
     {{- with .Values.priorityClassName }}

--- a/docs/reference/worker-configuration-reference.md
+++ b/docs/reference/worker-configuration-reference.md
@@ -151,8 +151,7 @@ core:
 
 ### core.klog
 
-The following options specify the logger configuration. Most of which can be
-dynamically adjusted at run-time.
+The following options specify the logger configuration.
 
 > **NOTE:** The logger options can also be specified via command line flags
 > which take precedence over any corresponding config file options.
@@ -163,15 +162,11 @@ If true, adds the file directory to the header of the log messages.
 
 Default: `false`
 
-Run-time configurable: yes
-
 #### core.klog.alsologtostderr
 
 Log to standard error as well as files.
 
 Default: `false`
-
-Run-time configurable: yes
 
 #### core.klog.logBacktraceAt
 
@@ -179,23 +174,17 @@ When logging hits line file:N, emit a stack trace.
 
 Default: *empty*
 
-Run-time configurable: yes
-
 #### core.klog.logDir
 
 If non-empty, write log files in this directory.
 
 Default: *empty*
 
-Run-time configurable: no
-
 #### core.klog.logFile
 
 If non-empty, use this log file.
 
 Default: *empty*
-
-Run-time configurable: no
 
 #### core.klog.logFileMaxSize
 
@@ -204,15 +193,11 @@ value is 0, the maximum file size is unlimited.
 
 Default: `1800`
 
-Run-time configurable: no
-
 #### core.klog.logtostderr
 
 Log to standard error instead of files
 
 Default: `true`
-
-Run-time configurable: yes
 
 #### core.klog.skipHeaders
 
@@ -220,21 +205,15 @@ If true, avoid header prefixes in the log messages.
 
 Default: `false`
 
-Run-time configurable: yes
-
 #### core.klog.skipLogHeaders
 
 If true, avoid headers when opening log files.
 
 Default: `false`
 
-Run-time configurable: no
-
 #### core.klog.stderrthreshold
 
 Logs at or above this threshold go to stderr (default 2)
-
-Run-time configurable: yes
 
 #### core.klog.v
 
@@ -242,15 +221,11 @@ Number for the log level verbosity.
 
 Default: `0`
 
-Run-time configurable: yes
-
 #### core.klog.vmodule
 
 Comma-separated list of `pattern=N` settings for file-filtered logging.
 
 Default: *empty*
-
-Run-time configurable: yes
 
 ## sources
 

--- a/docs/usage/nfd-master.md
+++ b/docs/usage/nfd-master.md
@@ -32,28 +32,27 @@ received from nfd-worker instances through
 
 ## Master configuration
 
-NFD-Master supports dynamic configuration through a configuration file. The
+NFD-Master supports configuration through a configuration file. The
 default location is `/etc/kubernetes/node-feature-discovery/nfd-master.conf`,
 but, this can be changed by specifying the`-config` command line flag.
-Configuration file is re-read whenever it is modified which makes run-time
-re-configuration of nfd-master straightforward.
 
 Master configuration file is read inside the container, and thus, Volumes and
 VolumeMounts are needed to make your configuration available for NFD. The
 preferred method is to use a ConfigMap which provides easy deployment and
 re-configurability.
 
-The provided nfd-master deployment templates create an empty configmap and
-mount it inside the nfd-master containers. In kustomize deployments,
-configuration can be edited with:
-
-```bash
-kubectl -n ${NFD_NS} edit configmap nfd-master-conf
-```
+The provided deployment methods (Helm and Kustomize) create an empty configmap
+and mount it inside the nfd-master containers.
 
 In Helm deployments,
 [Master pod parameter](../deployment/helm.md#master-pod-parameters)
 `master.config` can be used to edit the respective configuration.
+
+In Kustomize deployments, modify the `nfd-master-conf` ConfigMap with a custom
+overlay.
+
+> **NOTE:** dynamic run-time reconfiguration was dropped in NFD v0.17.
+> Re-configuration is handled by pod restarts.
 
 See
 [nfd-master configuration file reference](../reference/master-configuration-reference.md)

--- a/docs/usage/nfd-topology-updater.md
+++ b/docs/usage/nfd-topology-updater.md
@@ -62,26 +62,21 @@ NFD-Topology-Updater supports configuration through a configuration file. The
 default location is `/etc/kubernetes/node-feature-discovery/topology-updater.conf`,
 but, this can be changed by specifying the`-config` command line flag.
 
-> **NOTE:** unlike nfd-worker, dynamic configuration updates are not supported.
-
 Topology-Updater configuration file is read inside the container,
 and thus, Volumes and VolumeMounts are needed
 to make your configuration available for NFD.
 The preferred method is to use a ConfigMap
 which provides easy deployment and re-configurability.
 
-The provided nfd-topology-updater deployment templates
-create an empty configmap
+The provided deployment templates create an empty configmap
 and mount it inside the nfd-topology-updater containers.
-In kustomize deployments, configuration can be edited with:
-
-```bash
-kubectl -n ${NFD_NS} edit configmap nfd-topology-updater-conf
-```
 
 In Helm deployments,
 [Topology Updater parameters](../deployment/helm.md#topology-updater-parameters)
 `toplogyUpdater.config` can be used to edit the respective configuration.
+
+In Kustomize deployments, modify the `nfd-worker-conf` ConfigMap with a custom
+overlay.
 
 See
 [nfd-topology-updater configuration file reference](../reference/topology-updater-configuration-reference.md)

--- a/docs/usage/nfd-worker.md
+++ b/docs/usage/nfd-worker.md
@@ -19,13 +19,9 @@ This can be changed by using the
 [`core.sleepInterval`](../reference/worker-configuration-reference.md#coresleepinterval)
 config option.
 
-The worker configuration file is watched and re-read on every change which
-provides a mechanism of dynamic run-time reconfiguration. See
-[worker configuration](#worker-configuration) for more details.
-
 ## Worker configuration
 
-NFD-Worker supports dynamic configuration through a configuration file. The
+NFD-Worker supports configuration through a configuration file. The
 default location is `/etc/kubernetes/node-feature-discovery/nfd-worker.conf`,
 but, this can be changed by specifying the`-config` command line flag.
 Configuration file is re-read whenever it is modified which makes run-time
@@ -36,17 +32,18 @@ VolumeMounts are needed to make your configuration available for NFD. The
 preferred method is to use a ConfigMap which provides easy deployment and
 re-configurability.
 
-The provided nfd-worker deployment templates create an empty configmap and
-mount it inside the nfd-worker containers. In kustomize deployments,
-configuration can be edited with:
-
-```bash
-kubectl -n ${NFD_NS} edit configmap nfd-worker-conf
-```
+The provided deployment methods (Helm and Kustomize) create an empty configmap
+and mount it inside the nfd-master containers.
 
 In Helm deployments,
 [Worker pod parameter](../deployment/helm.md#worker-pod-parameters)
 `worker.config` can be used to edit the respective configuration.
+
+In Kustomize deployments, modify the `nfd-worker-conf` ConfigMap with a custom
+overlay.
+
+> **NOTE:** dynamic run-time reconfiguration was dropped in NFD v0.17.
+> Re-configuration is handled by pod restarts.
 
 See
 [nfd-worker configuration file reference](../reference/worker-configuration-reference)

--- a/test/e2e/node_feature_discovery_test.go
+++ b/test/e2e/node_feature_discovery_test.go
@@ -940,24 +940,6 @@ denyLabelNs: ["*.denied.ns","random.unwanted.ns"]
 				By("Deleting NodeFeature object")
 				err = nfdClient.NfdV1alpha1().NodeFeatures(f.Namespace.Name).Delete(ctx, nodeFeatures[0], metav1.DeleteOptions{})
 				Expect(err).NotTo(HaveOccurred())
-
-				// TODO: Find a better way to handle the timeout that happens to reflect the configmap changes
-				Skip("Testing the master dynamic configuration")
-				// Verify that config changes were applied
-				By("Updating the master config")
-				Expect(testutils.UpdateConfigMap(ctx, f.ClientSet, "nfd-master-conf", f.Namespace.Name, "nfd-master.conf", `
-denyLabelNs: []
-`))
-				By("Verifying that denied labels were removed")
-				expectedLabels = map[string]k8sLabels{
-					targetNodeName: {
-						nfdv1alpha1.FeatureLabelNs + "/e2e-nodefeature-test-4": "obj-4",
-						"custom.vendor.io/e2e-nodefeature-test-3":              "vendor-ns",
-						"random.denied.ns/e2e-nodefeature-test-1":              "denied-ns",
-						"random.unwanted.ns/e2e-nodefeature-test-2":            "unwanted-ns",
-					},
-				}
-				eventuallyNonControlPlaneNodes(ctx, f.ClientSet).Should(MatchLabels(expectedLabels, nodes))
 			})
 		})
 


### PR DESCRIPTION
Simplify the code and reduce possible error scenarios by dropping fsnotify-based reconfiguration from nfd-master and nfd-worker. Also eliminates repeated re-configuration in scenarios where kubelet continuosly touches the (every minute) mounted file (configmap) on the filesystem.

Also modifies the Helm and kustomize deployments so that nfd-master, nfd-worker and nfd-topology-updater pods are restarted on configmap updates. In kustomize, the slght downside of this is the name of the config map(s) depends on the content, so every time a user customizes the config data, the old unused configmap will be left and must be garbage-collected manually.

Fixes #1846