### PR TITLE
[release-0.16] nfd-master: skip NodeFeatureGroup informers if feature gate disabled

### DIFF
--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -1512,8 +1512,9 @@ func (m *nfdMaster) startNfdApiController() error {
 	}
 	klog.InfoS("starting the nfd api controller")
 	m.nfdController, err = newNfdController(kubeconfig, nfdApiControllerOptions{
-		DisableNodeFeature: !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.NodeFeatureAPI) || !m.args.EnableNodeFeatureApi,
-		ResyncPeriod:       m.config.ResyncPeriod.Duration,
+		DisableNodeFeature:      !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.NodeFeatureAPI) || !m.args.EnableNodeFeatureApi,
+		ResyncPeriod:            m.config.ResyncPeriod.Duration,
+		DisableNodeFeatureGroup: !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.NodeFeatureGroupAPI),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize CRD controller: %w", err)


### PR DESCRIPTION
(cherry picked from commit acc94b9f7379eb9b80bc1d940de438c981dce8b8)