### PR TITLE
helm: Inherit resource limits for prune job

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/post-delete-job.yaml
+++ b/deployment/helm/node-feature-discovery/templates/post-delete-job.yaml
@@ -97,5 +97,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.master.resources }}
+      resources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}
 


### PR DESCRIPTION
This adds in some resource limits so the prune job can't run away with the system.