### PR TITLE
add configurable pagination to nfd-master

### DIFF
--- a/cmd/nfd-master/main.go
+++ b/cmd/nfd-master/main.go
@@ -140,6 +140,8 @@ func initFlags(flagset *flag.FlagSet) (*master.Args, *master.ConfigOverrideArgs)
 	flagset.Var(overrides.ResyncPeriod, "resync-period", "Specify the NFD API controller resync period.")
 	overrides.NfdApiParallelism = flagset.Int("nfd-api-parallelism", 10, "Defines the maximum number of goroutines responsible of updating nodes. "+
 		"Can be used for the throttling mechanism.")
+	overrides.InformerPageSize = flagset.Int64("informer-page-size", 200,
+		"The list size to use when listing NodeFeature objects to sync informer cache.")
 
 	return args, overrides
 }

--- a/deployment/components/master-config/nfd-master.conf.example
+++ b/deployment/components/master-config/nfd-master.conf.example
@@ -2,6 +2,7 @@
 # extraLabelNs: ["added.ns.io","added.kubernets.io"]
 # denyLabelNs: ["denied.ns.io","denied.kubernetes.io"]
 # enableTaints: false
+# informerPageSize: 200
 # labelWhiteList: "foo"
 # resyncPeriod: "2h"
 # restrictions:

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -28,6 +28,7 @@ master:
     # extraLabelNs: ["added.ns.io","added.kubernets.io"]
     # denyLabelNs: ["denied.ns.io","denied.kubernetes.io"]
     # enableTaints: false
+    # informerPageSize: 200
     # labelWhiteList: "foo"
     # resyncPeriod: "2h"
     # restrictions:

--- a/docs/reference/master-commandline-reference.md
+++ b/docs/reference/master-commandline-reference.md
@@ -173,6 +173,21 @@ Example:
 nfd-master -deny-label-ns=*.vendor.com,vendor-2.io
 ```
 
+### -informer-page-size
+
+The `-informer-page-size` flag is used to control pagination
+during informer cache sync on nfd-master startup.
+This is useful to control load on api-server/etcd as listing
+NodeFeature objects can be expensive, especially in large clusters.
+
+Default: 200
+
+Example:
+
+```bash
+nfd-master -informer-page-size=20
+```
+
 ### -config
 
 The `-config` flag specifies the path of the nfd-master configuration file to

--- a/docs/reference/master-configuration-reference.md
+++ b/docs/reference/master-configuration-reference.md
@@ -180,6 +180,21 @@ Example:
 nfdApiParallelism: 1
 ```
 
+## informerPageSize
+
+The `informerPageSize` option is used to control pagination
+during informer cache sync on nfd-master startup.
+This is useful to control load on api-server/etcd as listing
+NodeFeature objects can be expensive, especially in large clusters.
+
+Default: 200
+
+Example:
+
+```yaml
+informerPageSize: 50
+```
+
 ## klog
 
 The following options specify the logger configuration. Most of which can be

--- a/docs/usage/nfd-master.md
+++ b/docs/usage/nfd-master.md
@@ -84,3 +84,11 @@ If you have RBAC authorization enabled (as is the default e.g. with clusters
 initialized with kubeadm) you need to configure the appropriate ClusterRoles,
 ClusterRoleBindings and a ServiceAccount for NFD to create node
 labels. The provided template will configure these for you.
+
+## Informer List Pagination
+
+When NFD Master starts up it starts an informer on the nodefeatures resources.
+These resources can be large and in a large cluster this initial list call
+to sync the informer cache can be expensive and heavy on api-server/etcd.
+You can use the `informer-list-size` argument to NFD master to
+control pagination size to help control the load during NFD-Master restart.


### PR DESCRIPTION
addresses scalability and api-server load concerns for large clusters by adding configurable pagination to the informer cache of nfd-master

related to: https://github.com/kubernetes-sigs/node-feature-discovery/issues/1998 