### PR TITLE
scripts/test-infra/push-image: more robust parsing of version

### DIFF
--- a/scripts/test-infra/push-image.sh
+++ b/scripts/test-infra/push-image.sh
@@ -3,11 +3,10 @@
 # Override VERSION if _GIT_TAG is specified. Strip 10 first characters
 # ('vYYYYMMDD-') from _GIT_TAG in order to get a reproducible version and
 # container image tag
-if [ -n "$_GIT_TAG" ]; then
-    MAKE_VARS="VERSION=${_GIT_TAG:10}"
-fi
-if ! [[ $_PULL_BASE_REF =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    MAKE_VARS="$MAKE_VARS IMAGE_EXTRA_TAG_NAMES=${_PULL_BASE_REF} CHART_EXTRA_VERSIONS=0.0.0-${_PULL_BASE_REF}"
+if [[ $_PULL_BASE_REF =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    MAKE_VARS="VERSION=${_PULL_BASE_REF}"
+else
+    MAKE_VARS="VERSION=${_GIT_TAG:10} IMAGE_EXTRA_TAG_NAMES=${_PULL_BASE_REF} CHART_EXTRA_VERSIONS=0.0.0-${_PULL_BASE_REF}"
 fi
 
 # Authenticate in order to be able to push images


### PR DESCRIPTION
If the _PULL_BASE_REF matches a release tag use that as the VERSION. This fixes a problem in cases we push multiple tags at the same time like:

    git push origin v0.X.Y api/nfd/v0.X.Y

and the _GIT_TAG might be derived from the api/nfd/... tag.