### PR TITLE
Drop gRPC startup probe

### DIFF
--- a/deployment/base/master/master-deployment.yaml
+++ b/deployment/base/master/master-deployment.yaml
@@ -28,10 +28,6 @@ spec:
             requests:
               cpu: 100m
               memory: 128Mi
-          startupProbe:
-            grpc:
-              port: 8082
-            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
Remove gRPC startup probe from master following gRPC [logging removal](https://github.com/kubernetes-sigs/node-feature-discovery/pull/2004).