### PR TITLE
api/nfd: fix broken unit test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,7 @@ helm-lint:
 
 test:
 	$(GO_CMD) test -covermode=atomic -coverprofile=coverage.out ./cmd/... ./pkg/... ./source/...
+	cd api/nfd && $(GO_CMD) test -covermode=atomic -coverprofile=coverage.out ./...
 
 e2e-test:
 	@if [ -z ${KUBECONFIG} ]; then echo "[ERR] KUBECONFIG missing, must be defined"; exit 1; fi

--- a/api/nfd/v1alpha1/feature_test.go
+++ b/api/nfd/v1alpha1/feature_test.go
@@ -85,7 +85,6 @@ func TestInstanceFeatureSet(t *testing.T) {
 	assert.Equal(t, expectedElems, f1.Elements)
 
 	f2 = NewInstanceFeatures()
-	expectedElems = []InstanceFeature{}
 	f2.MergeInto(&f1)
 	assert.Equal(t, expectedElems, f1.Elements)
 


### PR DESCRIPTION
It was broken in 719c5186f6a555a9ca4389b33754781b6ab2cb56 but never caught as the unit tests were not run (after the api was moved to a separate module).

This patch also modifies the makefile to run the unit tests from api/ directory.