### PR TITLE
Allow configuration of image pull secrets in post-delete job

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/post-delete-job.yaml
+++ b/deployment/helm/node-feature-discovery/templates/post-delete-job.yaml
@@ -66,6 +66,10 @@ spec:
         role: prune
     spec:
       serviceAccountName: {{ include "node-feature-discovery.fullname" . }}-prune
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
         - name: nfd-master
           securityContext:


### PR DESCRIPTION
This is taking the work done here: https://github.com/kubernetes-sigs/node-feature-discovery/pull/1893.

Given the original author is non-responsive I am raising this in hope to get this merged faster.