### PR TITLE
source/system: Add reading product name information

### DIFF
--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -1027,6 +1027,7 @@ The following features are available for matching:
 |                  |              | **`<parameter>`** | string | One parameter from `/etc/os-release` |
 | **`system.dmiid`** | attribute |       |            | DMI identification data from `/sys/devices/virtual/dmi/id/` |
 |                  |              | **`sys_vendor`** | string | Vendor name from `/sys/devices/virtual/dmi/id/sys_vendor` |
+|                  |              | **`product_name`** | string | Product name from `/sys/devices/virtual/dmi/id/product_name` |
 | **`system.name`** | attribute   |          |            | System name information |
 |                  |              | **`nodename`** | string | Name of the kubernetes node object |
 | **`usb.device`** | instance     |          |            | USB devices present in the system |

--- a/source/system/system.go
+++ b/source/system/system.go
@@ -103,7 +103,7 @@ func (s *systemSource) Discover() error {
 	}
 
 	// Get DMI ID attributes
-	dmiIDAttributeNames := []string{"sys_vendor"}
+	dmiIDAttributeNames := []string{"sys_vendor", "product_name"}
 	dmiAttrs := make(map[string]string)
 	for _, name := range dmiIDAttributeNames {
 		val, err := getDmiIDAttribute(name)


### PR DESCRIPTION
This PR adds Add reading product name information from `/sys/devices/virtual/dmi/id/product_name`.

I want to add this feature because I want to label based on the product name of the compute machine.