### PR TITLE
Revert "nfd-master: use only unbuffered chans in the nfd api-controller"

### DIFF
--- a/pkg/nfd-master/nfd-api-controller.go
+++ b/pkg/nfd-master/nfd-api-controller.go
@@ -66,9 +66,9 @@ func init() {
 func newNfdController(config *restclient.Config, nfdApiControllerOptions nfdApiControllerOptions) (*nfdController, error) {
 	c := &nfdController{
 		stopChan:                       make(chan struct{}),
-		updateAllNodesChan:             make(chan struct{}),
+		updateAllNodesChan:             make(chan struct{}, 1),
 		updateOneNodeChan:              make(chan string),
-		updateAllNodeFeatureGroupsChan: make(chan struct{}),
+		updateAllNodeFeatureGroupsChan: make(chan struct{}, 1),
 		updateNodeFeatureGroupChan:     make(chan string),
 	}
 

--- a/test/e2e/data/nodefeature-1.yaml
+++ b/test/e2e/data/nodefeature-1.yaml
@@ -21,6 +21,7 @@ spec:
       fake.instance:
         elements:
         - attributes:
+            name: "instance-x"
             attr_1: "true"
             attr_2: "9"
   # Labels to be created

--- a/test/e2e/data/nodefeaturegroup-2.yaml
+++ b/test/e2e/data/nodefeaturegroup-2.yaml
@@ -1,0 +1,54 @@
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureGroup
+metadata:
+  name: e2e-test-2
+spec:
+  featureGroupRules:
+    - name: "e2e-matchany-test-1"
+      vars:
+        e2e-matchany-test-1: "true"
+      matchAny:
+        - matchFeatures:
+            - feature: "fake.instance"
+              matchExpressions:
+                "attr_1": {op: In, value: ["nomatch"]}
+        - matchFeatures:
+            - feature: "fake.instance"
+              matchExpressions:
+                "attr_3": {op: In, value: ["100"]}
+
+    #
+    # Test templating
+    #
+    - name: "e2e-template-test-1"
+      varsTemplate: |
+        {{ range .fake.instance }}e2e-template-test-1-{{ .name }}=found
+        {{ end }}
+      matchFeatures:
+        - feature: "fake.instance"
+          matchExpressions:
+            "attr_1": {op: In, value: ["true"]}
+
+    - name: "e2e-template-test-2"
+      varsTemplate: |
+        {{ range .fake.attribute }}e2e-template-test-2-{{ .Name }}={{ .Value }}
+        {{ end }}
+      matchFeatures:
+        - feature: "fake.attribute"
+          matchExpressions:
+            # expect attr_2 overridden from nodefeature-1.yaml
+            "attr_2": {op: IsTrue}
+          matchName: {op: In, value: ["attr_3"]}
+
+    #
+    # Test backreference
+    #
+    - name: "e2e-backreference-test-1"
+      matchFeatures:
+        - feature: "rule.matched"
+          matchExpressions:
+            "e2e-matchany-test-1:": {op: IsTrue}
+            "e2e-template-test-1-instance_1": {op: In, value: ["found"]}
+            "e2e-template-test-1-instance_2": {op: Exists}
+            "e2e-template-test-2-attr_2": {op: IsTrue}
+            "e2e-template-test-2-attr_3": {op: In, value: ["10"]}


### PR DESCRIPTION
Fixes a bug where updates to NodeFeatureGroup objects were not happening after the initial sync.

We need to use buffered channels for the "update all" channels as there is the default: case in select that is sending the update all signal (to the channel). An alternative would be to remove the default: case from the select block but it is more efficient this way - just skip if the reader side hasn't yet got the "update all" signal.

This PR also adds new e2e-tests for NodeFeatureGroup to cover this case (plus test the recently added templating and backrefs).