### PR TITLE
cloudbuild: fix build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 timeout: 3000s
 steps:
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079
     entrypoint: scripts/test-infra/push-image.sh
     env:
     - IMAGE_REGISTRY=gcr.io/$PROJECT_ID

--- a/scripts/test-infra/push-image.sh
+++ b/scripts/test-infra/push-image.sh
@@ -16,6 +16,6 @@ gcloud auth configure-docker
 IMAGE_ALL_PLATFORMS=linux/amd64,linux/arm64 make push-all $MAKE_VARS
 
 go install helm.sh/helm/v3/cmd/helm@v3.17.3
-go install oras.land/oras/cmd/oras@v1.3.0
+go install oras.land/oras/cmd/oras@v1.2.3
 
 make helm-push $VERSION_OVERRIDE $MAKE_VARS


### PR DESCRIPTION
Bump cloudbuild image to the latest version and match oras version with the golang version within.