### PR TITLE
Move the default values for images to Dockerfile to fix InvalidDefaultArgInFrom warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_IMAGE_FULL
 ARG BASE_IMAGE_MINIMAL
 
 # Build node feature discovery
-FROM ${BUILDER_IMAGE} AS builder
+FROM ${BUILDER_IMAGE:-golang} AS builder
 
 # Get (cache) deps in a separate layer
 COPY go.mod go.sum /go/node-feature-discovery/
@@ -23,7 +23,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
     make install VERSION=$VERSION HOSTMOUNT_PREFIX=$HOSTMOUNT_PREFIX
 
 # Create full variant of the production image
-FROM ${BASE_IMAGE_FULL} AS full
+FROM ${BASE_IMAGE_FULL:-debian:stable-slim} AS full
 
 # Run as unprivileged user
 USER 65534:65534
@@ -35,7 +35,7 @@ COPY deployment/components/worker-config/nfd-worker.conf.example /etc/kubernetes
 COPY --from=builder /go/bin/* /usr/bin/
 
 # Create minimal variant of the production image
-FROM ${BASE_IMAGE_MINIMAL} AS minimal
+FROM ${BASE_IMAGE_MINIMAL:-scratch} AS minimal
 
 # Run as unprivileged user
 USER 65534:65534


### PR DESCRIPTION
Add the default values for images in Dockerfile to fix build checks warnings which might come from an empty variable.

```
 => WARN: InvalidDefaultArgInFrom: Default value for ARG ${BUILDER_IMAGE} results in empty or inval  0.0s
 => WARN: InvalidDefaultArgInFrom: Default value for ARG ${BASE_IMAGE_FULL} results in empty or inv  0.0s
 => WARN: InvalidDefaultArgInFrom: Default value for ARG ${BASE_IMAGE_MINIMAL} results in empty or   0.0s
```