### PR TITLE
compat/api: use GroupRule type

### DIFF
--- a/api/image-compatibility/v1alpha1/spec.go
+++ b/api/image-compatibility/v1alpha1/spec.go
@@ -38,7 +38,7 @@ type Spec struct {
 // that describe the image requirements for the host and OS.
 type Compatibility struct {
 	// Rules represents a list of Node Feature Rules.
-	Rules []nfdv1alpha1.Rule `json:"rules"`
+	Rules []nfdv1alpha1.GroupRule `json:"rules"`
 	// Weight indicates the priority of the compatibility set.
 	Weight int `json:"weight,omitempty"`
 	// Tag enables grouping or distinguishing between compatibility sets.

--- a/docs/usage/image-compatibility.md
+++ b/docs/usage/image-compatibility.md
@@ -20,7 +20,8 @@ sort: 11
 **Image Compatibility is in the experimental `v1alpha1` version.**
 
 Image compatibility metadata enables container image authors to define their
-image requirements using [Node Feature Rules](./custom-resources.md#nodefeaturerule).
+image requirements using a spec similar to
+[Node Feature Groups](./custom-resources.md#nodefeaturegroup).
 This complementary solution allows features discovered on nodes to be matched
 directly from images. As a result, container requirements become discoverable
 and programmable, supporting various consumers and use cases where applications
@@ -29,9 +30,9 @@ need a specific compatible environment.
 ### Compatibility Specification
 
 The compatibility specification is a list of compatibility objects that contain
-[Node Feature Rules](./custom-resources.md#nodefeaturerule), along with
-additional fields to control the execution of validation between the image and
-the host.
+rules similar to [Node Feature Groups](./custom-resources.md#nodefeaturegroup),
+along with additional fields to control the execution of validation between the
+image and the host.
 
 ### Schema
 
@@ -42,9 +43,9 @@ the host.
   This REQUIRED property is a list of compatibility sets.
 
   - **rules** - *object*  
-    This REQUIRED property is a reference to the spec of the [NodeFeatureRule API](./custom-resources.md#nodefeaturerule).
+    This REQUIRED property is a reference to the spec of the [NodeFeatureGroup API](./custom-resources.md#nodefeaturegroup).
     The spec allows image requirements to be described using the features
-    discovered from NFD sources. For more details, please refer to [the documentation](./custom-resources.md#nodefeaturerule).
+    discovered from NFD sources. For more details, please refer to [the documentation](./custom-resources.md#nodefeaturegroup).
 
   - **weight** - *int*  
     This OPTIONAL property specifies the [node affinity weight](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity-weight).

--- a/pkg/client-nfd/compat/node-validator/node-validator.go
+++ b/pkg/client-nfd/compat/node-validator/node-validator.go
@@ -81,14 +81,13 @@ func (nv *nodeValidator) Execute(ctx context.Context) ([]*CompatibilityStatus, e
 		compat := newCompatibilityStatus(&c)
 
 		for _, r := range c.Rules {
-			ruleOut, err := nodefeaturerule.Execute(&r, features, false)
+			ruleOut, err := nodefeaturerule.ExecuteGroupRule(&r, features, false)
 			if err != nil {
 				return nil, err
 			}
 			compat.Rules = append(compat.Rules, nv.evaluateRuleStatus(&r, ruleOut.MatchStatus))
 
 			// Add the 'rule.matched' feature for backreference functionality
-			features.InsertAttributeFeatures(nfdv1alpha1.RuleBackrefDomain, nfdv1alpha1.RuleBackrefFeature, ruleOut.Labels)
 			features.InsertAttributeFeatures(nfdv1alpha1.RuleBackrefDomain, nfdv1alpha1.RuleBackrefFeature, ruleOut.Vars)
 		}
 		compats = append(compats, &compat)
@@ -97,7 +96,7 @@ func (nv *nodeValidator) Execute(ctx context.Context) ([]*CompatibilityStatus, e
 	return compats, nil
 }
 
-func (nv *nodeValidator) evaluateRuleStatus(rule *nfdv1alpha1.Rule, matchStatus *nodefeaturerule.MatchStatus) ProcessedRuleStatus {
+func (nv *nodeValidator) evaluateRuleStatus(rule *nfdv1alpha1.GroupRule, matchStatus *nodefeaturerule.MatchStatus) ProcessedRuleStatus {
 	out := ProcessedRuleStatus{Name: rule.Name, IsMatch: matchStatus.IsMatch}
 
 	matchedFeatureTerms := nfdv1alpha1.FeatureMatcher{}

--- a/pkg/client-nfd/compat/node-validator/node-validator_test.go
+++ b/pkg/client-nfd/compat/node-validator/node-validator_test.go
@@ -34,7 +34,7 @@ func init() {
 	fs.SetConfig(fs.NewConfig())
 }
 
-func buildDefaultSpec(rules []v1alpha1.Rule) *compatv1alpha1.Spec {
+func buildDefaultSpec(rules []v1alpha1.GroupRule) *compatv1alpha1.Spec {
 	return &compatv1alpha1.Spec{
 		Version: compatv1alpha1.Version,
 		Compatibilties: []compatv1alpha1.Compatibility{
@@ -73,7 +73,7 @@ func TestNodeValidator(t *testing.T) {
 	Convey("With a single compatibility set", t, func() {
 
 		Convey("That contains flag which results in match", func() {
-			spec := buildDefaultSpec([]v1alpha1.Rule{
+			spec := buildDefaultSpec([]v1alpha1.GroupRule{
 				{
 					Name: "fake_1",
 					MatchFeatures: v1alpha1.FeatureMatcher{
@@ -105,7 +105,7 @@ func TestNodeValidator(t *testing.T) {
 		})
 
 		Convey("That contains flags and attribute which result in mismatch", func() {
-			spec := buildDefaultSpec([]v1alpha1.Rule{
+			spec := buildDefaultSpec([]v1alpha1.GroupRule{
 				{
 					Name: "fake_2",
 					MatchFeatures: v1alpha1.FeatureMatcher{
@@ -152,7 +152,7 @@ func TestNodeValidator(t *testing.T) {
 		})
 
 		Convey("That contains instances which results in mismatch", func() {
-			spec := buildDefaultSpec([]v1alpha1.Rule{
+			spec := buildDefaultSpec([]v1alpha1.GroupRule{
 				{
 					Name: "fake_3",
 					MatchFeatures: v1alpha1.FeatureMatcher{
@@ -215,7 +215,7 @@ func TestNodeValidator(t *testing.T) {
 		})
 
 		Convey("That contains instances which results in match", func() {
-			spec := buildDefaultSpec([]v1alpha1.Rule{
+			spec := buildDefaultSpec([]v1alpha1.GroupRule{
 				{
 					Name: "fake_4",
 					MatchAny: []v1alpha1.MatchAnyElem{
@@ -278,7 +278,7 @@ func TestNodeValidator(t *testing.T) {
 		})
 
 		Convey("That contains spec with zero matches which results in mismatch", func() {
-			spec := buildDefaultSpec([]v1alpha1.Rule{
+			spec := buildDefaultSpec([]v1alpha1.GroupRule{
 				{
 					Name: "fake_5",
 					MatchFeatures: v1alpha1.FeatureMatcher{
@@ -312,7 +312,7 @@ func TestNodeValidator(t *testing.T) {
 		})
 
 		Convey("That contains matchAny and matchFeatures in one spec", func() {
-			spec := buildDefaultSpec([]v1alpha1.Rule{
+			spec := buildDefaultSpec([]v1alpha1.GroupRule{
 				{
 					Name: "fake_6",
 					MatchAny: []v1alpha1.MatchAnyElem{
@@ -401,7 +401,7 @@ func TestNodeValidator(t *testing.T) {
 					Tag:         "prefered",
 					Weight:      90,
 					Description: "Fake compatibility 1",
-					Rules: []v1alpha1.Rule{
+					Rules: []v1alpha1.GroupRule{
 						{
 							Name: "fake_1",
 							MatchFeatures: v1alpha1.FeatureMatcher{
@@ -419,7 +419,7 @@ func TestNodeValidator(t *testing.T) {
 					Tag:         "fallback",
 					Weight:      40,
 					Description: "Fake compatibility 2",
-					Rules: []v1alpha1.Rule{
+					Rules: []v1alpha1.GroupRule{
 						{
 							Name: "fake_1",
 							MatchFeatures: v1alpha1.FeatureMatcher{
@@ -498,7 +498,7 @@ func TestNodeValidator(t *testing.T) {
 					Tag:         "prefered",
 					Weight:      90,
 					Description: "Fake compatibility 1",
-					Rules: []v1alpha1.Rule{
+					Rules: []v1alpha1.GroupRule{
 						{
 							Name: "fake_1",
 							MatchFeatures: v1alpha1.FeatureMatcher{
@@ -516,7 +516,7 @@ func TestNodeValidator(t *testing.T) {
 					Tag:         "fallback",
 					Weight:      40,
 					Description: "Fake compatibility 2",
-					Rules: []v1alpha1.Rule{
+					Rules: []v1alpha1.GroupRule{
 						{
 							Name: "fake_1",
 							MatchFeatures: v1alpha1.FeatureMatcher{


### PR DESCRIPTION
Simplify and rationalize the compat api. Many of the fields in Rule, like Labels, Annotations or ExtendedResources are not applicable in this context.