### PR TITLE
feat(rbac): add permissions for daemonsets finalizers in worker role

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/role.yaml
+++ b/deployment/helm/node-feature-discovery/templates/role.yaml
@@ -22,4 +22,12 @@ rules:
   - pods
   verbs:
   - get
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets/finalizers
+  verbs:
+  - get
+  - update
+  - delete
 {{- end }}


### PR DESCRIPTION
`nodefeatures` has ownerRef to gpu-operator-node-feature-discovery-worker DaemonSet 

```
  ownerReferences:
  - apiVersion: apps/v1
    blockOwnerDeletion: true
    controller: true
    kind: DaemonSet
    name: gpu-operator-node-feature-discovery-worker
    uid: 66a15f02-08ec-4c43-b659-1b9d1641f6f4
```

`gpu-operator-node-feature-discovery-worker` pods are trying to set the blockOwnerDeletion but failing

```
"main.go:91] " error while running" err="failed to advertise features (via CRD API): failed to create NodeFeature object \"skynet-dev-b6zqb\": nodefeatures.nfd.k8s-sigs.io \"skynet-dev-b6zqb\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"
```