### PR TITLE
scripts/update-gh-pages: fix release version parsing

### DIFF
--- a/scripts/github/update-gh-pages.sh
+++ b/scripts/github/update-gh-pages.sh
@@ -105,7 +105,7 @@ site_subdir=${site_subdir:-master}
 
 # Check if this ref is for a released version
 if [ "$site_subdir" != "master" ]; then
-    _base_tag=`git describe --abbrev=0 || :`
+    _base_tag=`git describe --abbrev=0 --match "v*" || :`
     case "$_base_tag" in
         $site_subdir*)
             ;;


### PR DESCRIPTION
When determining the release branch only consider "main" release tags, refusing to pick api/nfd/v* tags.