### PR TITLE
images: Publish s390x and ppc64le images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ BUILD_FLAGS = -tags osusergo,netgo \
               -ldflags "-s -w -extldflags=-static -X sigs.k8s.io/node-feature-discovery/pkg/version.version=$(VERSION) -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=$(HOSTMOUNT_PREFIX)"
 
 # multi-arch build with buildx
-IMAGE_ALL_PLATFORMS ?= linux/amd64,linux/arm64,linux/arm/v7
+IMAGE_ALL_PLATFORMS ?= linux/amd64,linux/arm64,linux/arm/v7,linux/s390x,linux/ppc64le
 
 # enable buildx
 ensure-buildx:

--- a/scripts/test-infra/build-image-cross.sh
+++ b/scripts/test-infra/build-image-cross.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
 # cross build
-IMAGE_ALL_PLATFORMS=linux/amd64,linux/arm64 make image-all
+IMAGE_ALL_PLATFORMS=linux/amd64,linux/arm64,linux/s390x,linux/ppc64le make image-all

--- a/scripts/test-infra/push-image.sh
+++ b/scripts/test-infra/push-image.sh
@@ -13,7 +13,7 @@ fi
 gcloud auth configure-docker
 
 # Build and push images
-IMAGE_ALL_PLATFORMS=linux/amd64,linux/arm64 make push-all $MAKE_VARS
+IMAGE_ALL_PLATFORMS=linux/amd64,linux/arm64,linux/s390x,linux/ppc64le make push-all $MAKE_VARS
 
 go install helm.sh/helm/v3/cmd/helm@v3.17.3
 go install oras.land/oras/cmd/oras@v1.2.3


### PR DESCRIPTION
Kata Containers has added NFD as a dependency, and we have folks from those two architectures willing to get NFD working as expected for their virt / TEE capabilities.

However, we cannot run tests with s390x / ppc64le right now as the images are not published by NFD (thus, not helping us to fully add NFD as a requirement).