### PR TITLE
Makefile: fix version parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ SITE_BASEURL ?=
 SITE_DESTDIR ?= _site
 JEKYLL_OPTS := -d '$(SITE_DESTDIR)' $(if $(SITE_BASEURL),-b '$(SITE_BASEURL)',)
 
-VERSION := $(shell git describe --tags --dirty --always)
+VERSION := $(shell git describe --tags --dirty --always --match "v*")
 
 IMAGE_REGISTRY ?= registry.k8s.io/nfd
 IMAGE_TAG_NAME ?= $(VERSION)


### PR DESCRIPTION
One bit that was accidentally left out from
047d0314aa91c7e81a87914789e75b97b330ed5e