### PR TITLE
docs: document -port flag

### DIFF
--- a/docs/reference/master-commandline-reference.md
+++ b/docs/reference/master-commandline-reference.md
@@ -47,20 +47,17 @@ The `-prune` flag is a sub-command like option for cleaning up the cluster. It
 causes nfd-master to remove all NFD related labels, annotations and extended
 resources from all Node objects of the cluster and exit.
 
-### -metrics
+### -port
 
-**DEPRECATED**: Will be removed in NFD v0.17 and replaced by `-port`.
+The `-port` flag specifies the port on which metrics and healthz endpoints are
+served on.
 
-The `-metrics` flag specifies the port on which to expose
-[Prometheus](https://prometheus.io/) metrics. Setting this to 0 disables the
-metrics server on nfd-master.
-
-Default: 8081
+Default: 8080
 
 Example:
 
 ```bash
-nfd-master -metrics=12345
+nfd-master -port=12345
 ```
 
 ### -instance

--- a/docs/reference/topology-updater-commandline-reference.md
+++ b/docs/reference/topology-updater-commandline-reference.md
@@ -72,20 +72,17 @@ Example:
 nfd-topology-updater -oneshot -no-publish
 ```
 
-### -metrics
+### -port
 
-**DEPRECATED**: Will be removed in NFD v0.17 and replaced by `-port`.
+The `-port` flag specifies the port on which metrics and healthz endpoints are
+served on.
 
-The `-metrics` flag specifies the port on which to expose
-[Prometheus](https://prometheus.io/) metrics. Setting this to 0 disables the
-metrics server on nfd-topology-updater.
-
-Default: 8081
+Default: 8080
 
 Example:
 
 ```bash
-nfd-topology-updater -metrics=12345
+nfd-topology-updater -port=12345
 ```
 
 ### -sleep-interval

--- a/docs/reference/worker-commandline-reference.md
+++ b/docs/reference/worker-commandline-reference.md
@@ -126,20 +126,17 @@ Example:
 nfd-worker -label-sources=kernel,system,local
 ```
 
-### -metrics
+### -port
 
-**DEPRECATED**: Will be removed in NFD v0.17 and replaced by `-port`.
+The `-port` flag specifies the port on which metrics and healthz endpoints are
+served on.
 
-The `-metrics` flag specifies the port on which to expose
-[Prometheus](https://prometheus.io/) metrics. Setting this to 0 disables the
-metrics server on nfd-worker.
-
-Default: 8081
+Default: 8080
 
 Example:
 
 ```bash
-nfd-worker -metrics=12345
+nfd-worker -port=12345
 ```
 
 ### -no-publish


### PR DESCRIPTION
The command line reference of nfd-master, nfd-worker and nfd-topology-updater were outdated. They were documenting the already removed -metrics and missing -port completely.