### PR TITLE
Remove deprecated toleration/affinity value

### DIFF
--- a/deployment/components/common/master-affinity.yaml
+++ b/deployment/components/common/master-affinity.yaml
@@ -6,23 +6,9 @@
       - weight: 1
         preference:
           matchExpressions:
-          - key: "node-role.kubernetes.io/master"
-            operator: In
-            values: [""]
-      - weight: 1
-        preference:
-          matchExpressions:
           - key: node-role.kubernetes.io/control-plane
             operator: In
             values: [""]
-
-- op: add
-  path: /spec/template/spec/tolerations/-
-  value:
-    key: "node-role.kubernetes.io/master"
-    operator: "Equal"
-    value: ""
-    effect: "NoSchedule"
 
 - op: add
   path: /spec/template/spec/tolerations/-

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -120,10 +120,6 @@ master:
   nodeSelector: {}
 
   tolerations:
-  - key: "node-role.kubernetes.io/master"
-    operator: "Equal"
-    value: ""
-    effect: "NoSchedule"
   - key: "node-role.kubernetes.io/control-plane"
     operator: "Equal"
     value: ""
@@ -134,12 +130,6 @@ master:
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 1
-          preference:
-            matchExpressions:
-              - key: "node-role.kubernetes.io/master"
-                operator: In
-                values: [""]
         - weight: 1
           preference:
             matchExpressions:


### PR DESCRIPTION
Fix this warning during helm install

```bash
W0303 17:28:58.017492   44880 warnings.go:70] spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key: node-role.kubernetes.io/master is use "node-role.kubernetes.io/control-plane" instead
```

Cause of the Warning
	•	node-role.kubernetes.io/master is deprecated.
	•	Since Kubernetes v1.20, the preferred label is node-role.kubernetes.io/control-plane.
	•	The warning is triggered because node-role.kubernetes.io/master is still used in your chart’s nodeAffinity rules.