### PR TITLE
api: bump go to v1.23

### DIFF
--- a/api/nfd/go.mod
+++ b/api/nfd/go.mod
@@ -1,7 +1,6 @@
 module sigs.k8s.io/node-feature-discovery/api/nfd
 
-go 1.22.2
-toolchain go1.23.7
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.8.4


### PR DESCRIPTION
One of the latest dep updates i.e. golang.org/x/net v0.36.0 requires go v1.23.0.