### PR TITLE
add configurable pagination to nfd-gc

### DIFF
--- a/cmd/nfd-gc/main.go
+++ b/cmd/nfd-gc/main.go
@@ -85,6 +85,8 @@ func initFlags(flagset *flag.FlagSet) *nfdgarbagecollector.Args {
 		"Kubeconfig to use")
 	flagset.IntVar(&args.MetricsPort, "metrics", 8081,
 		"Port on which to expose metrics.")
+	flagset.Int64Var(&args.ListSize, "list-size", 200,
+		"the pagination size used when listing node features")
 
 	klog.InitFlags(flagset)
 

--- a/docs/reference/gc-commandline-reference.md
+++ b/docs/reference/gc-commandline-reference.md
@@ -35,6 +35,15 @@ Print version and exit.
 
 The pagination size to use when calling api-server to list nodefeatures. 
 Pagination is useful for controlling the load on api-server/etcd as the nodefeature resources can be large.
+A value of 0 will disable pagination.
+
+Default: 200
+
+Example:
+
+```bash
+nfd-gc -list-size=100
+```
 
 ### -gc-interval
 

--- a/docs/reference/gc-commandline-reference.md
+++ b/docs/reference/gc-commandline-reference.md
@@ -31,6 +31,11 @@ Print usage and exit.
 
 Print version and exit.
 
+### -list-size
+
+The pagination size to use when calling api-server to list nodefeatures. 
+Pagination is useful for controlling the load on api-server/etcd as the nodefeature resources can be large.
+
 ### -gc-interval
 
 The `-gc-interval` specifies the interval between periodic garbage collector runs.

--- a/docs/usage/nfd-gc.md
+++ b/docs/usage/nfd-gc.md
@@ -27,3 +27,10 @@ default garbage collector interval is set to 1h which is the value when no
 In Helm deployments see
 [garbage collector parameters](../deployment/helm.md#garbage-collector-parameters)
 for altering the nfd-gc configuration.
+
+## List Pagination & Scalability
+
+When NFD GC runs up it lists nodefeatures from api-server.
+These resources can be large and in a large cluster this initial list call to sync the informer cache can be
+expensive and heavy on api-server/etcd. You can use the `list-size` argument to control pagination size
+to help control the load from this list.

--- a/pkg/nfd-gc/nfd-gc.go
+++ b/pkg/nfd-gc/nfd-gc.go
@@ -49,6 +49,7 @@ type Args struct {
 	GCPeriod    time.Duration
 	Kubeconfig  string
 	MetricsPort int
+	ListSize    int64
 }
 
 type NfdGarbageCollector interface {
@@ -155,7 +156,7 @@ func (n *nfdGarbageCollector) garbageCollect() {
 
 	listAndHandle := func(gvr schema.GroupVersionResource, handler func(metav1.PartialObjectMetadata)) {
 		opts := metav1.ListOptions{
-			Limit: 200,
+			Limit: n.args.ListSize,
 		}
 		for {
 			rsp, err := n.client.Resource(gvr).List(context.TODO(), opts)


### PR DESCRIPTION
adds command line flag to configure pagination for nfd-gc for issue: https://github.com/kubernetes-sigs/node-feature-discovery/issues/1998 