### PR TITLE
nfd-master: check that namespace informer cache sync succeeded

### DIFF
--- a/pkg/nfd-master/nfd-api-controller.go
+++ b/pkg/nfd-master/nfd-api-controller.go
@@ -78,7 +78,12 @@ func newNfdController(config *restclient.Config, nfdApiControllerOptions nfdApiC
 			klog.ErrorS(err, "failed to convert label selector to map", "selector", nfdApiControllerOptions.NodeFeatureNamespaceSelector)
 			return nil, err
 		}
-		c.namespaceLister = newNamespaceLister(nfdApiControllerOptions.K8sClient, labelMap)
+		c.namespaceLister, err = newNamespaceLister(nfdApiControllerOptions.K8sClient, labelMap)
+		if err != nil {
+			klog.ErrorS(err, "coudn't create namespace lister")
+			return nil, err
+		}
+
 	}
 
 	nfdClient := nfdclientset.NewForConfigOrDie(config)

--- a/pkg/nfd-master/nfd-api-controller_test.go
+++ b/pkg/nfd-master/nfd-api-controller_test.go
@@ -104,7 +104,9 @@ func TestIsNamespaceSelected(t *testing.T) {
 
 	for _, tc := range testcases {
 		labelMap, _ := metav1.LabelSelectorAsSelector(tc.nodeFeatureNamespaceSelector)
-		c.namespaceLister = newNamespaceLister(fakeCli, labelMap)
+		lister, err := newNamespaceLister(fakeCli, labelMap)
+		assert.Nil(t, err)
+		c.namespaceLister = lister
 		res := c.isNamespaceSelected(tc.objectNamespace)
 		assert.Equal(t, res, tc.expectedResult)
 	}


### PR DESCRIPTION
Mitigate the namespace cache sync reported in issue #1936 