### PR TITLE
fix: allow helm chart to use object type in worker and master config

### DIFF
--- a/deployment/helm/node-feature-discovery/values.schema.json
+++ b/deployment/helm/node-feature-discovery/values.schema.json
@@ -273,7 +273,10 @@
                 },
                 "config": {
                     "description": "NFD master [configuration](https://kubernetes-sigs.github.io/node-feature-discovery/master/reference/master-configuration-reference).",
-                    "type": "null"
+                    "type": [
+                        "object",
+                        "null"
+                    ]
                 },
                 "denyLabelNs": {
                     "description": "Label namespaces to deny. Labels with these prefixes will not be published to the nodes.",
@@ -596,7 +599,10 @@
                 },
                 "config": {
                     "description": "Configuration for the topology updater. See the [configuration reference](https://kubernetes-sigs.github.io/node-feature-discovery/master/reference/topology-updater-configuration-reference) for details.",
-                    "type": "null"
+                    "type": [
+                        "object",
+                        "null"
+                    ]
                 },
                 "createCRDs": {
                     "description": "Create CustomResourceDefinitions for the TopologyUpdater.",
@@ -825,7 +831,10 @@
                 },
                 "config": {
                     "description": "NFD worker [configuration](https://kubernetes-sigs.github.io/node-feature-discovery/master/reference/worker-configuration-reference).",
-                    "type": "null"
+                    "type": [
+                        "object",
+                        "null"
+                    ]
                 },
                 "daemonsetAnnotations": {
                     "description": "[Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations) to add to the nfd-worker DaemonSet.",

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -69,6 +69,7 @@ master:
   # -- NFD master pod [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
   # @section -- NFD-Master
   dnsPolicy: ClusterFirstWithHostNet
+  # @schema type: [object, null]
   # -- NFD master [configuration](https://kubernetes-sigs.github.io/node-feature-discovery/master/reference/master-configuration-reference).
   # @section -- NFD-Master
   config: ### <NFD-MASTER-CONF-START-DO-NOT-REMOVE>
@@ -341,6 +342,7 @@ worker:
   # -- NFD worker pod [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-policy).
   # @section -- NFD-Worker
   dnsPolicy: ClusterFirstWithHostNet
+  # @schema type: [object, null]
   # -- NFD worker [configuration](https://kubernetes-sigs.github.io/node-feature-discovery/master/reference/worker-configuration-reference).
   # @section -- NFD-Worker
   config: ### <NFD-WORKER-CONF-START-DO-NOT-REMOVE>
@@ -725,6 +727,7 @@ worker:
 # NFD-Topology-Updater configuration
 #
 topologyUpdater:
+  # @schema type: [object, null]
   # -- Configuration for the topology updater. See the [configuration reference](https://kubernetes-sigs.github.io/node-feature-discovery/master/reference/topology-updater-configuration-reference) for details.
   # @section -- NFD-Topology-Updater
   config: ### <NFD-TOPOLOGY-UPDATER-CONF-START-DO-NOT-REMOVE>


### PR DESCRIPTION
Having only "null" as type breaks deployment of the chart if config is not empty