### PR TITLE
update: add support for 'imagePullSecrets' propagation by root helm chart

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/_helpers.tpl
+++ b/deployment/helm/node-feature-discovery/templates/_helpers.tpl
@@ -105,3 +105,22 @@ Create the name of the service account which nfd-gc will use
     {{ default "default" .Values.gc.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+imagePullSecrets helper - uses local values or falls back to global values
+*/}}
+{{- define "node-feature-discovery.imagePullSecrets" -}}
+{{- $imagePullSecrets := list -}}
+{{- if .Values.imagePullSecrets -}}
+  {{- range .Values.imagePullSecrets -}}
+    {{- $imagePullSecrets = append $imagePullSecrets . -}}
+  {{- end -}}
+{{- else if and .Values.global .Values.global.imagePullSecrets -}}
+  {{- range .Values.global.imagePullSecrets -}}
+    {{- $imagePullSecrets = append $imagePullSecrets . -}}
+  {{- end -}}
+{{- end -}}
+{{- if $imagePullSecrets -}}
+{{- $imagePullSecrets | toJson }}
+{{- end -}}
+{{- end -}}

--- a/deployment/helm/node-feature-discovery/templates/master.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master.yaml
@@ -33,10 +33,7 @@ spec:
     {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
     {{- end }}
-    {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      imagePullSecrets: {{ include "node-feature-discovery.imagePullSecrets" . }}
       serviceAccountName: {{ include "node-feature-discovery.master.serviceAccountName" . }}
       enableServiceLinks: false
       securityContext:

--- a/deployment/helm/node-feature-discovery/templates/nfd-gc.yaml
+++ b/deployment/helm/node-feature-discovery/templates/nfd-gc.yaml
@@ -33,10 +33,7 @@ spec:
     {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
     {{- end }}
-    {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      imagePullSecrets: {{ include "node-feature-discovery.imagePullSecrets" . }}
       securityContext:
         {{- toYaml .Values.gc.podSecurityContext | nindent 8 }}
       hostNetwork: {{ .Values.gc.hostNetwork }}

--- a/deployment/helm/node-feature-discovery/templates/post-delete-job.yaml
+++ b/deployment/helm/node-feature-discovery/templates/post-delete-job.yaml
@@ -67,10 +67,7 @@ spec:
         role: prune
     spec:
       serviceAccountName: {{ include "node-feature-discovery.fullname" . }}-prune
-    {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      imagePullSecrets: {{ include "node-feature-discovery.imagePullSecrets" . }}
       containers:
         - name: nfd-master
           securityContext:

--- a/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
+++ b/deployment/helm/node-feature-discovery/templates/topologyupdater.yaml
@@ -33,10 +33,7 @@ spec:
     {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
     {{- end }}
-    {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      imagePullSecrets: {{ include "node-feature-discovery.imagePullSecrets" . }}
       securityContext:
         {{- toYaml .Values.topologyUpdater.podSecurityContext | nindent 8 }}
       hostNetwork: {{ .Values.topologyUpdater.hostNetwork }}

--- a/deployment/helm/node-feature-discovery/templates/worker.yaml
+++ b/deployment/helm/node-feature-discovery/templates/worker.yaml
@@ -36,10 +36,7 @@ spec:
     {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
     {{- end }}
-    {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      imagePullSecrets: {{ include "node-feature-discovery.imagePullSecrets" . }}
       serviceAccountName: {{ include "node-feature-discovery.worker.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.worker.podSecurityContext | nindent 8 }}

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -170,6 +170,12 @@ Metrics are configured to be exposed using prometheus operator API's by
 default. If you want to expose metrics using the prometheus operator
 API's you need to install the prometheus operator in your cluster.
 
+### Global parameters
+
+| Name                                        | Type    | Default                          | Description                                                                                                                |
+|---------------------------------------------|---------|----------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| `global.imagePullSecrets`                   | array   | []                               | An optional list of references to secrets with the same meaning as `imagePullSecrets`. If `imagePullSecrets` is specified, it takes precedence over `global.imagePullSecrets`. |
+
 ### Master pod parameters
 
 | Name                                        | Type    | Default                          | Description                                                                                                                |


### PR DESCRIPTION
nfd serves as sub-chart in our project, and we would like to propagate `imagePullSecrets` content in root `values.yaml` to nfd sub-chart. Therefore I have added `.Values.global.imagePullSecrets` and created a helper helm func to update accordingly.