### PR TITLE
github: specify workflow permissions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,12 +10,16 @@ on:
 concurrency:
   group: gh-pages
 
+permissions:
+  contents: read
+
 jobs:
   update-docs:
     name: Update gh-pages documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-
     - name: Install dependencies
       run: |
         sudo apt-get install -y jq curl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,15 @@ on:
 concurrency:
   group: gh-pages
 
+permissions:
+  contents: read
+
 jobs:
   update-helm-repo:
     name: Update gh-pages helm repo index
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: Install Helm
       uses: azure/setup-helm@v4


### PR DESCRIPTION
Update gh-pages has started failing with default permissions. It needs write permissions to be able to push to the gh-pages branch.