### PR TITLE
Bump Go to v1.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ IMAGE_BUILD_CMD ?= docker build
 IMAGE_BUILD_EXTRA_OPTS ?=
 IMAGE_PUSH_CMD ?= docker push
 CONTAINER_RUN_CMD ?= docker run
-BUILDER_IMAGE ?= golang:1.22-bookworm
+BUILDER_IMAGE ?= golang:1.23-bookworm
 BASE_IMAGE_FULL ?= debian:bookworm-slim
 BASE_IMAGE_MINIMAL ?= scratch
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -2,7 +2,7 @@
 
 BASE_IMAGE_MINIMAL="gcr.io/distroless/base"
 BASE_IMAGE_FULL="debian:bullseye-slim"
-BUILDER_IMAGE="golang:1.22-bullseye"
+BUILDER_IMAGE="golang:1.23-bookworm"
 HOSTMOUNT_PREFIX="/host-"
 IMAGE_TAG_NAME = os.getenv('IMAGE_TAG_NAME', "master")
 IMAGE_REGISTRY = os.getenv('IMAGE_REGISTRY', "gcr.io/k8s-staging-nfd")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/node-feature-discovery
 
-go 1.22.2
+go 1.23.0
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0


### PR DESCRIPTION
NOTE: api/nfd/go.mod is not bumped. There should be no need to force the importers of the API to v1.23 (yet).