### PR TITLE
fix(deploy,helm,overlays): use correct port for PodMonitor

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/prometheus.yaml
+++ b/deployment/helm/node-feature-discovery/templates/prometheus.yaml
@@ -14,7 +14,7 @@ spec:
     - honorLabels: true
       interval: {{ .Values.prometheus.scrapeInterval }}
       path: /metrics
-      port: metrics
+      port: http
       scheme: http
   namespaceSelector:
     matchNames:

--- a/deployment/overlays/prometheus/monitor.yaml
+++ b/deployment/overlays/prometheus/monitor.yaml
@@ -10,7 +10,7 @@ spec:
     - honorLabels: true
       interval: 10s
       path: /metrics
-      port: metrics
+      port: http
       scheme: http
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
In https://github.com/kubernetes-sigs/node-feature-discovery/commit/7fccf2325b479839c2f859d68b99d9f7c45bfb0e the metrics endpoint was merged/renamed to `http`. Unfortunately not for the `PodMonitor`. This PR fixes this.