### PR TITLE
Replace golang.org/x/exp/maps with the standard library's maps package.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/vektra/errors v0.0.0-20140903201135-c64d83aba85a
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/net v0.35.0
 	golang.org/x/time v0.10.0
 	google.golang.org/grpc v1.70.0
@@ -146,6 +145,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.33.0 // indirect
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/sync v0.11.0 // indirect

--- a/pkg/apis/nfd/nodefeaturerule/expression.go
+++ b/pkg/apis/nfd/nodefeaturerule/expression.go
@@ -19,11 +19,13 @@ package nodefeaturerule
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	strings "strings"
 
-	"golang.org/x/exp/maps"
+	"maps"
+
 	"k8s.io/klog/v2"
 
 	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
@@ -177,7 +179,7 @@ func evaluateMatchExpressionKeys(m *nfdv1alpha1.MatchExpression, name string, ke
 	if klogV := klog.V(3); klogV.Enabled() {
 		klogV.InfoS("matched keys", "matchResult", matched, "matchKey", name, "matchOp", m.Op)
 	} else if klogV := klog.V(4); klogV.Enabled() {
-		k := maps.Keys(keys)
+		k := slices.Collect(maps.Keys(keys))
 		sort.Strings(k)
 		klogV.InfoS("matched keys", "matchResult", matched, "matchKey", name, "matchOp", m.Op, "inputKeys", k)
 	}

--- a/pkg/nfd-worker/nfd-worker.go
+++ b/pkg/nfd-worker/nfd-worker.go
@@ -23,13 +23,15 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
 
+	"maps"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"golang.org/x/exp/maps"
 	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -394,7 +396,7 @@ func (w *nfdWorker) configureCore(c coreConfig) error {
 		}
 	}
 
-	w.featureSources = maps.Values(featureSources)
+	w.featureSources = slices.Collect(maps.Values(featureSources))
 
 	sort.Slice(w.featureSources, func(i, j int) bool { return w.featureSources[i].Name() < w.featureSources[j].Name() })
 
@@ -426,7 +428,7 @@ func (w *nfdWorker) configureCore(c coreConfig) error {
 		}
 	}
 
-	w.labelSources = maps.Values(labelSources)
+	w.labelSources = slices.Collect(maps.Values(labelSources))
 
 	sort.Slice(w.labelSources, func(i, j int) bool {
 		iP, jP := w.labelSources[i].Priority(), w.labelSources[j].Priority()

--- a/pkg/utils/flags.go
+++ b/pkg/utils/flags.go
@@ -21,11 +21,12 @@ import (
 	"flag"
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
 
-	"golang.org/x/exp/maps"
+	"maps"
 )
 
 // RegexpVal is a wrapper for regexp command line flags
@@ -60,7 +61,7 @@ func (a *StringSetVal) String() string {
 	if *a == nil {
 		return ""
 	}
-	vals := maps.Keys(*a)
+	vals := slices.Collect(maps.Keys(*a))
 	sort.Strings(vals)
 	return strings.Join(vals, ",")
 }

--- a/source/pci/pci.go
+++ b/source/pci/pci.go
@@ -18,9 +18,11 @@ package pci
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
-	"golang.org/x/exp/maps"
+	"maps"
+
 	"k8s.io/klog/v2"
 
 	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
@@ -103,7 +105,7 @@ func (s *pciSource) GetLabels() (source.FeatureLabels, error) {
 		}
 	}
 	if len(configLabelFields) > 0 {
-		klog.InfoS("ignoring invalid fields in deviceLabelFields", "invalidFieldNames", maps.Keys(configLabelFields))
+		klog.InfoS("ignoring invalid fields in deviceLabelFields", "invalidFieldNames", slices.Collect(maps.Keys(configLabelFields)))
 	}
 	if len(deviceLabelFields) == 0 {
 		deviceLabelFields = []string{"class", "vendor"}

--- a/source/usb/usb.go
+++ b/source/usb/usb.go
@@ -18,9 +18,11 @@ package usb
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
-	"golang.org/x/exp/maps"
+	"maps"
+
 	"k8s.io/klog/v2"
 
 	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
@@ -106,7 +108,7 @@ func (s *usbSource) GetLabels() (source.FeatureLabels, error) {
 		}
 	}
 	if len(configLabelFields) > 0 {
-		klog.InfoS("ignoring invalid fields in deviceLabelFields", "invalidFieldNames", maps.Keys(configLabelFields))
+		klog.InfoS("ignoring invalid fields in deviceLabelFields", "invalidFieldNames", slices.Collect(maps.Keys(configLabelFields)))
 	}
 	if len(deviceLabelFields) == 0 {
 		deviceLabelFields = defaultDeviceLabelFields()


### PR DESCRIPTION
Replace [golang.org/x/exp/maps](https://pkg.go.dev/golang.org/x/exp/maps) with the standard library's [maps](https://pkg.go.dev/maps) package.