### PR TITLE
scripts/test-infra: temporarily disable logcheck

### DIFF
--- a/scripts/test-infra/verify.sh
+++ b/scripts/test-infra/verify.sh
@@ -17,7 +17,8 @@ curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring 
 curl -Os https://uploader.codecov.io/latest/linux/codecov
 chmod +x codecov
 
-go install sigs.k8s.io/logtools/logcheck@v0.8.1
+# TODO: re-enable logcheck when https://github.com/kubernetes-sigs/logtools/pull/31 is merged
+#go install sigs.k8s.io/logtools/logcheck@v0.8.1
 
 # Run verify steps
 echo "Checking gofmt"
@@ -29,8 +30,9 @@ make ci-lint
 echo "Running Helm lint"
 make helm-lint
 
-echo "Running logcheck"
-logcheck -config "${this_dir}/logcheck.conf" ./cmd/... ./pkg/...  ./source/...
+# TODO: re-enable logcheck when https://github.com/kubernetes-sigs/logtools/pull/31 is merged
+#echo "Running logcheck"
+#logcheck -config "${this_dir}/logcheck.conf" ./cmd/... ./pkg/...  ./source/...
 
 echo "Running unit tests"
 make test


### PR DESCRIPTION
Logcheck does not build/install with golang v1.25.