### PR TITLE
[release-0.16] nfd-master: proper shutdown of nfd api informers

### DIFF
--- a/pkg/nfd-master/nfd-api-controller.go
+++ b/pkg/nfd-master/nfd-api-controller.go
@@ -187,7 +187,10 @@ func (c *nfdController) updateOneNode(typ string, obj metav1.Object) {
 		klog.ErrorS(err, "failed to determine node name for object", "type", typ, "object", klog.KObj(obj))
 		return
 	}
-	c.updateOneNodeChan <- nodeName
+	select {
+	case c.updateOneNodeChan <- nodeName:
+	case <-c.stopChan:
+	}
 }
 
 func (c *nfdController) updateAllNodes() {
@@ -198,7 +201,10 @@ func (c *nfdController) updateAllNodes() {
 }
 
 func (c *nfdController) updateNodeFeatureGroup(nodeFeatureGroup string) {
-	c.updateNodeFeatureGroupChan <- nodeFeatureGroup
+	select {
+	case c.updateNodeFeatureGroupChan <- nodeFeatureGroup:
+	case <-c.stopChan:
+	}
 }
 
 func (c *nfdController) updateAllNodeFeatureGroups() {

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -393,7 +393,7 @@ func (m *nfdMaster) Run() error {
 
 			// Update all nodes when the configuration changes
 			if m.nfdController != nil && nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.NodeFeatureAPI) && m.args.EnableNodeFeatureApi {
-				m.nfdController.updateAllNodesChan <- struct{}{}
+				m.nfdController.updateAllNodes()
 			}
 
 		case <-m.stop:


### PR DESCRIPTION
Stop blocking on event channels when the api controller is stopped. Ensures that the nfd API informer factory is properly shut down and all resources released when stop() is called. This eliminates a memory leak on re-configure events when leader election is enabled.

(cherry picked from commit 2bb8a725321adce8b8b97203b54ee40a0ea9b96d)

Backports #1848 