### PR TITLE
github: set JEKYLL_GITHUB_TOKEN env

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -34,6 +34,8 @@ jobs:
       run: git fetch --no-tags --prune --depth=1 origin refs/heads/gh-pages:refs/heads/gh-pages
 
     - name: Build site
+      env:
+        JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         git config user.name "Github Actions"
         git config user.email "no-reply@github.com"


### PR DESCRIPTION
This hopefully rate limiting warnings and errors in building the documentation.