### PR TITLE
Bugfixes for image compatibility feature

### DIFF
--- a/pkg/apis/nfd/nodefeaturerule/rule.go
+++ b/pkg/apis/nfd/nodefeaturerule/rule.go
@@ -268,8 +268,11 @@ func evaluateFeatureMatcher(m *nfdv1alpha1.FeatureMatcher, features *nfdv1alpha1
 		fA, okA := features.Attributes[featureName]
 		fI, okI := features.Instances[featureName]
 		if !okF && !okA && !okI {
-			klog.V(2).InfoS("feature not available", "featureName", featureName)
-			return false, nil, nil
+			if failFast {
+				klog.V(2).InfoS("feature not available", "featureName", featureName)
+				return false, nil, nil
+			}
+			continue
 		}
 
 		if term.MatchExpressions != nil {

--- a/pkg/apis/nfd/nodefeaturerule/rule.go
+++ b/pkg/apis/nfd/nodefeaturerule/rule.go
@@ -268,10 +268,11 @@ func evaluateFeatureMatcher(m *nfdv1alpha1.FeatureMatcher, features *nfdv1alpha1
 		fA, okA := features.Attributes[featureName]
 		fI, okI := features.Instances[featureName]
 		if !okF && !okA && !okI {
+			klog.V(2).InfoS("feature not available", "featureName", featureName)
 			if failFast {
-				klog.V(2).InfoS("feature not available", "featureName", featureName)
 				return false, nil, nil
 			}
+			isMatch = false
 			continue
 		}
 

--- a/pkg/client-nfd/compat/node-validator/node-validator.go
+++ b/pkg/client-nfd/compat/node-validator/node-validator.go
@@ -97,6 +97,7 @@ func (nv *nodeValidator) Execute(ctx context.Context) ([]*CompatibilityStatus, e
 }
 
 func evaluateRuleStatus(rule *nfdv1alpha1.Rule, matchStatus *nodefeaturerule.MatchStatus) ProcessedRuleStatus {
+	var matchedFeatureTerms nfdv1alpha1.FeatureMatcher
 	out := ProcessedRuleStatus{Name: rule.Name, IsMatch: matchStatus.IsMatch}
 
 	evaluateFeatureMatcher := func(featureMatcher, matchedFeatureTerms nfdv1alpha1.FeatureMatcher) []MatchedExpression {
@@ -163,11 +164,17 @@ func evaluateRuleStatus(rule *nfdv1alpha1.Rule, matchStatus *nodefeaturerule.Mat
 	}
 
 	if matchFeatures := rule.MatchFeatures; matchFeatures != nil {
-		out.MatchedExpressions = evaluateFeatureMatcher(matchFeatures, matchStatus.MatchedFeaturesTerms)
+		if matchStatus.MatchFeatureStatus != nil {
+			matchedFeatureTerms = matchStatus.MatchFeatureStatus.MatchedFeaturesTerms
+		}
+		out.MatchedExpressions = evaluateFeatureMatcher(matchFeatures, matchedFeatureTerms)
 	}
 
 	for i, matchAnyElem := range rule.MatchAny {
-		matchedExpressions := evaluateFeatureMatcher(matchAnyElem.MatchFeatures, matchStatus.MatchAny[i].MatchedFeaturesTerms)
+		if matchStatus.MatchAny[i].MatchedFeaturesTerms != nil {
+			matchedFeatureTerms = matchStatus.MatchAny[i].MatchedFeaturesTerms
+		}
+		matchedExpressions := evaluateFeatureMatcher(matchAnyElem.MatchFeatures, matchedFeatureTerms)
 		out.MatchedAny = append(out.MatchedAny, MatchAnyElem{MatchedExpressions: matchedExpressions})
 	}
 

--- a/pkg/client-nfd/compat/node-validator/node-validator_test.go
+++ b/pkg/client-nfd/compat/node-validator/node-validator_test.go
@@ -114,6 +114,17 @@ func TestNodeValidator(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: "fake_5",
+							MatchFeatures: v1alpha1.FeatureMatcher{
+								{
+									Feature: "unknown.unknown",
+									MatchExpressions: &v1alpha1.MatchExpressionSet{
+										"name": &v1alpha1.MatchExpression{Op: v1alpha1.MatchIn, Value: v1alpha1.MatchValue{"instance_1"}},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -216,6 +227,19 @@ func TestNodeValidator(t *testing.T) {
 										IsMatch:     false,
 									},
 								},
+							},
+						},
+					},
+					{
+						Name:    "fake_5",
+						IsMatch: false,
+						MatchedExpressions: []MatchedExpression{
+							{
+								Feature:     "unknown.unknown",
+								Name:        "name",
+								Expression:  &v1alpha1.MatchExpression{Op: v1alpha1.MatchIn, Value: v1alpha1.MatchValue{"instance_1"}},
+								MatcherType: MatchExpressionType,
+								IsMatch:     false,
 							},
 						},
 					},


### PR DESCRIPTION
Bugfixes:
* Always pull the latest compatibility artifact
* Handle missing compatibility matches to avoid panic
* Continue procesing the rule if the feature is missing