### PR TITLE
[release-0.14] docs: switch to jekyll-theme-read-the-docs

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -224,7 +224,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.6)
+    rexml (3.4.1)
     rouge (3.26.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -26,9 +26,7 @@ markdown: kramdown
 kramdown:
   toc_levels: 1..3
 
-remote_theme: rundocs/jekyll-rtd-theme@v2.0.10
-plugins:
-  - jekyll-remote-theme
+remote_theme: jv-conseil/jekyll-theme-read-the-docs@ce7ed5ad2184b36244a50adbeea2f0a6ab1f8606
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list


### PR DESCRIPTION
Pin to a specific commit for reproducibility.

(cherry picked from commit 4faf4df1e4f612b900d408a1c121595810429237)