### PR TITLE
[release-0.9] docs: switch to jekyll-theme-read-the-docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -26,7 +26,7 @@ markdown: kramdown
 kramdown:
   toc_levels: 1..3
 
-remote_theme: rundocs/jekyll-rtd-theme@v2.0.9
+remote_theme: jv-conseil/jekyll-theme-read-the-docs@ce7ed5ad2184b36244a50adbeea2f0a6ab1f8606
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/docs/_includes/templates/addons.liquid
+++ b/docs/_includes/templates/addons.liquid
@@ -43,14 +43,31 @@
                 {% endif %}
             </dl>
         {% endif %}
-        {%- assign items = "github" | split: ", " -%}
-        {% for item in items -%}
-            {% include addons/{{ item }}.liquid %}
-        {% endfor -%}
+        <dl>
+            <dt>{{ __.github | default: "GitHub" }}</dt>
+            <dd>
+                <a href="{{ docs.repository_url }}" title="{{ __.stars | default: 'Stars' }}: {{ rest.stargazers_count }}">
+                    <i class="fa fa-github"></i>
+                    {{ __.homepage | default: "Homepage" }}
+                </a>
+            </dd>
+            <dd>
+                <a href="{{ docs.issues_url }}" title="{{ __.open_issues | default: 'Open issues' }}: {{ rest.open_issues }}">
+                    <i class="fa fa-question-circle-o"></i>
+                    {{ __.issues | default: "Issues" }}
+                </a>
+            </dd>
+            <dd>
+                <a href="{{ docs.zip_url }}" title="{{ __.size | default: 'Size' }}: {{ rest.size }} Kb">
+                    <i class="fa fa-download"></i>
+                    {{ __.download | default: "Download" }}
+                </a>
+            </dd>
+        </dl>
         <hr>
         <div class="license f6 pb-2">
-            The
-            <a href="{{ site.baseurl }}/">software</a>
+            This
+            <a href="{{ site.baseurl }}/" title="{{ site.title }}">Software</a>
             is under the terms of
             <a href="{{ docs.repository_url }}">{{ docs.license.name | default: "The Unlicense" }}</a>.
         </div>

--- a/docs/_includes/templates/content.liquid
+++ b/docs/_includes/templates/content.liquid
@@ -1,0 +1,26 @@
+<div class="content-wrap">
+    <div class="header d-flex flex-justify-between p-2 hide-lg hide-xl" aria-label="top navigation">
+        <button id="toggle" aria-label="Toggle menu" class="btn-octicon p-2 m-0 text-white" type="button">
+            <i class="fa fa-bars"></i>
+        </button>
+        <div class="title flex-1 d-flex flex-justify-center">
+            <a class="h4 no-underline py-1 px-2 rounded-1" href="{{ site.baseurl }}/">{{ site.title }}</a>
+        </div>
+    </div>
+    <div class="bg-red-2">
+        <div class="content p-3 px-sm-5">
+            This documentation is for Node Feature Discovery version that is no longer supported. Please upgrade and visit the
+            <a class="no-underline" href="{{ '../stable' | relative_url }}">documentation of the latest stable release</a>.
+        </div>
+    </div>
+    <div class="content p-3 p-sm-5">
+        {% include templates/breadcrumbs.liquid %}
+        <hr>
+        <div role="main" itemscope="itemscope" itemtype="https://schema.org/Article">
+            <div class="markdown-body" itemprop="articleBody">
+                {{ content }}
+            </div>
+        </div>
+        {% include templates/footer.liquid %}
+    </div>
+</div>

--- a/docs/_includes/templates/sidebar.liquid
+++ b/docs/_includes/templates/sidebar.liquid
@@ -12,7 +12,7 @@
             </form>
         </div>
         <div class="toctree py-2" data-spy="affix" role="navigation" aria-label="main navigation">
-            {% include class/_toctree.liquid %}
+            {% include templates/toctree.liquid %}
         </div>
     </div>
 </div>


### PR DESCRIPTION
Pin to a specific commit for reproducibility.

(cherry picked from commit https://github.com/kubernetes-sigs/node-feature-discovery/commit/4faf4df1e4f612b900d408a1c121595810429237)

Also, sync (docs/_includes) from master branch to work with the updated theme.