### PR TITLE
helm: Drop obsolete lableSelector for node-role.kubernetes.io/master

### DIFF
--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -120,10 +120,6 @@ master:
   nodeSelector: {}
 
   tolerations:
-  - key: "node-role.kubernetes.io/master"
-    operator: "Equal"
-    value: ""
-    effect: "NoSchedule"
   - key: "node-role.kubernetes.io/control-plane"
     operator: "Equal"
     value: ""
@@ -134,12 +130,6 @@ master:
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 1
-          preference:
-            matchExpressions:
-              - key: "node-role.kubernetes.io/master"
-                operator: In
-                values: [""]
         - weight: 1
           preference:
             matchExpressions:


### PR DESCRIPTION
Closes: #2258