### PR TITLE
[gh-pages] Update Helm repo index for release v0.16.5

### DIFF
--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -2,6 +2,24 @@ apiVersion: v1
 entries:
   node-feature-discovery:
   - apiVersion: v2
+    appVersion: v0.16.5
+    created: "2024-10-15T08:55:53.777636648+03:00"
+    description: 'Detects hardware features available on each node in a Kubernetes
+      cluster, and advertises those features using node labels. '
+    digest: 268af506debe8708b80ad38b3e60d31c20474e95c4936d6fc1e932900dd360fa
+    home: https://github.com/kubernetes-sigs/node-feature-discovery
+    keywords:
+    - feature-discovery
+    - feature-detection
+    - node-labels
+    name: node-feature-discovery
+    sources:
+    - https://github.com/kubernetes-sigs/node-feature-discovery
+    type: application
+    urls:
+    - https://github.com/kubernetes-sigs/node-feature-discovery/releases/download/v0.16.5/node-feature-discovery-chart-0.16.5.tgz
+    version: 0.16.5
+  - apiVersion: v2
     appVersion: v0.16.4
     created: "2024-08-12T10:17:37.602438544Z"
     description: 'Detects hardware features available on each node in a Kubernetes
@@ -757,4 +775,4 @@ entries:
     urls:
     - https://github.com/kubernetes-sigs/node-feature-discovery/releases/download/v0.8.0/node-feature-discovery-chart-0.8.0.tgz
     version: 0.8.0
-generated: "2024-08-12T10:17:37.601077621Z"
+generated: "2024-10-15T08:55:53.775973439+03:00"


### PR DESCRIPTION
Manual update to work around insufficient permissions in the github workflow.