### PR TITLE
[WIP] NFD compatibility client prototype

### DIFF
--- a/api/image-compatibility/v1alpha1/spec.go
+++ b/api/image-compatibility/v1alpha1/spec.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+const ArtifactType = "application/vnd.k8s.nfd.image-compatibility.v1"
+
+type Spec struct {
+	Compatibilties []Compatibility `json:"compatibilities"`
+}
+
+type Compatibility struct {
+	Labels      map[string]interface{} `json:"labels"`
+	Tags        []string               `json:"tags,omitempty"`
+	Description string                 `json:"description,omitempty"`
+}

--- a/cmd/client-nfd/main.go
+++ b/cmd/client-nfd/main.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"sigs.k8s.io/node-feature-discovery/cmd/client-nfd/subcmd"
+)
+
+const ProgramName = "nfd"
+
+func main() {
+	subcmd.Execute()
+}

--- a/cmd/client-nfd/subcmd/compat/attach.go
+++ b/cmd/client-nfd/subcmd/compat/attach.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compat
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var specFilePath string
+
+var createArtifactCmd = &cobra.Command{
+	Use:   "attach",
+	Short: "Attach compatibility artifact to image",
+	Long:  "Attach image compatibility artifact for nodes validation and better pod scheduling",
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		return nil
+	},
+}
+
+func init() {
+	CompatCmd.AddCommand(createArtifactCmd)
+	createArtifactCmd.Flags().StringVar(&specFilePath, "spec-file", "", "Path to file with image compatibility spec")
+	createArtifactCmd.MarkFlagRequired("spec-file")
+}

--- a/cmd/client-nfd/subcmd/compat/compat.go
+++ b/cmd/client-nfd/subcmd/compat/compat.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compat
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var CompatCmd = &cobra.Command{
+	Use:   "compat",
+	Short: "image compatibility commands",
+	Long:  "TBD",
+}
+
+func Execute() {
+	if err := CompatCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/cmd/client-nfd/subcmd/compat/validate-node.go
+++ b/cmd/client-nfd/subcmd/compat/validate-node.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compat
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"oras.land/oras-go/v2/registry"
+
+	pkgcompat "sigs.k8s.io/node-feature-discovery/pkg/client-nfd/compat"
+)
+
+var (
+	image string
+)
+
+// TODO:
+// * add secrets handling
+// * add validation strategy
+
+var validateNodeCmd = &cobra.Command{
+	Use:   "validate-node",
+	Short: "Validate node based on image compatibility metadata",
+	Long:  "Validate node based on image compatibility metadata from the NFD artifact",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+
+		ref, err := registry.ParseReference(image)
+		if err != nil {
+			return err
+		}
+		results, err := pkgcompat.ValidateNode(ctx, &ref)
+		if err != nil {
+			return err
+		}
+		// TODO: add a better report
+		for i, r := range results {
+			msg := fmt.Sprintf("COMPATIBILITY GROUP NO %d", i+1)
+			if r.IsNodeValid {
+				msg += " \033[32mSUCEEDS\033[0m"
+			} else {
+				msg += " \033[31mFAILS\033[0m"
+			}
+			msg += fmt.Sprintf(" (%d/%d)", r.ChecksSucceded, r.ChecksTotal)
+			fmt.Println(msg)
+			fmt.Println("========================")
+			for k, v := range r.LabelsCheck {
+				fmt.Printf("%s - %s\n", k, v)
+			}
+			fmt.Println()
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	CompatCmd.AddCommand(validateNodeCmd)
+	validateNodeCmd.Flags().StringVar(&image, "image", "", "URL of image with compatibility metadata")
+	if err := validateNodeCmd.MarkFlagRequired("image"); err != nil {
+		panic(err)
+	}
+}

--- a/cmd/client-nfd/subcmd/root.go
+++ b/cmd/client-nfd/subcmd/root.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subcmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/node-feature-discovery/cmd/client-nfd/subcmd/compat"
+)
+
+// RootCmd represents the base command when called without any subcommands
+var RootCmd = &cobra.Command{
+	Use:   "nfd",
+	Short: "NFD client",
+	Long:  `NFD client TBD`,
+}
+
+func init() {
+	RootCmd.AddCommand(compat.CompatCmd)
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/examples/compatibility-6-wind-router.json
+++ b/examples/compatibility-6-wind-router.json
@@ -34,16 +34,26 @@
     },
     {
       "labels": {
-        "system-os.release.ID": "ubuntu",
-        "system-os.release.VERSION_ID": "20.04;22.04"
+        "system-os_release.ID": "linuxmint",
+        "system-os_release.VERSION_ID": "21.0;21.2",
+        "kernel-version.full": ">=5.0.0-x-generic,<6.10.0-x-generic"
       },
-      "description": "required configuration for ubuntu",
-      "tags": ["ubuntu-os"]
+      "description": "required configuration for linux mint",
+      "tags": ["mint-os"]
     },
     {
       "labels": {
-        "system-os.release.ID": "rhel",
-        "system-os.release.VERSION_ID": "8"
+        "system-os_release.ID": "ubuntu",
+        "system-os_release.VERSION_ID": "20.04;22.04",
+        "kernel-version.full": ">=5.0.0-x-gcp,<6.10.0-x-gcp"
+      },
+      "description": "required configuration for GCP ubuntu version",
+      "tags": ["ubuntu-gcp-os"]
+    },
+    {
+      "labels": {
+        "system-os_release.ID": "rhel",
+        "system-os_release.VERSION_ID": "8"
       },
       "description": "required configuration for rhel",
       "tags": ["rhel-os"]

--- a/examples/compatibility-6-wind-router.json
+++ b/examples/compatibility-6-wind-router.json
@@ -36,7 +36,7 @@
       "labels": {
         "system-os_release.ID": "linuxmint",
         "system-os_release.VERSION_ID": "21.0;21.2",
-        "kernel-version.full": ">=5.0.0-x-generic,<6.10.0-x-generic"
+        "kernel-version.full": ">=5.15.0-.*-generic,<6.10.0-.*-generic"
       },
       "description": "required configuration for linux mint",
       "tags": ["mint-os"]
@@ -45,7 +45,7 @@
       "labels": {
         "system-os_release.ID": "ubuntu",
         "system-os_release.VERSION_ID": "20.04;22.04",
-        "kernel-version.full": ">=5.0.0-x-gcp,<6.10.0-x-gcp"
+        "kernel-version.full": ">=5.0.0-.*-gcp,<6.10.0-.*-gcp"
       },
       "description": "required configuration for GCP ubuntu version",
       "tags": ["ubuntu-gcp-os"]

--- a/examples/compatibility-6-wind-router.json
+++ b/examples/compatibility-6-wind-router.json
@@ -1,0 +1,59 @@
+{
+  "compatibilities": [
+    {
+      "labels": {
+          "cpu-model.vendor_id": "Intel"
+      },
+      "description": "required cpu vendor"
+    },
+    {
+      "labels": {
+        "kernel-config.CONFIG_CGROUP_BPF": "y",
+        "kernel-config.CONFIG_XFRM_INTERFACE": "y",
+        "kernel-config.CONFIG_NF_TABLES": "y",
+        "kernel-config.CONFIG_NETFILTER_XT_TARGET_NOTRACK": "y",
+        "kernel-config.CONFIG_NET_ACT_BPF": "y",
+        "kernel-config.CONFIG_MPLS_ROUTING": "y",
+        "kernel-config.CONFIG_MPLS_IPTUNNEL": "y",
+        "kernel-config.CONFIG_PPPOE": "y",
+        "kernel-loadedmodule.br_netfilter": true,
+        "kernel-loadedmodule.ebtables": true,
+        "kernel-loadedmodule.ifb": true,
+        "kernel-loadedmodule.ip6_tables": true,
+        "kernel-loadedmodule.ip_tables": true,
+        "kernel-loadedmodule.mpls_iptunnel": true,
+        "kernel-loadedmodule.mpls_router": true,
+        "kernel-loadedmodule.nf_conntrack": true,
+        "kernel-loadedmodule.overlay": true,
+        "kernel-loadedmodule.ppp_generic": true,
+        "kernel-loadedmodule.vfio-pci": true,
+        "kernel-loadedmodule.vhost-net": true,
+        "kernel-loadedmodule.vrf": true
+      },
+      "description": "required kernel configuration"
+    },
+    {
+      "labels": {
+        "system-os.release.ID": "ubuntu",
+        "system-os.release.VERSION_ID": "20.04;22.04"
+      },
+      "description": "required configuration for ubuntu",
+      "tags": ["ubuntu-os"]
+    },
+    {
+      "labels": {
+        "system-os.release.ID": "rhel",
+        "system-os.release.VERSION_ID": "8"
+      },
+      "description": "required configuration for rhel",
+      "tags": ["rhel-os"]
+    },
+    {
+      "labels": {
+        "network-sriov.capable": true,
+        "network-sriov.configured": true
+      },
+      "description": "required network configuration"
+    }
+  ]
+}

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	github.com/sirupsen/logrus v1.9.0 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smarty/assertions v1.15.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module sigs.k8s.io/node-feature-discovery
 go 1.23.0
 
 require (
+	github.com/Masterminds/semver/v3 v3.3.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.6.0
@@ -11,9 +12,16 @@ require (
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.2
 	github.com/k8stopologyawareschedwg/podfingerprint v0.2.2
 	github.com/klauspost/cpuid/v2 v2.2.8
+<<<<<<< HEAD
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
 	github.com/opencontainers/runc v1.1.14
+=======
+	github.com/onsi/ginkgo/v2 v2.20.0
+	github.com/onsi/gomega v1.34.1
+	github.com/opencontainers/image-spec v1.1.0
+	github.com/opencontainers/runc v1.1.13
+>>>>>>> 4ef5f4b6 (NFD compatibility client prototype)
 	github.com/prometheus/client_golang v1.18.0
 	github.com/smartystreets/goconvey v1.8.1
 	github.com/spf13/cobra v1.8.1
@@ -36,6 +44,7 @@ require (
 	k8s.io/kubernetes v1.30.3
 	k8s.io/pod-security-admission v0.30.3
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
+	oras.land/oras-go/v2 v2.5.0
 	sigs.k8s.io/node-feature-discovery/api/nfd v0.0.0-00010101000000-000000000000
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncj
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/seccomp/libseccomp-golang v0.10.0 h1:aA4bp+/Zzi0BnWZ2F1wgNBs5gTpm+na2rWM6M9YjLpY=
 github.com/seccomp/libseccomp-golang v0.10.0/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
-github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
-github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smarty/assertions v1.15.1 h1:812oFiXI+G55vxsFf+8bIZ1ux30qtkdqzKbEFwyX3Tk=
 github.com/smarty/assertions v1.15.1/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
 github.com/smartystreets/goconvey v1.8.1 h1:qGjIddxOk4grTu9JPOU31tVfq3cNdBlNa5sSznIX1xY=

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGB
 cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab h1:UKkYhof1njT1/xq4SEg5z+VpTgjmNeHwPGRQl7takDI=
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
+github.com/Masterminds/semver/v3 v3.3.0 h1:B8LGeaivUe71a5qox1ICM/JLl0NqZSW5CHyL+hmvYS0=
+github.com/Masterminds/semver/v3 v3.3.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.0 h1:slsWYD/zyx7lCXoZVlvQrj0hPTM1HI4+v1sIda2yDvg=
 github.com/Microsoft/go-winio v0.6.0/go.mod h1:cTAf44im0RAYeL23bpB+fzCyDH2MJiz2BO69KH/soAE=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
@@ -194,8 +196,15 @@ github.com/onsi/gomega v1.34.2 h1:pNCwDkzrsv7MS9kpaQvVb1aVLahQXyJ/Tv5oAZMI3i8=
 github.com/onsi/gomega v1.34.2/go.mod h1:v1xfxRgk0KIsG+QOdm7p8UosrOzPYRo60fd3B/1Dukc=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+<<<<<<< HEAD
 github.com/opencontainers/runc v1.1.14 h1:rgSuzbmgz5DUJjeSnw337TxDbRuqjs6iqQck/2weR6w=
 github.com/opencontainers/runc v1.1.14/go.mod h1:E4C2z+7BxR7GHXp0hAY53mek+x49X1LjPNeMTfRGvOA=
+=======
+github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
+github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
+github.com/opencontainers/runc v1.1.13 h1:98S2srgG9vw0zWcDpFMn5TRrh8kLxa/5OFUstuUhmRs=
+github.com/opencontainers/runc v1.1.13/go.mod h1:R016aXacfp/gwQBYw2FDGa9m+n6atbLWrYY8hNMT/sA=
+>>>>>>> 4ef5f4b6 (NFD compatibility client prototype)
 github.com/opencontainers/runtime-spec v1.1.0-rc.2 h1:ucBtEms2tamYYW/SvGpvq9yUN0NEVL6oyLEwDcTSrk8=
 github.com/opencontainers/runtime-spec v1.1.0-rc.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
@@ -442,6 +451,8 @@ k8s.io/pod-security-admission v0.30.3 h1:UDGZWR3ry/XrN/Ki/w7qrp49OwgQsKyh+6xWbex
 k8s.io/pod-security-admission v0.30.3/go.mod h1:T1EQSOLl9YyDMnXNJfsq2jeci6uoymY0mrRkkKihd98=
 k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=
 k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+oras.land/oras-go/v2 v2.5.0 h1:o8Me9kLY74Vp5uw07QXPiitjsw7qNXi8Twd+19Zf02c=
+oras.land/oras-go/v2 v2.5.0/go.mod h1:z4eisnLP530vwIOUOJeBIj0aGI0L1C3d53atvCBqZHg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.29.0 h1:/U5vjBbQn3RChhv7P11uhYvCSm5G2GaIi5AIGBS6r4c=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.29.0/go.mod h1:z7+wmGM2dfIiLRfrC6jb5kV2Mq/sK1ZP303cxzkV5Y4=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=

--- a/pkg/client-nfd/compat/attach.go
+++ b/pkg/client-nfd/compat/attach.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compat

--- a/pkg/client-nfd/compat/match/generic.go
+++ b/pkg/client-nfd/compat/match/generic.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package match
+
+import (
+	"fmt"
+
+	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
+	"sigs.k8s.io/node-feature-discovery/pkg/client-nfd/compat/parser"
+	"sigs.k8s.io/node-feature-discovery/source"
+)
+
+type GenericMatcher struct {
+	SourceName   string
+	Initialized  bool
+	NodeFeatures *nfdv1alpha1.Features
+	NodeLabels   source.FeatureLabels
+
+	Validate ValidateFunc
+}
+
+func (m *GenericMatcher) Init() (err error) {
+	f := source.GetFeatureSource(m.SourceName)
+	if err := f.Discover(); err != nil {
+		return err
+	}
+	m.NodeFeatures = f.GetFeatures()
+
+	m.NodeLabels, err = source.GetLabelSource(m.SourceName).GetLabels()
+	if err != nil {
+		return err
+	}
+
+	m.Initialized = true
+
+	return nil
+}
+
+func (m *GenericMatcher) Check(entry parser.EntryGetter) (bool, error) {
+	if !m.Initialized {
+		if err := m.Init(); err != nil {
+			return false, err
+		}
+	}
+
+	return m.Validate(entry, m.NodeLabels, m.NodeFeatures)
+}
+
+func NewGenericMatcher(sourceName string, validate ValidateFunc) *GenericMatcher {
+	return &GenericMatcher{
+		SourceName: sourceName,
+		Validate:   validate,
+	}
+}
+
+func ValidateDefault(imageLabel parser.EntryGetter, nodeLabels source.FeatureLabels, _ *nfdv1alpha1.Features) (bool, error) {
+	if v, ok := nodeLabels[fmt.Sprintf("%s.%s", imageLabel.Feature(), imageLabel.Option())]; ok {
+		res, err := imageLabel.ValueEqualTo(v)
+		return res, err
+	}
+	return false, nil
+}

--- a/pkg/client-nfd/compat/match/kernel.go
+++ b/pkg/client-nfd/compat/match/kernel.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package match
+
+import (
+	"fmt"
+
+	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
+	"sigs.k8s.io/node-feature-discovery/pkg/client-nfd/compat/parser"
+	"sigs.k8s.io/node-feature-discovery/source"
+	"sigs.k8s.io/node-feature-discovery/source/kernel"
+)
+
+func ValidateKernel(imageLabel parser.EntryGetter, nodeLabels source.FeatureLabels, nodeFeatures *nfdv1alpha1.Features) (bool, error) {
+	switch f := imageLabel.Feature(); f {
+	case kernel.SelinuxFeature, kernel.VersionFeature:
+		// SeLinux and Version are advertised as labels
+		// thus it's ok to use the default match
+		return ValidateDefault(imageLabel, nodeLabels, nodeFeatures)
+	case kernel.ConfigFeature:
+		// Kernel config is advertised as labels by enabling specific items over allowed list.
+		// It makes more sense to look into discovered features than modifying NFD configuration for the image compatibility validation.
+		if v, ok := nodeFeatures.Attributes[kernel.ConfigFeature].Elements[imageLabel.Option()]; ok {
+			return imageLabel.ValueEqualTo(v)
+		}
+	case kernel.LoadedModuleFeature:
+		if _, ok := nodeFeatures.Flags[kernel.LoadedModuleFeature].Elements[imageLabel.Option()]; ok {
+			return true, nil
+		}
+	default:
+		return false, fmt.Errorf("unsupported kernel feature %q", f)
+	}
+
+	return false, nil
+}

--- a/pkg/client-nfd/compat/match/match.go
+++ b/pkg/client-nfd/compat/match/match.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package match
+
+import (
+	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
+	"sigs.k8s.io/node-feature-discovery/pkg/client-nfd/compat/parser"
+	"sigs.k8s.io/node-feature-discovery/source"
+
+	// Register sources for validation
+	"sigs.k8s.io/node-feature-discovery/source/cpu"
+	"sigs.k8s.io/node-feature-discovery/source/kernel"
+	"sigs.k8s.io/node-feature-discovery/source/local"
+	"sigs.k8s.io/node-feature-discovery/source/memory"
+	"sigs.k8s.io/node-feature-discovery/source/network"
+	"sigs.k8s.io/node-feature-discovery/source/pci"
+	"sigs.k8s.io/node-feature-discovery/source/storage"
+	"sigs.k8s.io/node-feature-discovery/source/system"
+	"sigs.k8s.io/node-feature-discovery/source/usb"
+)
+
+var Sources map[string]Matcher = make(map[string]Matcher)
+
+type ValidateFunc func(imageLabel parser.EntryGetter, nodeLabels source.FeatureLabels, nodeFeatures *nfdv1alpha1.Features) (bool, error)
+
+type Matcher interface {
+	Init() error
+	Check(parser.EntryGetter) (bool, error)
+}
+
+func init() {
+	// Register sources with default match function
+	Sources[cpu.Name] = NewGenericMatcher(cpu.Name, ValidateDefault)
+	// TODO: add support for custom features
+	// Sources[custom.Name] = NewGenericMatcher(custom.Name, ValidateDefault)
+	Sources[local.Name] = NewGenericMatcher(local.Name, ValidateDefault)
+	Sources[memory.Name] = NewGenericMatcher(memory.Name, ValidateDefault)
+	Sources[network.Name] = NewGenericMatcher(network.Name, ValidateDefault)
+	Sources[pci.Name] = NewGenericMatcher(pci.Name, ValidateDefault)
+	Sources[storage.Name] = NewGenericMatcher(storage.Name, ValidateDefault)
+	Sources[system.Name] = NewGenericMatcher(system.Name, ValidateDefault)
+	Sources[usb.Name] = NewGenericMatcher(usb.Name, ValidateDefault)
+
+	// Register kernel source with custom kernel match function.
+	// Kernel modules and config are not reported as labels, thus
+	// it's necessary to have lookup into raw data and have a custom match function
+	Sources[kernel.Name] = NewGenericMatcher(kernel.Name, ValidateKernel)
+}

--- a/pkg/client-nfd/compat/parser/entry.go
+++ b/pkg/client-nfd/compat/parser/entry.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parser
+
+import (
+	"fmt"
+	"strconv"
+
+	semver "github.com/Masterminds/semver/v3"
+
+	"sigs.k8s.io/node-feature-discovery/source"
+)
+
+type ValueType string
+
+func (t ValueType) String() string {
+	return string(t)
+}
+
+const (
+	LiteralValueType ValueType = "literal"
+	RangeValueType   ValueType = "range"
+)
+
+type EntryGetter interface {
+	KeyRaw() string
+	Source() string
+	Feature() string
+	Option() string
+	ValueRaw() interface{}
+	ValueType() ValueType
+	ValueEqualTo(source.FeatureLabelValue) (bool, error)
+}
+
+type CompatibilityEntry struct {
+	// Key
+	keyRaw  string
+	source  string
+	feature string
+	option  string
+
+	// Value
+	value CompatibilityValue
+}
+
+type CompatibilityValue struct {
+	raw       interface{}
+	kind      ValueType
+	intervals []string
+}
+
+func (c *CompatibilityEntry) KeyRaw() string {
+	return c.keyRaw
+}
+
+func (c *CompatibilityEntry) Source() string {
+	return c.source
+}
+
+func (c *CompatibilityEntry) Feature() string {
+	return c.feature
+}
+
+func (c *CompatibilityEntry) Option() string {
+	return c.option
+}
+
+func (c *CompatibilityEntry) ValueRaw() interface{} {
+	return c.value.raw
+}
+
+func (c *CompatibilityEntry) ValueType() ValueType {
+	return c.value.kind
+}
+
+func (c *CompatibilityEntry) ValueEqualTo(val source.FeatureLabelValue) (bool, error) {
+	switch c.value.kind {
+	case LiteralValueType:
+		return c.equalTo(val)
+	case RangeValueType:
+		return c.inRange(val)
+	default:
+		return false, fmt.Errorf("unknown type: %v", c.value.kind)
+	}
+}
+
+func (c *CompatibilityEntry) equalTo(val interface{}) (bool, error) {
+	switch v := val.(type) {
+	case string:
+		// NFD label boolean values are converted to string.
+		// It may be required to keep it this way for k8s labelling.
+		// TODO: either fix this in NFD or leave it as it is.
+		valB, err := strconv.ParseBool(v)
+		if err == nil {
+			cvB, ok := c.value.raw.(bool)
+			if ok {
+				return cvB == valB, nil
+			}
+			return false, nil
+		}
+		return c.value.raw == val, nil
+	case bool:
+		return c.value.raw == val, nil
+	default:
+		return false, fmt.Errorf("only string and boolean types are allowed for comparison")
+	}
+}
+
+func (c *CompatibilityEntry) inRange(val interface{}) (bool, error) {
+	val, ok := val.(string)
+	if !ok {
+		return false, fmt.Errorf("only string type is allowed to compare value to ranges")
+	}
+
+	// TODO: fix kernel versions comparison - this not gonna work for very
+	// flavor of the kernel has to be cut and compared separately,
+	// currently it's treated as a pre-release which is wrong!
+	v, err := semver.NewVersion(val.(string))
+	if err != nil {
+		return false, err
+	}
+
+	for _, constraint := range c.value.intervals {
+		c, err := semver.NewConstraint(constraint)
+		if err != nil {
+			return false, err
+		}
+
+		valid, _ := c.Validate(v)
+		if valid {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/client-nfd/compat/parser/parser.go
+++ b/pkg/client-nfd/compat/parser/parser.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parser
+
+import (
+	"fmt"
+	"strings"
+)
+
+func Parse(labelKey string, labelValue interface{}) (EntryGetter, error) {
+	var err error
+	entry := &CompatibilityEntry{
+		keyRaw: labelKey,
+		value: CompatibilityValue{
+			raw: labelValue,
+		},
+	}
+
+	entry.source, entry.feature, entry.option, err = parseKey(entry.keyRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	entry.value.kind, entry.value.intervals, err = parseValue(entry.value.raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return entry, nil
+}
+
+func parseKey(key string) (source, feature, option string, err error) {
+	sourceSplit := strings.SplitN(key, "-", 2)
+	if len(sourceSplit) <= 1 {
+		return "", "", "", fmt.Errorf("invalid label %q", key)
+	}
+	source = sourceSplit[0]
+
+	featureSplit := strings.SplitN(sourceSplit[1], ".", 2)
+	if len(featureSplit) <= 1 {
+		return "", "", "", fmt.Errorf("invalid feature %q -> %q", key, sourceSplit[1])
+	}
+	feature = featureSplit[0]
+	option = featureSplit[1]
+
+	return
+}
+
+func parseValue(value interface{}) (valueType ValueType, intervals []string, err error) {
+	switch value := value.(type) {
+	case bool:
+		valueType = LiteralValueType
+		return
+	case string:
+		vals := strings.Split(value, ";")
+		if len(vals) > 1 || (strings.HasPrefix(value, ">") || strings.HasPrefix(value, "<")) {
+			valueType = RangeValueType
+			intervals = vals
+		} else {
+			valueType = LiteralValueType
+		}
+		return
+	default:
+		err = fmt.Errorf("unspported value type: %T. Type must be either string or boolean", value)
+		return
+	}
+}

--- a/pkg/client-nfd/compat/spec.go
+++ b/pkg/client-nfd/compat/spec.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	oras "oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/registry"
+	"oras.land/oras-go/v2/registry/remote"
+
+	compatv1alpha1 "sigs.k8s.io/node-feature-discovery/api/image-compatibility/v1alpha1"
+)
+
+func FetchSpec(ctx context.Context, ref *registry.Reference) (*compatv1alpha1.Spec, error) {
+	repo, err := remote.NewRepository(ref.String())
+	if err != nil {
+		return nil, err
+	}
+	// TODO: remove - just experimental
+	repo.PlainHTTP = true
+
+	targetDesc, err := oras.Resolve(ctx, repo, ref.Reference, oras.DefaultResolveOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	descs, err := registry.Referrers(ctx, repo, targetDesc, compatv1alpha1.ArtifactType)
+	if err != nil {
+		return nil, nil
+	} else if len(descs) < 1 {
+		return nil, fmt.Errorf("compatibility artifact not found")
+	}
+	artifactDesc := descs[len(descs)-1]
+
+	_, content, err := oras.FetchBytes(ctx, repo.Manifests(), artifactDesc.Digest.String(), oras.DefaultFetchBytesOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	manifest := ocispec.Manifest{}
+	if err := json.Unmarshal(content, &manifest); err != nil {
+		return nil, err
+	}
+
+	// TODO: now it's a lazy check, verify in the future the media types and number of layers
+	if len(manifest.Layers) < 1 {
+		return nil, fmt.Errorf("compatibility layer not found")
+	}
+	specDesc := manifest.Layers[0]
+
+	_, specRaw, err := oras.FetchBytes(ctx, repo.Blobs(), specDesc.Digest.String(), oras.DefaultFetchBytesOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	spec := compatv1alpha1.Spec{}
+	err = json.Unmarshal(specRaw, &spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return &spec, nil
+}

--- a/pkg/client-nfd/compat/validate-node.go
+++ b/pkg/client-nfd/compat/validate-node.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compat
+
+import (
+	"context"
+	"fmt"
+
+	"oras.land/oras-go/v2/registry"
+	"sigs.k8s.io/node-feature-discovery/pkg/client-nfd/compat/match"
+	"sigs.k8s.io/node-feature-discovery/pkg/client-nfd/compat/parser"
+)
+
+type ValidationResult struct {
+	IsNodeValid    bool
+	LabelsCheck    map[string]string
+	ChecksTotal    int
+	ChecksSucceded int
+}
+
+func ValidateNode(ctx context.Context, ref *registry.Reference) ([]ValidationResult, error) {
+	spec, err := FetchSpec(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	results := []ValidationResult{}
+	for _, c := range spec.Compatibilties {
+		result := ValidationResult{}
+		result.LabelsCheck = make(map[string]string)
+
+		for k, v := range c.Labels {
+			entry, err := parser.Parse(k, v)
+			if err != nil {
+				return nil, err
+			}
+
+			if source, ok := match.Sources[entry.Source()]; ok {
+				valid, err := source.Check(entry)
+				if err != nil {
+					return nil, err
+				}
+
+				msg := "\033[31mINVALID\033[0m"
+				if valid {
+					msg = "\033[32mOK\033[0m"
+					result.ChecksSucceded++
+				}
+
+				result.LabelsCheck[fmt.Sprintf("%s:%v", entry.KeyRaw(), entry.ValueRaw())] = msg
+			} else {
+				// TODO: Probably just log a warning
+				return nil, fmt.Errorf("unsupported source %q", entry.Source())
+			}
+
+			result.ChecksTotal++
+		}
+
+		result.IsNodeValid = result.ChecksTotal == result.ChecksSucceded
+		results = append(results, result)
+	}
+
+	return results, nil
+}


### PR DESCRIPTION
The prototype is implemented based on the https://github.com/kubernetes-sigs/node-feature-discovery/pull/1845 proposal.
Overall, this implementation is a good validator of the approach taken in the proposal.

To test the tool (assuming you're in the root directory of NFD project):
1. Run local Zot registry https://zotregistry.dev/v2.1.0/ (with basic configuration - no auth).
2. Copy an image over [skopeo](https://github.com/containers/skopeo/tree/main).
`skopeo copy --insecure-policy --dest-tls-verify=false --src-tls-verify=false -f oci docker://busybox:1.35 docker://localhost:5000/busybox:1.35`
3. Attach compatibility spec (artifact) to the image over [oras cli](https://github.com/oras-project/oras/)
`oras attach --artifact-type application/vnd.k8s.nfd.image-compatibility.v1 localhost:5000/busybox:1.35 examples/compatibility-6-wind-router.json:application/vnd.k8s.nfd.image-compatibility.spec.v1+json`
4. Run `go run cmd/client-nfd/main.go compat validate-node --image localhost:5000/busybox:1.35`

<details>
<summary>
Output (should be similar to this)
</summary>

```
COMPATIBILITY GROUP NO 1 FAILS (0/1)
========================
cpu-model.vendor_id:Intel - INVALID

COMPATIBILITY GROUP NO 2 FAILS (4/21)
========================
kernel-config.CONFIG_MPLS_IPTUNNEL:y - INVALID
kernel-config.CONFIG_PPPOE:y - INVALID
kernel-loadedmodule.ip_tables:true - OK
kernel-loadedmodule.ebtables:true - INVALID
kernel-loadedmodule.vhost-net:true - INVALID
kernel-loadedmodule.nf_conntrack:true - OK
kernel-loadedmodule.mpls_iptunnel:true - INVALID
kernel-loadedmodule.ppp_generic:true - INVALID
kernel-loadedmodule.vfio-pci:true - INVALID
kernel-loadedmodule.mpls_router:true - INVALID
kernel-config.CONFIG_XFRM_INTERFACE:y - INVALID
kernel-config.CONFIG_NF_TABLES:y - INVALID
kernel-config.CONFIG_MPLS_ROUTING:y - INVALID
kernel-loadedmodule.br_netfilter:true - OK
kernel-config.CONFIG_CGROUP_BPF:y - INVALID
kernel-config.CONFIG_NET_ACT_BPF:y - INVALID
kernel-loadedmodule.vrf:true - INVALID
kernel-loadedmodule.overlay:true - OK
kernel-loadedmodule.ifb:true - INVALID
kernel-config.CONFIG_NETFILTER_XT_TARGET_NOTRACK:y - INVALID
kernel-loadedmodule.ip6_tables:true - INVALID

COMPATIBILITY GROUP NO 3 FAILS (0/2)
========================
system-os.release.ID:ubuntu - INVALID
system-os.release.VERSION_ID:20.04;22.04 - INVALID

COMPATIBILITY GROUP NO 4 FAILS (0/2)
========================
system-os.release.ID:rhel - INVALID
system-os.release.VERSION_ID:8 - INVALID

COMPATIBILITY GROUP NO 5 FAILS (0/2)
========================
network-sriov.configured:true - INVALID
network-sriov.capable:true - INVALID
```
</details>

NOTE: 6wind router container image is not publicy available, so in the above example, I just attached the requirements to the busybox image, just for test purposes. The compatibility spec has been prepared based on the [6wind router documentation](https://doc.6wind.com/new/vsr-3/latest/vsr-guide/getting-started/run-container/host-requirements.html#node-requirements-and-configuration).

**This PR is still in progress so the output and behavior will change and improve over time.**