### PR TITLE
client: add examples, short flags and better error handling

### DIFF
--- a/cmd/nfd/subcmd/compat/validate-node.go
+++ b/cmd/nfd/subcmd/compat/validate-node.go
@@ -49,11 +49,16 @@ var (
 	username        string
 	password        string
 	accessToken     string
+
+	validateExample = `
+# Validate image compatibility
+nfd compat validate-node --image <image-url>`
 )
 
 var validateNodeCmd = &cobra.Command{
-	Use:   "validate-node",
-	Short: "Perform node validation based on its associated image compatibility artifact",
+	Use:     "validate-node",
+	Short:   "Perform node validation based on its associated image compatibility artifact",
+	Example: validateExample,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 

--- a/cmd/nfd/subcmd/export/features.go
+++ b/cmd/nfd/subcmd/export/features.go
@@ -25,10 +25,20 @@ import (
 	"sigs.k8s.io/node-feature-discovery/source"
 )
 
+var (
+	exportFeaturesExample = `
+# Export node features to stdout (prints to terminal)
+nfd export features
+
+# Export node features to a file instead
+nfd export features --path /tmp/features.json`
+)
+
 func NewExportCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "features",
-		Short: "Export features for given node",
+		Use:     "features",
+		Short:   "Export features for given node",
+		Example: exportFeaturesExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			sources := map[string]source.FeatureSource{}
 			for k, v := range source.GetAllFeatureSources() {
@@ -59,7 +69,7 @@ func NewExportCmd() *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().StringVar(&outputPath, "path", "", "export to this JSON path")
+	cmd.Flags().StringVarP(&outputPath, "path", "p", "", "export to this JSON path")
 	return cmd
 }
 

--- a/cmd/nfd/subcmd/export/labels.go
+++ b/cmd/nfd/subcmd/export/labels.go
@@ -31,10 +31,20 @@ import (
 	"sigs.k8s.io/node-feature-discovery/source"
 )
 
+var (
+	exportLabelsExample = `
+# Export node labels to stdout (prints to terminal)
+nfd export features
+
+# Export node labels to a file instead
+nfd export features --path /tmp/labels.json`
+)
+
 func NewLabelsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "labels",
-		Short: "Export feature labels for given node",
+		Use:     "labels",
+		Short:   "Export feature labels for given node",
+		Example: exportLabelsExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// Determine enabled feature sources
@@ -93,7 +103,7 @@ func NewLabelsCmd() *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().StringVar(&outputPath, "path", "", "export to this JSON path")
+	cmd.Flags().StringVarP(&outputPath, "path", "p", "", "export to this JSON path")
 	return cmd
 }
 

--- a/cmd/nfd/subcmd/root.go
+++ b/cmd/nfd/subcmd/root.go
@@ -35,6 +35,7 @@ var RootCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(compat.CompatCmd)
 	RootCmd.AddCommand(export.ExportCmd)
+	RootCmd.SilenceUsage = true
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.


### PR DESCRIPTION
Improve user experience.
- add usage examples to export and compat commands
- add `-p` short flag for `--path` option
- silence usage output on runtime errors for cleaner error messages

Examples 
1. Usage silencing (before)
    ```
    $ ./bin/nfd export features --pathd
    Error: unknown flag: --pathd
    Usage:
      nfd export features [flags]

    Flags:
      -h, --help          help for features
          --path string   export to this JSON path

    unknown flag: --pathd
    ```
    after
    ```
    $ ./bin/nfd export features --pathd
    Error: unknown flag: --pathd
    unknown flag: --pathd
    ```

    before
    ```
    $  ./bin/nfd  compat validate-node --output-jsond true
    Error: unknown flag: --output-jsond
    Usage:
      nfd compat validate-node [flags]

    Flags:
      -h, --help                       help for validate-node
          --image string               the URL of the image containing compatibility metadata
          --output-json                print a JSON object
          --plain-http                 use of HTTP protocol for all registry communications
          --platform string            the artifact platform in the format os[/arch][/variant][:os_version]
          --registry-password-stdin    read registry password from stdin
          --registry-token-stdin       read registry access token from stdin
          --registry-username string   registry username
          --tags strings               a list of tags that must match the tags set on the compatibility objects

    unknown flag: --output-jsond
    ```
    after

    ```
    $ ./bin/nfd  compat validate-node --output-jsond true
    Error: unknown flag: --output-jsond
    unknown flag: --output-jsond
    ```
2. Helper examples:
    ```
    $ ./bin/nfd export features -h
    Export features for given node

    Usage:
      nfd export features [flags]

    Examples:

    # Export node features to stdout (prints to terminal)
    nfd export features

    # Export node features to a file instead
    nfd export features --path /tmp/features.json

    Flags:
      -h, --help          help for features
      -p, --path string   export to this JSON path
    ```