### PR TITLE
feat: add ability to export feature labels for static node

### DIFF
--- a/cmd/nfd-worker/flags.go
+++ b/cmd/nfd-worker/flags.go
@@ -1,0 +1,36 @@
+package main
+
+// boolOrStringValue is a custom flag type that can be a boolean or a non-empty string.
+// We need it to support nfd-worker --export, which can be set (true) or accept
+// an export value (--export=file.json). It satisfies the flag.Value interface.
+type boolOrStringValue struct {
+	// Fistinguish "not set" (false) from "set as a boolean" (true).
+	IsSet bool
+
+	// Value holds the string provided.
+	// If the flag is used as a boolean (e.g., -flag), this value will be "true".
+	Value string
+}
+
+// String is the method to format the flag's value for printing.
+// It's part of the flag.Value interface.
+func (b *boolOrStringValue) String() string {
+	if !b.IsSet {
+		// Represents the "not set" state
+		return ""
+	}
+	return b.Value
+}
+
+// Set parses the flag's value from the command line.
+func (b *boolOrStringValue) Set(s string) error {
+	// When Set is called, we know the flag was present on the command line.
+	b.IsSet = true
+	b.Value = s
+	return nil
+}
+
+// IsBoolFlag is an optional method that makes the flag behave like a boolean.
+func (b *boolOrStringValue) IsBoolFlag() bool {
+	return true
+}

--- a/docs/usage/nfd-worker.md
+++ b/docs/usage/nfd-worker.md
@@ -23,7 +23,7 @@ config option.
 
 NFD-Worker supports configuration through a configuration file. The
 default location is `/etc/kubernetes/node-feature-discovery/nfd-worker.conf`,
-but, this can be changed by specifying the`-config` command line flag.
+but, this can be changed by specifying the `-config` command line flag.
 Configuration file is re-read whenever it is modified which makes run-time
 re-configuration of nfd-worker straightforward.
 
@@ -63,3 +63,22 @@ file must be used, i.e. JSON (or YAML). For example:
 
 Configuration options specified from the command line will override those read
 from the config file.
+
+## Worker export
+
+The nfd worker supports an export mode, where metadata labels can be derived without requiring a Kubernetes context.
+This addresses use cases such as high performance computing (HPC) and other environments with compute nodes
+that warrant assessment, but may not have Kubernetes running, or may not be able to or want to run a central
+daemon service for data. To use export, you can simply add the `--export` flag to the worker start command:
+
+```bash
+nfd-worker --export
+```
+
+By default, the labels will be printed to the screen. If you want to export to a file path:
+
+```bash
+nfd-worker --export=labels.json
+```
+
+


### PR DESCRIPTION
Problem: We want to use NFD (labels and other functionality) for HPC, but a Kubernetes environment is expected.
Solution: Add an `nfd-worker --export` mode that allows for generation and export of static labels.

For the HPC use case, we want to be able to export static features without Kubernetes, either to the screen (for inspection) or a file (for saving and use with a scheduler, or other compatibility checking algorithm).  Adding support for this is fairly easy - we need to just expose the flag, disable the check for Kubernetes assets, and then generate the labels once and exit (without starting or sending to a server). The usage is simple and intuitive:

```bash
# Export labels to the terminal for inspection
nfd-worker --export

# Save to a file path
nfd-worker --export=labels.json
```
The flag is also useful for cases beyond HPC when a quick inspection is desired. Note that instead of adding two flags (a boolean for export, and string for a filepath) I opted for the design above - one flag that supports being used as a boolean or providing a path. A new flag type is added to support that, and it is generic so could be used for other future cases. For my implementation, for us to check how this new flag was set, we need to pass it to the initFlags function:

```go
args, overrides := initFlags(flags, &exportFlag)
```
And I think this is OK for now, but if more flags were defined in this manner, we would want to pass a structure with all of them. I decided that was overkill for the time being. For another design choice, I think the generation of the labels should be in the same function to `Run()`, and to support this I check `w.args.Export` before setting up any servers / Prometheus, and run the generation (that will handle the export to terminal or file and exit early, if applicable).  I have also added tests and documentation, and I tested on an HPC node (in user space) to make sure the labels generated without issue.

I realize I didn't open an issue for discussion - so am happy to have it here! To better explain the use case, this is a feature intended to better support compatibility checking, but for HPC. We won't be able to run compatibility checks assuming labels are available via Kubernetes, but we will be able to export them to files that represent nodes, and then be able to use associated tools to check compatibility artifacts against the known features. This is what I'm working on today. Thanks!