### PR TITLE
scripts/test-infra: bump golangci-lint to v2.4.0

### DIFF
--- a/cmd/nfd-gc/main.go
+++ b/cmd/nfd-gc/main.go
@@ -68,7 +68,7 @@ func parseArgs(flags *flag.FlagSet, osArgs ...string) *nfdgarbagecollector.Args 
 
 	_ = flags.Parse(osArgs)
 	if len(flags.Args()) > 0 {
-		fmt.Fprintf(flags.Output(), "unknown command line argument: %s\n", flags.Args()[0])
+		_, _ = fmt.Fprintf(flags.Output(), "unknown command line argument: %s\n", flags.Args()[0])
 		flags.Usage()
 		os.Exit(2)
 	}

--- a/cmd/nfd-master/main.go
+++ b/cmd/nfd-master/main.go
@@ -51,7 +51,7 @@ func main() {
 
 	_ = flags.Parse(os.Args[1:])
 	if len(flags.Args()) > 0 {
-		fmt.Fprintf(flags.Output(), "unknown command line argument: %s\n", flags.Args()[0])
+		_, _ = fmt.Fprintf(flags.Output(), "unknown command line argument: %s\n", flags.Args()[0])
 		flags.Usage()
 		os.Exit(2)
 	}

--- a/cmd/nfd-topology-updater/main.go
+++ b/cmd/nfd-topology-updater/main.go
@@ -70,7 +70,7 @@ func parseArgs(flags *flag.FlagSet, osArgs ...string) (*topology.Args, *resource
 
 	_ = flags.Parse(osArgs)
 	if len(flags.Args()) > 0 {
-		fmt.Fprintf(flags.Output(), "unknown command line argument: %s\n", flags.Args()[0])
+		_, _ = fmt.Fprintf(flags.Output(), "unknown command line argument: %s\n", flags.Args()[0])
 		flags.Usage()
 		os.Exit(2)
 	}
@@ -83,7 +83,7 @@ func parseArgs(flags *flag.FlagSet, osArgs ...string) (*topology.Args, *resource
 	if len(resourcemonitorArgs.KubeletConfigURI) == 0 {
 		nodeAddress := os.Getenv("NODE_ADDRESS")
 		if len(nodeAddress) == 0 {
-			fmt.Fprintf(flags.Output(), "unable to determine the default kubelet config endpoint 'https://${NODE_ADDRESS}:%d/configz' due to empty NODE_ADDRESS environment, "+
+			_, _ = fmt.Fprintf(flags.Output(), "unable to determine the default kubelet config endpoint 'https://${NODE_ADDRESS}:%d/configz' due to empty NODE_ADDRESS environment, "+
 				"please either define the NODE_ADDRESS environment variable or specify endpoint with the -kubelet-config-uri flag\n", kubeletSecurePort)
 			os.Exit(1)
 		}

--- a/cmd/nfd-worker/main.go
+++ b/cmd/nfd-worker/main.go
@@ -77,7 +77,7 @@ func parseArgs(flags *flag.FlagSet, osArgs ...string) *worker.Args {
 
 	_ = flags.Parse(osArgs)
 	if len(flags.Args()) > 0 {
-		fmt.Fprintf(flags.Output(), "unknown command line argument: %s\n", flags.Args()[0])
+		_, _ = fmt.Fprintf(flags.Output(), "unknown command line argument: %s\n", flags.Args()[0])
 		flags.Usage()
 		os.Exit(2)
 	}

--- a/pkg/apis/nfd/nodefeaturerule/expression.go
+++ b/pkg/apis/nfd/nodefeaturerule/expression.go
@@ -452,7 +452,7 @@ func MatchGetInstances(m *nfdv1alpha1.MatchExpressionSet, instances []nfdv1alpha
 func MatchMulti(m *nfdv1alpha1.MatchExpressionSet, keys map[string]nfdv1alpha1.Nil, values map[string]string, instances []nfdv1alpha1.InstanceFeature, failFast bool) (bool, []MatchedElement, *nfdv1alpha1.MatchExpressionSet, error) {
 	matchedElems := []MatchedElement{}
 	matchedExpressions := nfdv1alpha1.MatchExpressionSet{}
-	isMatch := false
+	isMatch := false // nolint: staticcheck
 
 	// Keys and values are handled as a union, it is enough to find a match in
 	// either of them

--- a/pkg/nfd-gc/nfd-gc.go
+++ b/pkg/nfd-gc/nfd-gc.go
@@ -131,7 +131,7 @@ func (n *nfdGarbageCollector) deleteNodeHandler(object interface{}) {
 		klog.InfoS("cannot convert object to metav1.ObjectMeta", "object", object)
 		return
 	}
-	nodeName := meta.ObjectMeta.GetName()
+	nodeName := meta.GetName()
 
 	n.deleteNRT(nodeName)
 
@@ -177,10 +177,10 @@ func (n *nfdGarbageCollector) garbageCollect() {
 				handler(item)
 			}
 
-			if rsp.ListMeta.Continue == "" {
+			if rsp.Continue == "" {
 				break
 			}
-			opts.Continue = rsp.ListMeta.Continue
+			opts.Continue = rsp.Continue
 		}
 	}
 
@@ -269,7 +269,7 @@ func (n *nfdGarbageCollector) Run() error {
 			klog.InfoS("HTTP server stopped")
 		}
 	}()
-	defer httpServer.Close()
+	defer httpServer.Close() // nolint:errcheck
 
 	if err := n.startNodeInformer(); err != nil {
 		return err

--- a/pkg/nfd-master/nfd-master-internal_test.go
+++ b/pkg/nfd-master/nfd-master-internal_test.go
@@ -645,7 +645,11 @@ func TestConfigParse(t *testing.T) {
 		})
 		// Create a temporary config file
 		f, err := os.CreateTemp("", "nfd-test-")
-		defer os.Remove(f.Name())
+		defer func() {
+			if err := os.Remove(f.Name()); err != nil {
+				t.Logf("failed to remove temp file %s: %v", f.Name(), err)
+			}
+		}()
 		So(err, ShouldBeNil)
 		_, err = f.WriteString(`
 noPublish: true
@@ -657,7 +661,8 @@ leaderElection:
   renewDeadline: 4s
   retryPeriod: 30s
 `)
-		f.Close()
+		So(err, ShouldBeNil)
+		err = f.Close()
 		So(err, ShouldBeNil)
 
 		Convey("and a proper config file is specified", func() {

--- a/pkg/nfd-topology-updater/nfd-topology-updater.go
+++ b/pkg/nfd-topology-updater/nfd-topology-updater.go
@@ -200,7 +200,7 @@ func (w *nfdTopologyUpdater) Run() error {
 		klog.InfoS("http server starting", "port", httpServer.Addr)
 		klog.InfoS("http server stopped", "exitCode", httpServer.ListenAndServe())
 	}()
-	defer httpServer.Close()
+	defer httpServer.Close() // nolint: errcheck
 
 	for {
 		select {

--- a/pkg/nfd-worker/nfd-worker-internal_test.go
+++ b/pkg/nfd-worker/nfd-worker-internal_test.go
@@ -129,7 +129,11 @@ func TestConfigParse(t *testing.T) {
 		})
 		// Create a temporary config file
 		f, err := os.CreateTemp("", "nfd-test-")
-		defer os.Remove(f.Name())
+		defer func() {
+			if err := os.Remove(f.Name()); err != nil {
+				t.Errorf("failed to remove temp file %s: %v", f.Name(), err)
+			}
+		}()
 		So(err, ShouldBeNil)
 		_, err = f.WriteString(`
 core:
@@ -145,7 +149,8 @@ sources:
   pci:
     deviceClassWhitelist:
       - "ff"`)
-		f.Close()
+		So(err, ShouldBeNil)
+		err = f.Close()
 		So(err, ShouldBeNil)
 
 		Convey("and a proper config file is specified", func() {

--- a/pkg/nfd-worker/nfd-worker.go
+++ b/pkg/nfd-worker/nfd-worker.go
@@ -216,7 +216,7 @@ func (i *infiniteTicker) Reset(d time.Duration) {
 	default:
 		// If the sleep interval is not a positive number the ticker will act
 		// as if it was set to an infinite duration by not ticking.
-		i.Ticker.Stop()
+		i.Stop()
 	}
 }
 
@@ -331,7 +331,7 @@ func (w *nfdWorker) Run() error {
 		klog.InfoS("http server starting", "port", httpServer.Addr)
 		klog.InfoS("http server stopped", "exitCode", httpServer.ListenAndServe())
 	}()
-	defer httpServer.Close()
+	defer httpServer.Close() // nolint: errcheck
 
 	for {
 		select {
@@ -356,7 +356,7 @@ func (w *nfdWorker) Stop() {
 func (c *coreConfig) sanitize() {
 	if c.SleepInterval.Duration > 0 && c.SleepInterval.Duration < time.Second {
 		klog.InfoS("too short sleep interval specified, forcing to 1s",
-			"sleepInterval", c.SleepInterval.Duration.String())
+			"sleepInterval", c.SleepInterval.String())
 		c.SleepInterval = utils.DurationVal{Duration: time.Second}
 	}
 }

--- a/pkg/nfd-worker/nfd-worker_test.go
+++ b/pkg/nfd-worker/nfd-worker_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/klog/v2"
 
 	fakenfdclient "sigs.k8s.io/node-feature-discovery/api/generated/clientset/versioned/fake"
-	"sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
 	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
 	"sigs.k8s.io/node-feature-discovery/pkg/features"
 	worker "sigs.k8s.io/node-feature-discovery/pkg/nfd-worker"
@@ -46,8 +45,8 @@ func TestRun(t *testing.T) {
 	initializeFeatureGates()
 	Convey("When running nfd-worker", t, func() {
 		Convey("When publishing features from fake source", func() {
-			os.Setenv("NODE_NAME", "fake-node")
-			os.Setenv("KUBERNETES_NAMESPACE", "fake-ns")
+			_ = os.Setenv("NODE_NAME", "fake-node")
+			_ = os.Setenv("KUBERNETES_NAMESPACE", "fake-ns")
 			args := &worker.Args{
 				Oneshot: true,
 				Overrides: worker.ConfigOverrideArgs{
@@ -86,16 +85,16 @@ func TestRun(t *testing.T) {
 							"feature.node.kubernetes.io/fake-fakefeature2": "true",
 							"feature.node.kubernetes.io/fake-fakefeature3": "true",
 						},
-						Features: v1alpha1.Features{
-							Flags: map[string]v1alpha1.FlagFeatureSet{
+						Features: nfdv1alpha1.Features{
+							Flags: map[string]nfdv1alpha1.FlagFeatureSet{
 								"fake.flag": {
-									Elements: map[string]v1alpha1.Nil{
+									Elements: map[string]nfdv1alpha1.Nil{
 										"flag_1": {},
 										"flag_2": {},
 										"flag_3": {}},
 								},
 							},
-							Attributes: map[string]v1alpha1.AttributeFeatureSet{
+							Attributes: map[string]nfdv1alpha1.AttributeFeatureSet{
 								"fake.attribute": {
 									Elements: map[string]string{
 										"attr_1": "true",
@@ -104,9 +103,9 @@ func TestRun(t *testing.T) {
 									},
 								},
 							},
-							Instances: map[string]v1alpha1.InstanceFeatureSet{
+							Instances: map[string]nfdv1alpha1.InstanceFeatureSet{
 								"fake.instance": {
-									Elements: []v1alpha1.InstanceFeature{
+									Elements: []nfdv1alpha1.InstanceFeature{
 										{Attributes: map[string]string{
 											"name":   "instance_1",
 											"attr_1": "true",

--- a/pkg/utils/featuregate/featuregate.go
+++ b/pkg/utils/featuregate/featuregate.go
@@ -175,9 +175,10 @@ func (f *featureGate) SetFromMap(m map[string]bool) error {
 		}
 		enabled[k] = v
 
-		if featureSpec.PreRelease == Deprecated {
+		switch featureSpec.PreRelease {
+		case Deprecated:
 			klog.InfoS("Setting deprecated feature gate. It will be removed in a future release.", "featureGateName", k, "featureGateValue", v)
-		} else if featureSpec.PreRelease == GA {
+		case GA:
 			klog.InfoS("Setting GA feature gate. It will be removed in a future release.", "featureGateName", k, "featureGateValue", v)
 		}
 	}

--- a/pkg/utils/featuregate/featuregate_test.go
+++ b/pkg/utils/featuregate/featuregate_test.go
@@ -84,7 +84,7 @@ func TestFeatureGateFlagDefaults(t *testing.T) {
 	const testBetaGate Feature = "TestBeta"
 
 	// Don't parse the flag, assert defaults are used.
-	var f *featureGate = NewFeatureGate()
+	var f = NewFeatureGate()
 	_ = f.Add(map[Feature]FeatureSpec{
 		testAlphaGate: {Default: false, PreRelease: Alpha},
 		testBetaGate:  {Default: true, PreRelease: Beta},
@@ -108,7 +108,7 @@ func TestFeatureGateKnownFeatures(t *testing.T) {
 	)
 
 	// Don't parse the flag, assert defaults are used.
-	var f *featureGate = NewFeatureGate()
+	var f = NewFeatureGate()
 	_ = f.Add(map[Feature]FeatureSpec{
 		testAlphaGate:      {Default: false, PreRelease: Alpha},
 		testBetaGate:       {Default: true, PreRelease: Beta},

--- a/pkg/utils/memory_resources_test.go
+++ b/pkg/utils/memory_resources_test.go
@@ -70,7 +70,11 @@ func TestGetMemoryResourceCounters(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to create temporary directory: %v", err)
 	}
-	defer os.RemoveAll(rootDir) // clean up
+	defer func() {
+		if err := os.RemoveAll(rootDir); err != nil {
+			t.Logf("failed to remove temporary directory %q: %v", rootDir, err)
+		}
+	}()
 
 	sysBusNodeBasepath = rootDir
 

--- a/scripts/test-infra/verify.sh
+++ b/scripts/test-infra/verify.sh
@@ -4,7 +4,7 @@ this_dir=`dirname $0`
 
 # Install deps
 gobinpath="$(go env GOPATH)/bin"
-curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b "$gobinpath" v1.64.5
+curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b "$gobinpath" v2.4.0
 export PATH=$PATH:$(go env GOPATH)/bin
 
 curl -sfL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash -s -- --version v3.15.3

--- a/source/cpu/security_amd64.go
+++ b/source/cpu/security_amd64.go
@@ -158,7 +158,7 @@ func getCgroupMiscCapacity(resource string) int64 {
 		miscCgroups := hostpath.SysfsDir.Path(miscCgroupsPath)
 		f, err := os.Open(miscCgroups)
 		if err == nil {
-			defer f.Close()
+			defer f.Close() // nolint: errcheck
 
 			return retrieveCgroupMiscCapacityValue(f, resource)
 		}

--- a/source/custom/api/conversion_test.go
+++ b/source/custom/api/conversion_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
 	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
 )
 
@@ -178,7 +177,7 @@ func TestRuleConversion(t *testing.T) {
 					nfdv1alpha1.FeatureMatcherTerm{
 						Feature:          "fake.attribute",
 						MatchExpressions: nil,
-						MatchName:        &v1alpha1.MatchExpression{Op: v1alpha1.MatchInRegexp, Value: v1alpha1.MatchValue{"^elem-"}},
+						MatchName:        &nfdv1alpha1.MatchExpression{Op: nfdv1alpha1.MatchInRegexp, Value: nfdv1alpha1.MatchValue{"^elem-"}},
 					},
 				},
 			},

--- a/source/kernel/kconfig.go
+++ b/source/kernel/kconfig.go
@@ -35,14 +35,14 @@ func readKconfigGzip(filename string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer f.Close() // nolint: errcheck
 
 	// Uncompress data
 	r, err := gzip.NewReader(f)
 	if err != nil {
 		return nil, err
 	}
-	defer r.Close()
+	defer r.Close() // nolint: errcheck
 
 	return io.ReadAll(r)
 }
@@ -83,7 +83,7 @@ func parseKconfig(configPath string) (realKconfig, legacyKconfig map[string]stri
 
 	for _, path := range append([]string{configPath}, searchPaths...) {
 		if len(path) > 0 {
-			if ".gz" == filepath.Ext(path) {
+			if filepath.Ext(path) == ".gz" {
 				if raw, err = readKconfigGzip(path); err == nil {
 					break
 				}

--- a/test/e2e/gomega.go
+++ b/test/e2e/gomega.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 	taintutils "k8s.io/kubernetes/pkg/util/taints"
 
@@ -36,8 +36,8 @@ type k8sLabels map[string]string
 type k8sAnnotations map[string]string
 
 // eventuallyNonControlPlaneNodes is a helper for asserting node properties
-func eventuallyNonControlPlaneNodes(ctx context.Context, cli clientset.Interface) AsyncAssertion {
-	return Eventually(func(g Gomega, ctx context.Context) ([]corev1.Node, error) {
+func eventuallyNonControlPlaneNodes(ctx context.Context, cli clientset.Interface) gomega.AsyncAssertion {
+	return gomega.Eventually(func(g gomega.Gomega, ctx context.Context) ([]corev1.Node, error) {
 		return getNonControlPlaneNodes(ctx, cli)
 	}).WithPolling(1 * time.Second).WithTimeout(10 * time.Second).WithContext(ctx)
 }


### PR DESCRIPTION
Also fix or silence errors from golangci-lint v2.4.0:

- unchecked return values (errcheck)
- nolint for Close() for read-only files and http servers
- unnecessary naming of embedded fields of structs (staticcheck)
- multiple imports of the same package (staticcheck)
- use switch-case instead of if/else (staticcheck)
- remove type from var declaration (staticcheck)
- remove "Yoda" condition from if (staticcheck)
- don't use dot imports