### PR TITLE
nfd-master: proper shutdown of nfd api informers

### DIFF
--- a/pkg/nfd-master/nfd-api-controller.go
+++ b/pkg/nfd-master/nfd-api-controller.go
@@ -206,7 +206,10 @@ func (c *nfdController) updateOneNode(typ string, obj metav1.Object) {
 		klog.ErrorS(err, "failed to determine node name for object", "type", typ, "object", klog.KObj(obj))
 		return
 	}
-	c.updateOneNodeChan <- nodeName
+	select {
+	case c.updateOneNodeChan <- nodeName:
+	case <-c.stopChan:
+	}
 }
 
 func (c *nfdController) updateAllNodes() {
@@ -217,7 +220,10 @@ func (c *nfdController) updateAllNodes() {
 }
 
 func (c *nfdController) updateNodeFeatureGroup(nodeFeatureGroup string) {
-	c.updateNodeFeatureGroupChan <- nodeFeatureGroup
+	select {
+	case c.updateNodeFeatureGroupChan <- nodeFeatureGroup:
+	case <-c.stopChan:
+	}
 }
 
 func (c *nfdController) updateAllNodeFeatureGroups() {

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -392,7 +392,7 @@ func (m *nfdMaster) Run() error {
 
 			// Update all nodes when the configuration changes
 			if m.nfdController != nil && nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.NodeFeatureAPI) {
-				m.nfdController.updateAllNodesChan <- struct{}{}
+				m.nfdController.updateAllNodes()
 			}
 
 		case <-m.stop:


### PR DESCRIPTION
Stop blocking on event channels when the api controller is stopped.
Ensures that the nfd API informer factory is properly shut down and all
resources released when stop() is called. This eliminates a memory leak
on re-configure events when leader election is enabled.

Fixes: #1841 