### PR TITLE
netlify: fix too aggressive redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
     PAGES_DISABLE_NETWORK = "1"
 
 [[redirects]]
-    from = "/*"
+    from = "https://nfd.sigs.k8s.io/*"
     to = "https://release-0-17--kubernetes-sigs-nfd.netlify.app/:splat"
     status = 301
     force = true


### PR DESCRIPTION
The netlify redirect is now redirects everything (PR previews, branch deploys etc) to the latest stable release. Try to fix that with a redirect rule that only redirect the production site (nfd.sigs.k8s.io).

Reading netlify docs this should work:
https://docs.netlify.com/manage/routing/redirects/redirect-options/#domain-level-redirects