### PR TITLE
helm: publish rolling staging version of OCI chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ JEKYLL_OPTS := -d '$(SITE_DESTDIR)' $(if $(SITE_BASEURL),-b '$(SITE_BASEURL)',)
 VERSION := $(shell git describe --tags --dirty --always --match "v*")
 
 CHART_VERSION ?= $(shell echo $(VERSION) | cut -c2-)
+CHART_EXTRA_VERSIONS ?=
 
 IMAGE_REGISTRY ?= registry.k8s.io/nfd
 IMAGE_TAG_NAME ?= $(VERSION)
@@ -182,8 +183,10 @@ helm-lint:
 	helm lint --strict deployment/helm/node-feature-discovery/
 
 helm-push:
-	helm package deployment/helm/node-feature-discovery --version $(CHART_VERSION) --app-version $(IMAGE_TAG_NAME)
-	helm push node-feature-discovery-$(CHART_VERSION).tgz oci://${IMAGE_REGISTRY}/charts
+	for v in $(CHART_VERSION) $(CHART_EXTRA_VERSIONS); do \
+	    helm package deployment/helm/node-feature-discovery --version $$v --app-version $(IMAGE_TAG_NAME); \
+	    helm push node-feature-discovery-$$v.tgz oci://${IMAGE_REGISTRY}/charts; \
+	done
 	# Push artifacthub.io metadata
 	# Ref: https://artifacthub.io/docs/topics/repositories/helm-charts/#oci-support
 	oras push \

--- a/scripts/test-infra/push-image.sh
+++ b/scripts/test-infra/push-image.sh
@@ -4,7 +4,7 @@
 # ('vYYYYMMDD-') from _GIT_TAG in order to get a reproducible version and
 # container image tag
 if [ -z "$_GIT_TAG" ]; then
-    MAKE_VARS="IMAGE_EXTRA_TAG_NAMES=${_PULL_BASE_REF}"
+    MAKE_VARS="IMAGE_EXTRA_TAG_NAMES=${_PULL_BASE_REF} CHART_EXTRA_VERSIONS=0.0.0-${_PULL_BASE_REF}"
 else
     MAKE_VARS="VERSION=${_GIT_TAG:10}"
 fi


### PR DESCRIPTION
For non-release builds, publish Helm chart with version `0.0.0-<branch-name>` in the OCI repo.