### PR TITLE
Docs: Fix the link to feature gates documentation

### DIFF
--- a/docs/reference/master-commandline-reference.md
+++ b/docs/reference/master-commandline-reference.md
@@ -33,8 +33,7 @@ Print version and exit.
 ### -feature-gates
 
 The `-feature-gates` flag is used to enable or disable non GA features.
-The list of available feature gates can be found in the [feature gates
-documentation](../feature-gates.md).
+The list of available feature gates can be found in the [feature gates documentation](feature-gates.md).
 
 Example:
 

--- a/docs/reference/worker-commandline-reference.md
+++ b/docs/reference/worker-commandline-reference.md
@@ -33,8 +33,7 @@ Print version and exit.
 ### -feature-gates
 
 The `-feature-gates` flag is used to enable or disable non GA features.
-The list of available feature gates can be found in the [feature gates
-documentation](../feature-gates.md).
+The list of available feature gates can be found in the [feature gates documentation](feature-gates.md).
 
 Example:
 


### PR DESCRIPTION
The link to feature gates documentation is pointing to the feature-gates.md in master-commandline-reference.html and worker-commandline-reference.html, it should be updated to linking html file.

Signed-off-by: joehuang <joehuang.sweden@gmail.com>
(cherry picked from commit a442749f89b9db2791b6c8eb5010f2b7753efed1)

Backports: #1821 
Fixes: #1971 