### PR TITLE
Add support running with OwnerReferencesPermissionEnforcement

### DIFF
--- a/deployment/base/rbac/worker-role.yaml
+++ b/deployment/base/rbac/worker-role.yaml
@@ -11,6 +11,7 @@ rules:
   - create
   - get
   - update
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/deployment/helm/node-feature-discovery/templates/role.yaml
+++ b/deployment/helm/node-feature-discovery/templates/role.yaml
@@ -15,6 +15,7 @@ rules:
   - create
   - get
   - update
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/pkg/nfd-worker/nfd-worker.go
+++ b/pkg/nfd-worker/nfd-worker.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	k8sclient "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	klogutils "sigs.k8s.io/node-feature-discovery/pkg/utils/klog"
 	"sigs.k8s.io/yaml"
 
@@ -280,7 +281,10 @@ func (w *nfdWorker) setOwnerReference() error {
 				klog.ErrorS(err, "failed to get self pod, cannot inherit ownerReference for NodeFeature")
 				return err
 			} else {
-				ownerReference = append(ownerReference, selfPod.OwnerReferences...)
+				for _, owner := range selfPod.OwnerReferences {
+					owner.BlockOwnerDeletion = ptr.To(false)
+					ownerReference = append(ownerReference, owner)
+				}
 			}
 
 			podUID := os.Getenv("POD_UID")

--- a/test/e2e/utils/rbac.go
+++ b/test/e2e/utils/rbac.go
@@ -227,7 +227,7 @@ func createRoleWorker(ctx context.Context, cs clientset.Interface, ns string) (*
 			{
 				APIGroups: []string{"nfd.k8s-sigs.io"},
 				Resources: []string{"nodefeatures"},
-				Verbs:     []string{"create", "get", "update"},
+				Verbs:     []string{"create", "get", "update", "delete"},
 			},
 			{
 				APIGroups: []string{""},


### PR DESCRIPTION
when OwnerReferencesPermissionEnforcement validating webhook is
enabled additional permissions are required to set/update owner ref
field. NFD worker sets/updates NodeFeature owner ref field to
the worker pod and owning daemonset.

owner reference can only be updated if the worker has delete permissions
for NodeFeatures.

if owner reference has blockOwnerDeletion (as the case for the daemonset
owner reference) then it requires update permissions to the finalizers
of the owner, to avoid this, we set blockOwnerDeleteion to false for all
owners referenced from NFD worker pod when setting/updating NodeFeature
owner ref.


more info on [OwnerReferencesPermissionEnforcement](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement)