### PR TITLE
github: don't cancel gh-pages update on congestion

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,6 +9,7 @@ on:
 
 concurrency:
   group: gh-pages
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
 
 concurrency:
   group: gh-pages
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
Don't cancel but wait for the other job(s) to be finished.