### PR TITLE
Increase image building timeout

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 3000s
+timeout: 5000s
 steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079
     entrypoint: scripts/test-infra/push-image.sh

--- a/scripts/test-infra/test-e2e.sh
+++ b/scripts/test-infra/test-e2e.sh
@@ -27,7 +27,7 @@ i=1
 while true; do
     if make poll-images; then
         break
-    elif [ $i -ge 55 ]; then
+    elif [ $i -ge 90 ]; then
         echo "ERROR: too many tries when polling for image"
         exit 1
     fi


### PR DESCRIPTION
Enabling new archs (ppc64le and s390x) increased the image build time considerably.