### PR TITLE
Allow unprefixed extended resources via feature-gate

### DIFF
--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -724,10 +724,10 @@ Resources names:
   generally be used
 - the only exception is `feature.node.kubernetes.io/` and its sub-namespaces
   (like `sub.ns.feature.node.kubernetes.io`)
-- unprefixed names (like `my-er`) site.version }} unprefixed names will be
-  automatically prefixed with `feature.node.kubernetes.io/` but this will
-  change in a future version (see the
-  [DisableAutoPrefix](../reference/feature-gates.md#disableautoprefix) feature gate).
+- if an unprefixed name (e.g., `my-er`) is used, NFD {{ site.version }}
+  will automatically prefix it with `feature.node.kubernetes.io/` unless the
+  `DisableAutoPrefix` feature gate is set to true, in which case no prefixing
+  occurs.
 
 > **NOTE:** `.extendedResources` is not supported by the
 > [custom feature source](#custom-feature-source) -- it can only be used in

--- a/pkg/nfd-master/nfd-master-internal_test.go
+++ b/pkg/nfd-master/nfd-master-internal_test.go
@@ -379,12 +379,13 @@ func TestFilterLabels(t *testing.T) {
 	}
 
 	type TC struct {
-		description   string
-		labelName     string
-		labelValue    string
-		features      nfdv1alpha1.Features
-		expectErr     bool
-		expectedValue string
+		description          string
+		labelName            string
+		labelValue           string
+		features             nfdv1alpha1.Features
+		expectErr            bool
+		expectedValue        string
+		expectedExtResources ExtendedResources
 	}
 
 	tcs := []TC{
@@ -459,6 +460,24 @@ func TestFilterLabels(t *testing.T) {
 			}
 		})
 	}
+
+	tcs = []TC{
+		{
+			description:          "Unprefixed extended resources should not be allowed",
+			expectedExtResources: ExtendedResources{},
+		},
+	}
+
+	extendedResources := ExtendedResources{"micromicrowaves": "10", "tooster": "5"}
+	for _, tc := range tcs {
+		t.Run(tc.description, func(t *testing.T) {
+			outExtendedResources := fakeMaster.filterExtendedResources(&tc.features, extendedResources)
+			Convey("Unprefixed extended resources should npotbe allowed", t, func() {
+				So(outExtendedResources, ShouldEqual, tc.expectedExtResources)
+			})
+		})
+	}
+
 	// Create a new fake master with the feature gate enabled
 	fakeMaster = newFakeMasterWithFeatureGate()
 	tcs = []TC{
@@ -478,6 +497,26 @@ func TestFilterLabels(t *testing.T) {
 			})
 			Convey("Label value should be correct", t, func() {
 				So(labelValue, ShouldEqual, tc.expectedValue)
+			})
+		})
+	}
+
+	tcs = []TC{
+		{
+			description: "Unprefixed extended resources should be allowed",
+			expectedExtResources: ExtendedResources{
+				"micromicrowaves": "10",
+				"tooster":         "5",
+			},
+		},
+	}
+
+	extendedResources = ExtendedResources{"micromicrowaves": "10", "tooster": "5"}
+	for _, tc := range tcs {
+		t.Run(tc.description, func(t *testing.T) {
+			outExtendedResources := fakeMaster.filterExtendedResources(&tc.features, extendedResources)
+			Convey("Unprefixed extended resources should be allowed", t, func() {
+				So(outExtendedResources, ShouldEqual, tc.expectedExtResources)
 			})
 		})
 	}

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -809,7 +809,9 @@ func filterExtendedResource(name, value string, features *nfdv1alpha1.Features) 
 	// Validate
 	err := validate.ExtendedResource(name, filteredValue)
 	if err != nil {
-		return "", err
+		if !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.DisableAutoPrefix) || err != validate.ErrUnprefixedKeysNotAllowed {
+			return "", err
+		}
 	}
 
 	return filteredValue, nil


### PR DESCRIPTION
Second part of https://github.com/kubernetes-sigs/node-feature-discovery/issues/2120 and is related to https://github.com/kubernetes-sigs/node-feature-discovery/issues/2074.