### PR TITLE
cloudbuild: export _PULL_BASE_REF as an env variable

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,6 +5,7 @@ steps:
     env:
     - IMAGE_REGISTRY=gcr.io/$PROJECT_ID
     - _GIT_TAG=$_GIT_TAG
+    - _PULL_BASE_REF=$_PULL_BASE_REF
     - HOME=/root
 substitutions:
   _GIT_TAG: '0.0.0'


### PR DESCRIPTION
Needed by the latest version of push-image.sh script.