### PR TITLE
source/kernel: Add kvm availability

### DIFF
--- a/deployment/base/nfd-crds/cr-sample.yaml
+++ b/deployment/base/nfd-crds/cr-sample.yaml
@@ -47,6 +47,9 @@ spec:
         - feature: kernel.selinux
           matchExpressions:
             enabled: {op: IsFalse}
+        - feature: kernel.kvm
+          matchExpressions:
+            enabled: {op: IsFalse}
         - feature: kernel.version
           matchExpressions:
             major: {op: In, value: ["5"]}

--- a/deployment/components/worker-config/nfd-worker.conf.example
+++ b/deployment/components/worker-config/nfd-worker.conf.example
@@ -116,6 +116,9 @@
 #        - feature: kernel.selinux
 #          matchExpressions:
 #            enabled: {op: IsFalse}
+#        - feature: kernel.kvm
+#          matchExpressions:
+#            enabled: {op: IsFalse}
 #        - feature: kernel.version
 #          matchExpressions:
 #            major: {op: In, value: ["5"]}

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -468,6 +468,9 @@ worker:
     #        - feature: kernel.selinux
     #          matchExpressions:
     #            enabled: {op: IsFalse}
+    #        - feature: kernel.kvm
+    #          matchExpressions:
+    #            enabled: {op: IsFalse}
     #        - feature: kernel.version
     #          matchExpressions:
     #            major: {op: In, value: ["5"]}

--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -962,6 +962,8 @@ The following features are available for matching:
 |                  |              | **`mod-name`** |      | Kernel module `<mod-name>` is loaded |
 | **`kernel.selinux`** | attribute |         |            | Kernel SELinux related features |
 |                  |              | **`enabled`** | bool  | `true` if SELinux has been enabled and is in enforcing mode, otherwise `false` |
+| **`kernel.kvm`** | attribute |         |            | Kernel KVM related features |
+|                  |              | **`enabled`** | bool  | `true` if KVM has been enabled, otherwise `false` |
 | **`kernel.version`** | attribute |          |           | Kernel version information |
 |                  |              | **`full`** | string   | Full kernel version (e.g. ‘4.5.6-7-g123abcde') |
 |                  |              | **`major`** | int     | First component of the kernel version (e.g. ‘4') |

--- a/source/kernel/kernel.go
+++ b/source/kernel/kernel.go
@@ -36,6 +36,7 @@ const (
 	SelinuxFeature       = "selinux"
 	VersionFeature       = "version"
 	EnabledModuleFeature = "enabledmodule"
+	KvmFeature           = "kvm"
 )
 
 // Configuration file options
@@ -157,6 +158,13 @@ func (s *kernelSource) Discover() error {
 	} else {
 		s.features.Attributes[SelinuxFeature] = nfdv1alpha1.NewAttributeFeatures(nil)
 		s.features.Attributes[SelinuxFeature].Elements["enabled"] = strconv.FormatBool(selinux)
+	}
+
+	if kvm, err := KvmEnabled(); err != nil {
+		klog.ErrorS(err, "failed to detect kvm status")
+	} else {
+		s.features.Attributes[KvmFeature] = nfdv1alpha1.NewAttributeFeatures(nil)
+		s.features.Attributes[KvmFeature].Elements["enabled"] = strconv.FormatBool(kvm)
 	}
 
 	klog.V(3).InfoS("discovered features", "featureSource", s.Name(), "features", utils.DelayedDumper(s.features))

--- a/source/kernel/kvm.go
+++ b/source/kernel/kvm.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2017-2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kernel
+
+import (
+	"os"
+
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath"
+)
+
+// KvmEnabled detects if kvm has been enabled in the kernel
+func KvmEnabled() (bool, error) {
+	_, err := os.Stat(hostpath.SysfsDir.Path("devices/virtual/misc/kvm"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			klog.V(1).InfoS("kvm not available on the system")
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/test/e2e/e2e-test-config.example.yaml
+++ b/test/e2e/e2e-test-config.example.yaml
@@ -52,6 +52,7 @@ defaultFeatures:
     - "feature.node.kubernetes.io/kernel-config.NO_HZ_IDLE"
     - "feature.node.kubernetes.io/kernel-config.PREEMPT"
     - "feature.node.kubernetes.io/kernel-selinux.enabled"
+    - "feature.node.kubernetes.io/kernel-kvm.enabled"
     - "feature.node.kubernetes.io/kernel-version.full"
     - "feature.node.kubernetes.io/kernel-version.major"
     - "feature.node.kubernetes.io/kernel-version.minor"


### PR DESCRIPTION
Add support for testing if a node can use virtualization for use by kata-containers (see https://katacontainers.slack.com/archives/C879ACQ00/p1761731112286659). On AMD and Intel platforms this can be determined with CPU feature flags, but on arm64 the situation is more complex. There 2 two flags - `ID_AA64PFR0_EL1.EL2` ([doc](https://developer.arm.com/documentation/ddi0601/2025-09/AArch64-Registers/ID-AA64PFR0-EL1--AArch64-Processor-Feature-Register-0)) and `ID_AA64MMFR1_EL1.VH` ([doc](https://developer.arm.com/documentation/ddi0601/2025-09/AArch64-Registers/ID-AA64MMFR1-EL1--AArch64-Memory-Model-Feature-Register-1))

* `ID_AA64PFR0_EL1.EL2` & 0b0001 != 0 (kernel runs at EL1, hyp world at EL2 - nVHE)
* `ID_AA64MMFR1_EL1.VH` & 0b0001 != 0 (kernel is at EL2 using VHE), not visible from user space

Instead, check if `kvm` is initialized and has created `/sys/devices/virtual/misc/kvm`.