### PR TITLE
helm: fixes

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/master-pdb.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master-pdb.yaml
@@ -12,6 +12,6 @@ spec:
     matchLabels:
       {{- include "node-feature-discovery.selectorLabels" . | nindent 6 }}
       role: master
-{{- toYaml (omit .Values.master.podDisruptionBudget "enable") | indent 2 }}
+{{- toYaml (omit .Values.master.podDisruptionBudget "enable") | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/deployment/helm/node-feature-discovery/templates/master.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master.yaml
@@ -125,9 +125,6 @@ spec:
             {{- if .Values.master.enableTaints }}
             - "-enable-taints"
             {{- end }}
-            {{- if .Values.master.featureRulesController | kindIs "invalid" | not }}
-            - "-featurerules-controller={{ .Values.master.featureRulesController }}"
-            {{- end }}
             {{- if .Values.master.resyncPeriod }}
             - "-resync-period={{ .Values.master.resyncPeriod }}"
             {{- end }}

--- a/deployment/helm/node-feature-discovery/templates/master.yaml
+++ b/deployment/helm/node-feature-discovery/templates/master.yaml
@@ -105,7 +105,7 @@ spec:
               fieldRef:
                 fieldPath: spec.nodeName
         {{- with .Values.master.extraEnvs }}
-          {{- toYaml . | nindent 8 }}
+          {{- toYaml . | nindent 10 }}
         {{- end}}
           command:
             - "nfd-master"

--- a/deployment/helm/node-feature-discovery/templates/nfd-gc-pdb.yaml
+++ b/deployment/helm/node-feature-discovery/templates/nfd-gc-pdb.yaml
@@ -12,6 +12,6 @@ spec:
     matchLabels:
       {{- include "node-feature-discovery.selectorLabels" . | nindent 6 }}
       role: gc
-{{- toYaml (omit .Values.gc.podDisruptionBudget "enable") | indent 2 }}
+{{- toYaml (omit .Values.gc.podDisruptionBudget "enable") | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -593,7 +593,7 @@ gc:
   podDisruptionBudget:
     enable: false
     minAvailable: 1
-    unhealthyPodEvictionPolicy: Always
+    unhealthyPodEvictionPolicy: AlwaysAllow
 
   # specify how many old ReplicaSets for the Deployment to retain.
   revisionHistoryLimit:

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -71,7 +71,6 @@ master:
   ### <NFD-MASTER-CONF-END-DO-NOT-REMOVE>
   port: 8080
   instance:
-  featureApi:
   resyncPeriod:
   denyLabelNs: []
   extraLabelNs: []

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -75,7 +75,6 @@ master:
   denyLabelNs: []
   extraLabelNs: []
   enableTaints: false
-  featureRulesController: null
   nfdApiParallelism: null
   deploymentAnnotations: {}
   replicaCount: 1


### PR DESCRIPTION
A bunch of fixes to the Helm chart:

1. Drop unused master.featureApi from values.yaml
2. Drop featureRulesController parameter
    The nfd-master does not have such commandline flag as `-featurerules-controller` anymore.
3. Fix master.extraEnvs
4. Fix PodDisruptionBudget