### PR TITLE
Convert testdata to an empty go module

### DIFF
--- a/testdata/README.md
+++ b/testdata/README.md
@@ -1,0 +1,3 @@
+Some of the test data in this folder contains colon characters which causes "go get" commands to fail with "invalid char ':'".
+The empty go.mod file is a workaround to prevent this error. This effectively makes this folder its own go module, so it will be
+ignored when "go get" is executed.

--- a/testdata/go.mod
+++ b/testdata/go.mod
@@ -1,0 +1,3 @@
+// This empty go.mod file ensures that the testdata folder is not included
+// in the top-level module. This prevents issues such as unsupported characters
+// in path names.


### PR DESCRIPTION
This ensures that the testdata folder is not included in the top-level module and prevents issues such as unsupported characters in path names.

See also https://github.com/openshift/oc-mirror/pull/669