### PR TITLE
scripts/test-infra/push-image: fix env variable parsing

### DIFF
--- a/scripts/test-infra/push-image.sh
+++ b/scripts/test-infra/push-image.sh
@@ -3,10 +3,11 @@
 # Override VERSION if _GIT_TAG is specified. Strip 10 first characters
 # ('vYYYYMMDD-') from _GIT_TAG in order to get a reproducible version and
 # container image tag
-if [ -z "$_GIT_TAG" ]; then
-    MAKE_VARS="IMAGE_EXTRA_TAG_NAMES=${_PULL_BASE_REF} CHART_EXTRA_VERSIONS=0.0.0-${_PULL_BASE_REF}"
-else
+if [ -n "$_GIT_TAG" ]; then
     MAKE_VARS="VERSION=${_GIT_TAG:10}"
+fi
+if ! [[ $_PULL_BASE_REF =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    MAKE_VARS="$MAKE_VARS IMAGE_EXTRA_TAG_NAMES=${_PULL_BASE_REF} CHART_EXTRA_VERSIONS=0.0.0-${_PULL_BASE_REF}"
 fi
 
 # Authenticate in order to be able to push images


### PR DESCRIPTION
The _GIT_TAG variable is always specified (set by the prow job). We can determine whether we're building a tag or branch from the _PULL_BASE_REF.