### PR TITLE
nfd-worker: Add an option to disable setting the owner references

### DIFF
--- a/cmd/nfd-worker/main.go
+++ b/cmd/nfd-worker/main.go
@@ -94,6 +94,8 @@ func parseArgs(flags *flag.FlagSet, osArgs ...string) *worker.Args {
 			args.Overrides.FeatureSources = overrides.FeatureSources
 		case "label-sources":
 			args.Overrides.LabelSources = overrides.LabelSources
+		case "no-owner-refs":
+			args.Overrides.NoOwnerRefs = overrides.NoOwnerRefs
 		}
 	})
 
@@ -126,6 +128,8 @@ func initFlags(flagset *flag.FlagSet) (*worker.Args, *worker.ConfigOverrideArgs)
 	}
 	overrides.NoPublish = flagset.Bool("no-publish", false,
 		"Do not publish discovered features, disable connection to nfd-master and don't create NodeFeature object.")
+	overrides.NoOwnerRefs = flagset.Bool("no-owner-refs", false,
+		"Do not set owner references for NodeFeature object.")
 	flagset.Var(overrides.FeatureSources, "feature-sources",
 		"Comma separated list of feature sources. Special value 'all' enables all sources. "+
 			"Prefix the source name with '-' to disable it.")

--- a/cmd/nfd-worker/main_test.go
+++ b/cmd/nfd-worker/main_test.go
@@ -43,12 +43,14 @@ func TestParseArgs(t *testing.T) {
 		Convey("When all override args are specified", func() {
 			args := parseArgs(flags,
 				"-no-publish",
+				"-no-owner-refs",
 				"-feature-sources=cpu",
 				"-label-sources=fake1,fake2,fake3")
 
 			Convey("args.sources is set to appropriate values", func() {
 				So(args.Oneshot, ShouldBeFalse)
 				So(*args.Overrides.NoPublish, ShouldBeTrue)
+				So(*args.Overrides.NoOwnerRefs, ShouldBeTrue)
 				So(*args.Overrides.FeatureSources, ShouldResemble, utils.StringSliceVal{"cpu"})
 				So(*args.Overrides.LabelSources, ShouldResemble, utils.StringSliceVal{"fake1", "fake2", "fake3"})
 			})

--- a/deployment/components/worker-config/nfd-worker.conf.example
+++ b/deployment/components/worker-config/nfd-worker.conf.example
@@ -1,6 +1,7 @@
 #core:
 #  labelWhiteList:
 #  noPublish: false
+#  noOwnerRefs: false
 #  sleepInterval: 60s
 #  featureSources: [all]
 #  labelSources: [all]

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -177,6 +177,7 @@ worker:
     #core:
     #  labelWhiteList:
     #  noPublish: false
+    #  noOwnerRefs: false
     #  sleepInterval: 60s
     #  featureSources: [all]
     #  labelSources: [all]

--- a/docs/reference/worker-commandline-reference.md
+++ b/docs/reference/worker-commandline-reference.md
@@ -162,6 +162,23 @@ Example:
 nfd-worker -no-publish
 ```
 
+### -no-owner-refs
+
+The `-no-owner-refs` flag disables setting the owner references to Pod
+of the NodeFeature object.
+
+> **NOTE:** This flag takes precedence over the
+> [`core.noOwnerRefs`](worker-configuration-reference.md#corenoownerrefs)
+> configuration file option.
+
+Default: *false*
+
+Example:
+
+```bash
+nfd-worker -no-owner-refs
+```
+
 ### -oneshot
 
 The `-oneshot` flag causes nfd-worker to exit after one pass of feature

--- a/docs/reference/worker-configuration-reference.md
+++ b/docs/reference/worker-configuration-reference.md
@@ -149,6 +149,24 @@ core:
   noPublish: true
 ```
 
+### core.noOwnerRefs
+
+Setting `core.noOwnerRefs` to `true` disables setting the owner references
+of the NodeFeature object created by the nfd-worker.
+
+> **NOTE:** Overridden by the
+> [`-no-owner-refs`](worker-commandline-reference.md#-no-owner-refs)
+> command line flag (if specified).
+
+Default: `false`
+
+Example:
+
+```yaml
+core:
+  noOwnerRefs: true
+```
+
 ### core.klog
 
 The following options specify the logger configuration.


### PR DESCRIPTION
In some cases it's desirable to control automatic garbage collection of NodeFeature object.

Add an option to disable setting the owner references to Pod for NodeFeature object.

Closes: #1817