### PR TITLE
Clean up cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,6 @@ steps:
     env:
     - IMAGE_REGISTRY=gcr.io/$PROJECT_ID
     - _GIT_TAG=$_GIT_TAG
-    - IMAGE_EXTRA_TAG_NAMES=$_PULL_BASE_REF
     - HOME=/root
 substitutions:
   _GIT_TAG: '0.0.0'

--- a/scripts/test-infra/push-image.sh
+++ b/scripts/test-infra/push-image.sh
@@ -3,14 +3,18 @@
 # Override VERSION if _GIT_TAG is specified. Strip 10 first characters
 # ('vYYYYMMDD-') from _GIT_TAG in order to get a reproducible version and
 # container image tag
-VERSION_OVERRIDE=${_GIT_TAG+VERSION=${_GIT_TAG:10}}
+if [ -z "$_GIT_TAG" ]; then
+    MAKE_VARS="IMAGE_EXTRA_TAG_NAMES=${_PULL_BASE_REF}"
+else
+    MAKE_VARS="VERSION=${_GIT_TAG:10}"
+fi
 
 # Authenticate in order to be able to push images
 gcloud auth configure-docker
 
 # Build and push images
-IMAGE_ALL_PLATFORMS=linux/amd64,linux/arm64 make push-all $VERSION_OVERRIDE
+IMAGE_ALL_PLATFORMS=linux/amd64,linux/arm64 make push-all $MAKE_VARS
 
 go install helm.sh/helm/v3/cmd/helm@v3.17.3
 
-make helm-push $VERSION_OVERRIDE
+make helm-push $VERSION_OVERRIDE $MAKE_VARS


### PR DESCRIPTION
Don't specify the IMAGE_EXTRA_TAG_NAMES when we're building release (git tag) images.