### PR TITLE
Set memory soft limit for the worker & master via downwardAPI

### DIFF
--- a/deployment/base/master/master-deployment.yaml
+++ b/deployment/base/master/master-deployment.yaml
@@ -21,6 +21,11 @@ spec:
         - name: nfd-master
           image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
           imagePullPolicy: Always
+          env:
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
           resources:
             limits:
               cpu: 300m

--- a/deployment/base/worker-daemonset/worker-daemonset.yaml
+++ b/deployment/base/worker-daemonset/worker-daemonset.yaml
@@ -19,6 +19,11 @@ spec:
         - name: nfd-worker
           image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
           imagePullPolicy: Always
+          env:
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
By default, Go’s garbage collector isn’t aware of memory limits, which can cause either quite aggressive GC or OOM crashes. This causes common issues, where an app is set to require 1GB of memory but it is running into OOM on a node with 2 GB of memory. To control those sort of issues, GO has introduced `GOMEMLIMIT` which allows setting a soft memory cap that adjusts GC aggressiveness based on available memory. When there is plenty of memory available, GC runs infrequently while it becomes more aggressive when memory becomes scarce. A best practice and according to the GO's documentation, one should leave some room  (roughly 5-10%  free memory for the processes that GO runtime isn't aware of).  This means that, we have to set `GOMEMLIMIT` to be 5-10% smaller than the `.spec.containers[0].resources.limits.memory`. Since K8s doesn't support percentage based resource setting, we can do it statically, but finding 10% of 300m (master) and setting it based on that. But the problem with this approach is that, it is static and whenever we change the limits or someone else, the change won't be reflected in `GOMEMLIMIT`. The workaround for this is to set the limit at least  10% more than the request and luckily in our case in NFD, we are using Burstable QoS. In other words, we are safe to stick to the limit value that can be fetched via downwardAPI and passed down to the master & worker as env variable. 

