### PR TITLE
Enable unprefixed label setting via feature gate

### DIFF
--- a/docs/reference/feature-gates.md
+++ b/docs/reference/feature-gates.md
@@ -55,8 +55,7 @@ to `false`, a NodeFeatureRule with
     foo: bar
 ```
 
-will turn into `feature.node.kubernetes.io/foo=bar` node label. With
-`DisableAutoPrefix` set to `true`, no prefix is added and the label will be
-filtered out.
-
-Note that taint keys are not affected by this feature gate.
+will be automatically prefixed, resulting in the node label
+`feature.node.kubernetes.io/foo=bar`. However, when `DisableAutoPrefix` is set
+to `true`, no prefix is added, and the label remains as `foo=bar`. Note that
+taint keys are not affected by this feature gate.

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -482,7 +482,6 @@ func (m *nfdMaster) filterFeatureLabels(labels Labels, features *nfdv1alpha1.Fea
 
 	return outLabels
 }
-
 func (m *nfdMaster) filterFeatureLabel(name, value string, features *nfdv1alpha1.Features) (string, error) {
 	// Check if Value is dynamic
 	var filteredValue string
@@ -504,7 +503,9 @@ func (m *nfdMaster) filterFeatureLabel(name, value string, features *nfdv1alpha1
 			return "", fmt.Errorf("namespace %q is not allowed", ns)
 		}
 	} else if err != nil {
-		return "", err
+		if !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.DisableAutoPrefix) || err != validate.ErrUnprefixedKeysNotAllowed {
+			return "", err
+		}
 	}
 
 	// Skip if label doesn't match labelWhiteList


### PR DESCRIPTION
Currently, unprefixed labels are not allowed, despite the existence of the `DisableAutoPrefix` feature gate, which is intended for this purpose. This change ensures that when `DisableAutoPrefix` is set to True, the namespace addition is skipped, allowing unprefixed labels.
Fixes: https://github.com/kubernetes-sigs/node-feature-discovery/issues/2074