### PR TITLE
[release-0.13] docs: switch to jekyll-theme-read-the-docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -26,9 +26,7 @@ markdown: kramdown
 kramdown:
   toc_levels: 1..3
 
-remote_theme: rundocs/jekyll-rtd-theme@v2.0.10
-plugins:
-  - jekyll-remote-theme
+remote_theme: jv-conseil/jekyll-theme-read-the-docs@ce7ed5ad2184b36244a50adbeea2f0a6ab1f8606
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list


### PR DESCRIPTION
Pin to a specific commit for reproducibility.

(cherry picked from commit 4faf4df1e4f612b900d408a1c121595810429237)