### PR TITLE
Add VersionRange operator for NFR/NFG API

### DIFF
--- a/api/nfd/go.mod
+++ b/api/nfd/go.mod
@@ -1,7 +1,6 @@
 module sigs.k8s.io/node-feature-discovery/api/nfd
 
-go 1.22.2
-toolchain go1.23.7
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.8.4

--- a/api/nfd/v1alpha1/types.go
+++ b/api/nfd/v1alpha1/types.go
@@ -360,6 +360,9 @@ const (
 	// MatchIsFalse returns true if the input holds the value "false". The
 	// expression must not have any values.
 	MatchIsFalse MatchOp = "IsFalse"
+	// MatchVersionRange returns true if the input is version that falls into the
+	// specified version range. Both the input and value must be semantic versions.
+	MatchVersionRange MatchOp = "VersionRange"
 )
 
 const (

--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -816,6 +816,7 @@ below.
 |  `GeLe`         | 2            | Input falls within a range that includes the boundary values. Both the input and value must be integer numbers. |
 |  `IsTrue`       | 0            | Input is equal to "true" |
 |  `IsFalse`      | 0            | Input is equal "false" |
+|  `VersionRange` | 2            | Input falls within a range that includes the boundary values. Both the input and value must contain semantic versions. |
 
 The `value` field of MatchExpression is a list of string arguments to the
 operator.

--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -816,7 +816,7 @@ below.
 |  `GeLe`         | 2            | Input falls within a range that includes the boundary values. Both the input and value must be integer numbers. |
 |  `IsTrue`       | 0            | Input is equal to "true" |
 |  `IsFalse`      | 0            | Input is equal "false" |
-|  `VersionRange` | 2            | Input falls within a range that includes the boundary values. Both the input and value must contain semantic versions. |
+|  `VersionRange` | 2            | The input must be a semantic version and falls within a range that includes the boundary values. Boundaries can be either a valid semantic version or an empty string (""), which represents an infinite limit. |
 
 The `value` field of MatchExpression is a list of string arguments to the
 operator.

--- a/pkg/apis/nfd/nodefeaturerule/expression.go
+++ b/pkg/apis/nfd/nodefeaturerule/expression.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/klog/v2"
 
 	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils"
 )
 
 const (
@@ -53,6 +54,7 @@ var matchOps = map[nfdv1alpha1.MatchOp]struct{}{
 	nfdv1alpha1.MatchGeLe:         {},
 	nfdv1alpha1.MatchIsTrue:       {},
 	nfdv1alpha1.MatchIsFalse:      {},
+	nfdv1alpha1.MatchVersionRange: {},
 }
 
 // evaluateMatchExpression evaluates the MatchExpression against a single input value.
@@ -166,6 +168,42 @@ func evaluateMatchExpression(m *nfdv1alpha1.MatchExpression, valid bool, value i
 				return false, fmt.Errorf("invalid expression, 'value' field must be empty for Op %q (have %v)", m.Op, m.Value)
 			}
 			return value == "false", nil
+		case nfdv1alpha1.MatchVersionRange:
+			if len(m.Value) != 2 {
+				return false, fmt.Errorf("invalid expression, 'value' field must contain exactly two elements for Op %q (have %v)", m.Op, m.Value)
+			}
+			versions := map[string]string{
+				"min": m.Value[0],
+				"max": m.Value[1],
+			}
+
+			for k, v := range versions {
+				if v == "" {
+					continue
+				}
+				ver, err := utils.ExtractSemVer(v)
+				if err != nil {
+					return false, fmt.Errorf("invalid expression, 'value' field must contain semantic versions or empty string for Op %q (have: %v)", m.Op, m.Value)
+				}
+				versions[k] = ver
+			}
+
+			ver, err := utils.ExtractSemVer(value)
+			if err != nil {
+				return false, fmt.Errorf("invalid expression, the flag/attribute/instance value is not a semantic version %q", value)
+			}
+			versions["current"] = ver
+
+			if versions["min"] != "" && versions["max"] != "" && utils.CompareVersions(versions["min"], versions["max"]) == 1 {
+				return false, fmt.Errorf("invalid expressions, minVersion value %q is greater than maxVersion value %q", versions["min"], versions["max"])
+			}
+			if versions["min"] != "" && utils.CompareVersions(versions["current"], versions["min"]) < 0 {
+				return false, nil
+			}
+			if versions["max"] != "" && utils.CompareVersions(versions["current"], versions["max"]) > 0 {
+				return false, nil
+			}
+			return true, nil
 		default:
 			return false, fmt.Errorf("unsupported Op %q", m.Op)
 		}

--- a/pkg/apis/nfd/nodefeaturerule/expression_test.go
+++ b/pkg/apis/nfd/nodefeaturerule/expression_test.go
@@ -265,6 +265,28 @@ func TestEvaluateMatchExpressionValues(t *testing.T) {
 
 		{name: "44", op: nfdv1alpha1.MatchIsFalse, key: "foo", input: I{"foo": "true"}, result: assert.False, err: assert.Nil},
 		{name: "45", op: nfdv1alpha1.MatchIsFalse, key: "foo", input: I{"foo": "false"}, result: assert.True, err: assert.Nil},
+
+		{name: "46", op: nfdv1alpha1.MatchVersionRange, values: V{"", ""}, key: "foo", input: I{"foo": "3.5.0-flavor"}, result: assert.True, err: assert.Nil},
+		{name: "47", op: nfdv1alpha1.MatchVersionRange, values: V{"3.5.0", "4.0.1"}, key: "foo", input: I{"foo": "3.5.0-flavor"}, result: assert.True, err: assert.Nil},
+		{name: "48", op: nfdv1alpha1.MatchVersionRange, values: V{"3.5.0", "4.0.1"}, key: "foo", input: I{"foo": "3.5-flavor"}, result: assert.True, err: assert.Nil},
+		{name: "49", op: nfdv1alpha1.MatchVersionRange, values: V{"3.0.0", "4.0.1"}, key: "foo", input: I{"foo": "3-flavor"}, result: assert.True, err: assert.Nil},
+		{name: "50", op: nfdv1alpha1.MatchVersionRange, values: V{"3", "4"}, key: "foo", input: I{"foo": "3.5.0"}, result: assert.True, err: assert.Nil},
+		{name: "51", op: nfdv1alpha1.MatchVersionRange, values: V{"3.5.0", "4.0.1"}, key: "foo", input: I{"foo": "3.5.0"}, result: assert.True, err: assert.Nil},
+		{name: "52", op: nfdv1alpha1.MatchVersionRange, values: V{"3.5.0", "4.0.1"}, key: "foo", input: I{"foo": "3.5"}, result: assert.True, err: assert.Nil},
+		{name: "53", op: nfdv1alpha1.MatchVersionRange, values: V{"3.5", "4.0"}, key: "foo", input: I{"foo": "3.5"}, result: assert.True, err: assert.Nil},
+		{name: "54", op: nfdv1alpha1.MatchVersionRange, values: V{"3.5", "4.0"}, key: "foo", input: I{"foo": "3.5.2"}, result: assert.True, err: assert.Nil},
+		{name: "55", op: nfdv1alpha1.MatchVersionRange, values: V{"3.5", ""}, key: "foo", input: I{"foo": "3.6.2"}, result: assert.True, err: assert.Nil},
+		{name: "56", op: nfdv1alpha1.MatchVersionRange, values: V{"3.6", ""}, key: "foo", input: I{"foo": "3.6.2"}, result: assert.True, err: assert.Nil},
+		{name: "57", op: nfdv1alpha1.MatchVersionRange, values: V{"3.6.2", ""}, key: "foo", input: I{"foo": "3.6.2"}, result: assert.True, err: assert.Nil},
+		{name: "58", op: nfdv1alpha1.MatchVersionRange, values: V{"", "4.5"}, key: "foo", input: I{"foo": "4.4.9"}, result: assert.True, err: assert.Nil},
+		{name: "59", op: nfdv1alpha1.MatchVersionRange, values: V{"", "4.4.9"}, key: "foo", input: I{"foo": "4.4.9"}, result: assert.True, err: assert.Nil},
+		{name: "60", op: nfdv1alpha1.MatchVersionRange, values: V{"invalid", "invalid"}, key: "foo", input: I{"foo": "3.5.0"}, result: assert.False, err: assert.NotNil},
+		{name: "61", op: nfdv1alpha1.MatchVersionRange, values: V{"3.5.0", "4.0.1"}, key: "foo", input: I{"foo": "invalid"}, result: assert.False, err: assert.NotNil},
+		{name: "62", op: nfdv1alpha1.MatchVersionRange, values: V{"3.5", ""}, key: "foo", input: I{"bar": "3.6"}, result: assert.False, err: assert.Nil},
+		{name: "63", op: nfdv1alpha1.MatchVersionRange, values: V{"3.5.9", ""}, key: "foo", input: I{"foo": "3.5.8"}, result: assert.False, err: assert.Nil},
+		{name: "64", op: nfdv1alpha1.MatchVersionRange, values: V{"", "4.5"}, key: "foo", input: I{"foo": "4.6"}, result: assert.False, err: assert.Nil},
+		{name: "65", op: nfdv1alpha1.MatchVersionRange, values: V{"", "4.4"}, key: "foo", input: I{"foo": "4.4.9"}, result: assert.False, err: assert.Nil},
+		{name: "66", op: nfdv1alpha1.MatchVersionRange, values: V{"5.0", "4.0"}, key: "foo", input: I{"foo": "4.5"}, result: assert.False, err: assert.NotNil},
 	}
 
 	for _, tc := range tcs {

--- a/pkg/utils/parser.go
+++ b/pkg/utils/parser.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ExtractSemVer extracts semantic version from string (e.g., "1.2.3")
+func ExtractSemVer(s string) (string, error) {
+	var major, minor, patch int
+
+	_, err := fmt.Sscanf(s, "%d.%d.%d", &major, &minor, &patch)
+	if err == nil {
+		return fmt.Sprintf("%d.%d.%d", major, minor, patch), nil
+	}
+
+	_, err = fmt.Sscanf(s, "%d.%d", &major, &minor)
+	if err == nil {
+		return fmt.Sprintf("%d.%d", major, minor), nil
+	}
+
+	_, err = fmt.Sscanf(s, "%d", &major)
+	if err == nil {
+		return fmt.Sprintf("%d", major), nil
+	}
+
+	return "", fmt.Errorf("unable to extract semantic version from value: %s", s)
+}
+
+// CompareVersions compare to semantic versions (e.g., "1.2.3")
+// Returns:
+// -1 if v1 < v2
+// 0 if v1 == v2
+// 1 if v1 > v2
+func CompareVersions(v1, v2 string) int {
+	p1 := strings.Split(v1, ".")
+	p2 := strings.Split(v2, ".")
+
+	maxLen := max(len(p1), len(p2))
+
+	for i := 0; i < maxLen; i++ {
+		var num1, num2 int
+		if i < len(p1) {
+			num1, _ = strconv.Atoi(p1[i])
+		}
+		if i < len(p2) {
+			num2, _ = strconv.Atoi(p2[i])
+		}
+		if num1 < num2 {
+			return -1
+		} else if num1 > num2 {
+			return 1
+		}
+	}
+	return 0
+}


### PR DESCRIPTION
The PR adds a new `VersionRange` operator.
The input must be a semantic version and falls within a range that includes the boundary values. Boundaries can be either a valid semantic version or an empty string (""), which represents an infinite limit.

Example of usage
```
- feature: kernel.version
  matchExpressions:
    full: {op: VersionRange, value: ["5.15", "7.0.0"]}
- feature: kernel.version
  matchExpressions:
    full: {op: VersionRange, value: ["", "7.0.0"]}
- feature: kernel.version
  matchExpressions:
    full: {op: VersionRange, value: ["5.15", "5.25"]}
- feature: kernel.version
  matchExpressions:
    full: {op: VersionRange, value: ["5.15", ""]}
```