### PR TITLE
[release-0.9] github: specify workflow permissions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,12 +8,20 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
   release:
     types: [published]
+
+concurrency:
+  group: gh-pages
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Update gh-pages
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-
     - name: Install dependencies
       run: |
         sudo apt-get install -y jq curl


### PR DESCRIPTION
Update gh-pages has started failing with default permissions. It needs write permissions to be able to push to the gh-pages branch.

(cherry picked from commit b024fa1a79d85ebed23a9027ff4e9c72158dfbf5)