### PR TITLE
Template exposed health port in helm chart

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/master.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master.yaml
@@ -56,7 +56,7 @@ spec:
             name: grpc
           - containerPort: {{ .Values.master.metricsPort | default "8081" }}
             name: metrics
-          - containerPort: 8082
+          - containerPort: {{ .Values.master.healthPort  | default "8082" }}
             name: health
           env:
           - name: NODE_NAME

--- a/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
+++ b/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
@@ -97,7 +97,7 @@ spec:
         ports:
           - containerPort: {{ .Values.topologyUpdater.metricsPort | default "8081"}}
             name: metrics
-          - containerPort: 8082
+          - containerPort: {{ .Values.topologyUpdater.healthPort  | default "8082" }}
             name: health
         volumeMounts:
         {{- if .Values.topologyUpdater.kubeletConfigPath | empty | not }}

--- a/deployment/helm/node-feature-discovery/templates/worker.yaml
+++ b/deployment/helm/node-feature-discovery/templates/worker.yaml
@@ -91,7 +91,7 @@ spec:
         ports:
           - containerPort: {{ .Values.worker.metricsPort | default "8081"}}
             name: metrics
-          - containerPort: 8082
+          - containerPort: {{ .Values.worker.healthPort  | default "8082" }}
             name: health
         volumeMounts:
         - name: host-boot


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes-sigs/node-feature-discovery/pull/1885

```
❯ helm template \
  --set topologyUpdater.enable=true \
  --set master.healthPort=9001 \
  --set worker.healthPort=9002 \
  --set topologyUpdater.healthPort=9003 \
  deployment/helm/node-feature-discovery | grep -e -health -e "900[123]"
          - "-grpc-health=9003"
          - containerPort: 9003
        - "-grpc-health=9002"
          - containerPort: 9002
          - containerPort: 9001
            - "-grpc-health=9001"
```