### PR TITLE
nfd-master: drop the deprecated autoDefaultNs config option

### DIFF
--- a/deployment/components/master-config/nfd-master.conf.example
+++ b/deployment/components/master-config/nfd-master.conf.example
@@ -1,5 +1,4 @@
 # noPublish: false
-# autoDefaultNs: true
 # extraLabelNs: ["added.ns.io","added.kubernets.io"]
 # denyLabelNs: ["denied.ns.io","denied.kubernetes.io"]
 # enableTaints: false

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -23,7 +23,6 @@ master:
   dnsPolicy: ClusterFirstWithHostNet
   config: ### <NFD-MASTER-CONF-START-DO-NOT-REMOVE>
     # noPublish: false
-    # autoDefaultNs: true
     # extraLabelNs: ["added.ns.io","added.kubernets.io"]
     # denyLabelNs: ["denied.ns.io","denied.kubernetes.io"]
     # enableTaints: false

--- a/docs/reference/master-configuration-reference.md
+++ b/docs/reference/master-configuration-reference.md
@@ -65,42 +65,6 @@ Example:
 denyLabelNs: ["denied.ns.io","denied.kubernetes.io"]
 ```
 
-## autoDefaultNs
-
-**DEPRECATED**: Will be removed in NFD v0.17. Use the
-[DisableAutoPrefix](feature-gates.md#disableautoprefix) feature gate instead.
-
-The `autoDefaultNs` option controls the automatic prefixing of names. When set
-to true (the default in NFD version {{ site.version }}) nfd-master
-automatically adds the default `feature.node.kubernetes.io/` prefix to
-unprefixed labels, annotations and extended resources - this is also the
-default behavior in NFD v0.15 and earlier. When the option is set to `false`,
-no prefix will be prepended to unprefixed names, effectively causing them to be
-filtered out (as NFD does not allow unprefixed names of labels, annotations or
-extended resources).  The default will be changed to `false` in a future
-release.
-
-For example, with the `autoDefaultNs` set to `true`, a NodeFeatureRule with
-
-```yaml
-  labels:
-    foo: bar
-```
-
-Will turn into `feature.node.kubernetes.io/foo=bar` node label. With
-`autoDefaultNs` set to `false`, no prefix is added and the label will be
-filtered out.
-
-Note that taint keys are not affected by this option.
-
-Default: `true`
-
-Example:
-
-```yaml
-autoDefaultNs: false
-```
-
 ## enableTaints
 `enableTaints` enables/disables node tainting feature of NFD.
 

--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -361,10 +361,9 @@ vendor.io/my-feature=value
 > **NOTE:** use of unprefixed label names (like `foo=bar`) should not be used.
 > In NFD {{ site.version }} unprefixed names will be automatically prefixed
 > with `feature.node.kubernetes.io/` but this will change in a future version
-> (see
-> [autoDefaultNs config option](../reference/master-configuration-reference.md#autoDefaultNs).
-> Unprefixed names for plain Features (tagged with `# +no-label`) can be used
-> without restrictions, however.
+> (see the [DisableAutoPrefix](../reference/feature-gates.md#disableautoprefix)
+> feature gate). Unprefixed names for plain Features (tagged with `#+no-label`)
+> can be used without restrictions, however.
 
 ### Mounts
 
@@ -608,8 +607,8 @@ NFD enforces some limitations to the namespace (or prefix)/ of the annotations:
   (like `sub.ns.feature.node.kubernetes.io`)
 - unprefixed names (like `my-annotation`) should not be used. In NFD {{
   site.version }} unprefixed names will be automatically prefixed with
-  `feature.node.kubernetes.io/` but this will change in a future version (see
-  [autoDefaultNs config option](../reference/master-configuration-reference.md#autoDefaultNs).
+  `feature.node.kubernetes.io/` but this will change in a future version (see the
+  [DisableAutoPrefix](../reference/feature-gates.md#disableautoprefix) feature gate).
 
 > **NOTE:** The `annotations` field has will only advertise features via node
 > annotations the features won't be advertised as node labels unless they are
@@ -727,8 +726,8 @@ Resources names:
   (like `sub.ns.feature.node.kubernetes.io`)
 - unprefixed names (like `my-er`) site.version }} unprefixed names will be
   automatically prefixed with `feature.node.kubernetes.io/` but this will
-  change in a future version (see
-  [autoDefaultNs config option](../reference/master-configuration-reference.md#autoDefaultNs).
+  change in a future version (see the
+  [DisableAutoPrefix](../reference/feature-gates.md#disableautoprefix) feature gate).
 
 > **NOTE:** `.extendedResources` is not supported by the
 > [custom feature source](#custom-feature-source) -- it can only be used in

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -81,7 +81,6 @@ type Restrictions struct {
 
 // NFDConfig contains the configuration settings of NfdMaster.
 type NFDConfig struct {
-	AutoDefaultNs     bool
 	DenyLabelNs       utils.StringSetVal
 	ExtraLabelNs      utils.StringSetVal
 	LabelWhiteList    *regexp.Regexp
@@ -238,7 +237,6 @@ func newDefaultConfig() *NFDConfig {
 		DenyLabelNs:       utils.StringSetVal{},
 		ExtraLabelNs:      utils.StringSetVal{},
 		NoPublish:         false,
-		AutoDefaultNs:     true,
 		NfdApiParallelism: 10,
 		EnableTaints:      false,
 		ResyncPeriod:      utils.DurationVal{Duration: time.Duration(1) * time.Hour},
@@ -634,7 +632,7 @@ func (m *nfdMaster) getAndMergeNodeFeatures(nodeName string) (*nfdv1alpha1.NodeF
 			features.Labels = nil
 		}
 
-		if !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.DisableAutoPrefix) && m.config.AutoDefaultNs {
+		if !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.DisableAutoPrefix) {
 			features.Labels = addNsToMapKeys(features.Labels, nfdv1alpha1.FeatureLabelNs)
 		}
 
@@ -645,7 +643,7 @@ func (m *nfdMaster) getAndMergeNodeFeatures(nodeName string) (*nfdv1alpha1.NodeF
 				s.Labels = nil
 			}
 
-			if !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.DisableAutoPrefix) && m.config.AutoDefaultNs {
+			if !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.DisableAutoPrefix) {
 				s.Labels = addNsToMapKeys(s.Labels, nfdv1alpha1.FeatureLabelNs)
 			}
 
@@ -815,7 +813,7 @@ func filterExtendedResource(name, value string, features *nfdv1alpha1.Features) 
 }
 
 func (m *nfdMaster) refreshNodeFeatures(cli k8sclient.Interface, node *corev1.Node, labels map[string]string, features *nfdv1alpha1.Features) error {
-	if !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.DisableAutoPrefix) && m.config.AutoDefaultNs {
+	if !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.DisableAutoPrefix) {
 		labels = addNsToMapKeys(labels, nfdv1alpha1.FeatureLabelNs)
 	} else if labels == nil {
 		labels = make(map[string]string)
@@ -973,7 +971,7 @@ func (m *nfdMaster) processNodeFeatureRule(nodeName string, features *nfdv1alpha
 			l := ruleOut.Labels
 			e := ruleOut.ExtendedResources
 			a := ruleOut.Annotations
-			if !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.DisableAutoPrefix) && m.config.AutoDefaultNs {
+			if !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.DisableAutoPrefix) {
 				l = addNsToMapKeys(ruleOut.Labels, nfdv1alpha1.FeatureLabelNs)
 				e = addNsToMapKeys(ruleOut.ExtendedResources, nfdv1alpha1.ExtendedResourceNs)
 				a = addNsToMapKeys(ruleOut.Annotations, nfdv1alpha1.FeatureAnnotationNs)


### PR DESCRIPTION
The autoDefaultNs was deprecated in NFD v0.16 and replaced by the DisableAutoPrefix feature gate.