### PR TITLE
Make DNS Policy configurable in helm chart

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/master.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master.yaml
@@ -29,6 +29,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      dnsPolicy: {{ .Values.master.dnsPolicy }}
     {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
     {{- end }}

--- a/deployment/helm/node-feature-discovery/templates/nfd-gc.yaml
+++ b/deployment/helm/node-feature-discovery/templates/nfd-gc.yaml
@@ -29,7 +29,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "node-feature-discovery.gc.serviceAccountName" . }}
-      dnsPolicy: ClusterFirstWithHostNet
+      dnsPolicy: {{ .Values.gc.dnsPolicy }}
     {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
     {{- end }}

--- a/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
+++ b/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
@@ -29,7 +29,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "node-feature-discovery.topologyUpdater.serviceAccountName" . }}
-      dnsPolicy: ClusterFirstWithHostNet
+      dnsPolicy: {{ .Values.topologyUpdater.dnsPolicy }}
     {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
     {{- end }}

--- a/deployment/helm/node-feature-discovery/templates/worker.yaml
+++ b/deployment/helm/node-feature-discovery/templates/worker.yaml
@@ -28,7 +28,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      dnsPolicy: ClusterFirstWithHostNet
+      dnsPolicy: {{ .Values.worker.dnsPolicy }}
     {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
     {{- end }}

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -20,6 +20,7 @@ master:
   extraArgs: []
   extraEnvs: []
   hostNetwork: false
+  dnsPolicy: ClusterFirstWithHostNet
   config: ### <NFD-MASTER-CONF-START-DO-NOT-REMOVE>
     # noPublish: false
     # autoDefaultNs: true
@@ -173,6 +174,7 @@ worker:
   extraArgs: []
   extraEnvs: []
   hostNetwork: false
+  dnsPolicy: ClusterFirstWithHostNet
   config: ### <NFD-WORKER-CONF-START-DO-NOT-REMOVE>
     #core:
     #  labelWhiteList:
@@ -499,6 +501,7 @@ topologyUpdater:
   extraArgs: []
   extraEnvs: []
   hostNetwork: false
+  dnsPolicy: ClusterFirstWithHostNet
 
   serviceAccount:
     create: true
@@ -563,6 +566,7 @@ gc:
   extraEnvs: []
   hostNetwork: false
   replicaCount: 1
+  dnsPolicy: ClusterFirstWithHostNet
 
   serviceAccount:
     create: true

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -213,6 +213,7 @@ API's you need to install the prometheus operator in your cluster.
 | `master.readinessProbe.periodSeconds`       | integer | 10 (by Kubernetes)               | Specifies how often (in seconds) to perform the readiness probe.                                                                                                                                      |
 | `master.readinessProbe.timeoutSeconds`      | integer | 1 (by Kubernetes)                | Specifies the number of seconds after which the probe times out.                                                                                                                                      |
 | `master.readinessProbe.successThreshold`    | integer | 1 (by Kubernetes)                | Specifies the number of consecutive successes of readiness probes before considering the pod as ready.                                                                                                |
+| `master.dnsPolicy`                          | array   | ClusterFirstWithHostNet                               | NFD master pod [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)                                                                                 |
 
 > `[0]` Additional info for `master.resources.requests`: \
 > You may want to use the same value for `requests.memory` and `limits.memory`.
@@ -261,6 +262,7 @@ API's you need to install the prometheus operator in your cluster.
 | `worker.readinessProbe.periodSeconds`       | integer | 10 (by Kubernetes)      | Specifies how often (in seconds) to perform the readiness probe.                                                                                                                                             |
 | `worker.readinessProbe.timeoutSeconds`      | integer | 1 (by Kubernetes)       | Specifies the number of seconds after which the probe times out.                                                                                                                                             |
 | `worker.readinessProbe.successThreshold`    | integer | 1 (by Kubernetes)       | Specifies the number of consecutive successes of readiness probes before considering the pod as ready.                                                                                                       |
+| `worker.dnsPolicy`                          | array   | ClusterFirstWithHostNet                               | NFD worker pod [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)                                                                                        |
 
 ### Topology updater parameters
 
@@ -304,6 +306,7 @@ API's you need to install the prometheus operator in your cluster.
 | `topologyUpdater.readinessProbe.periodSeconds`       | integer | 10 (by Kubernetes)       | Specifies how often (in seconds) to perform the readiness probe.                                                                                                                                            |
 | `topologyUpdater.readinessProbe.timeoutSeconds`      | integer | 1 (by Kubernetes)        | Specifies the number of seconds after which the probe times out.                                                                                                                                            |
 | `topologyUpdater.readinessProbe.successThreshold`    | integer | 1 (by Kubernetes)        | Specifies the number of consecutive successes of readiness probes before considering the pod as ready.                                                                                                      |
+| `topologyUpdater.dnsPolicy`                          | array   | ClusterFirstWithHostNet                               | Topology updater pod [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)                                                                       |
 
 ### Garbage collector parameters
 
@@ -329,6 +332,7 @@ API's you need to install the prometheus operator in your cluster.
 | `gc.extraArgs`                  | array   | []                        | Additional [command line arguments](../reference/gc-commandline-reference.md) to pass to nfd-gc                                                                                                       |
 | `gc.extraEnvs`                  | array   | []                        | Additional environment variables to pass to nfd-gc                                                                                                                                                    |
 | `gc.revisionHistoryLimit`       | integer |                           | Specify how many old ReplicaSets for this Deployment you want to retain. [revisionHistoryLimit](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit)         |
+| `gc.dnsPolicy`                  | array   | ClusterFirstWithHostNet                               | Garbage collector pod [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)                                                                          |
 
 <!-- Links -->
 

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -213,7 +213,7 @@ API's you need to install the prometheus operator in your cluster.
 | `master.readinessProbe.periodSeconds`       | integer | 10 (by Kubernetes)               | Specifies how often (in seconds) to perform the readiness probe.                                                                                                                                      |
 | `master.readinessProbe.timeoutSeconds`      | integer | 1 (by Kubernetes)                | Specifies the number of seconds after which the probe times out.                                                                                                                                      |
 | `master.readinessProbe.successThreshold`    | integer | 1 (by Kubernetes)                | Specifies the number of consecutive successes of readiness probes before considering the pod as ready.                                                                                                |
-| `master.dnsPolicy`                          | array   | ClusterFirstWithHostNet                               | NFD master pod [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)                                                                                 |
+| `master.dnsPolicy`                          | array   | ClusterFirstWithHostNet          | NFD master pod [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)                                                                                 |
 
 > `[0]` Additional info for `master.resources.requests`: \
 > You may want to use the same value for `requests.memory` and `limits.memory`.
@@ -262,7 +262,7 @@ API's you need to install the prometheus operator in your cluster.
 | `worker.readinessProbe.periodSeconds`       | integer | 10 (by Kubernetes)      | Specifies how often (in seconds) to perform the readiness probe.                                                                                                                                             |
 | `worker.readinessProbe.timeoutSeconds`      | integer | 1 (by Kubernetes)       | Specifies the number of seconds after which the probe times out.                                                                                                                                             |
 | `worker.readinessProbe.successThreshold`    | integer | 1 (by Kubernetes)       | Specifies the number of consecutive successes of readiness probes before considering the pod as ready.                                                                                                       |
-| `worker.dnsPolicy`                          | array   | ClusterFirstWithHostNet                               | NFD worker pod [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)                                                                                        |
+| `worker.dnsPolicy`                          | array   | ClusterFirstWithHostNet | NFD worker pod [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)                                                                                        |
 
 ### Topology updater parameters
 
@@ -306,7 +306,7 @@ API's you need to install the prometheus operator in your cluster.
 | `topologyUpdater.readinessProbe.periodSeconds`       | integer | 10 (by Kubernetes)       | Specifies how often (in seconds) to perform the readiness probe.                                                                                                                                            |
 | `topologyUpdater.readinessProbe.timeoutSeconds`      | integer | 1 (by Kubernetes)        | Specifies the number of seconds after which the probe times out.                                                                                                                                            |
 | `topologyUpdater.readinessProbe.successThreshold`    | integer | 1 (by Kubernetes)        | Specifies the number of consecutive successes of readiness probes before considering the pod as ready.                                                                                                      |
-| `topologyUpdater.dnsPolicy`                          | array   | ClusterFirstWithHostNet                               | Topology updater pod [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)                                                                       |
+| `topologyUpdater.dnsPolicy`                          | array   | ClusterFirstWithHostNet  | Topology updater pod [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)                                                                                 |
 
 ### Garbage collector parameters
 
@@ -332,7 +332,7 @@ API's you need to install the prometheus operator in your cluster.
 | `gc.extraArgs`                  | array   | []                        | Additional [command line arguments](../reference/gc-commandline-reference.md) to pass to nfd-gc                                                                                                       |
 | `gc.extraEnvs`                  | array   | []                        | Additional environment variables to pass to nfd-gc                                                                                                                                                    |
 | `gc.revisionHistoryLimit`       | integer |                           | Specify how many old ReplicaSets for this Deployment you want to retain. [revisionHistoryLimit](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit)         |
-| `gc.dnsPolicy`                  | array   | ClusterFirstWithHostNet                               | Garbage collector pod [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)                                                                          |
+| `gc.dnsPolicy`                  | array   | ClusterFirstWithHostNet   | Garbage collector pod [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)                                                                          |
 
 <!-- Links -->
 


### PR DESCRIPTION
Enable setting the dnsPolicy in pods deployed as part of the NFD helm chart.