### PR TITLE
helm: bundle schema refs to support air-gapped environments

### DIFF
--- a/deployment/helm/node-feature-discovery/.schema.yaml
+++ b/deployment/helm/node-feature-discovery/.schema.yaml
@@ -4,3 +4,7 @@ values:
 output: values.schema.json
 k8sSchemaVersion: "v1.34.1"
 useHelmDocs: true
+# Bundle external $ref schemas into $defs to support air-gapped environments
+# See: https://github.com/kubernetes-sigs/node-feature-discovery/issues/2398
+bundle: true
+bundleWithoutID: true

--- a/deployment/helm/node-feature-discovery/values.schema.json
+++ b/deployment/helm/node-feature-discovery/values.schema.json
@@ -20,17 +20,17 @@
             "properties": {
                 "affinity": {
                     "description": "[Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the nfd-gc pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Affinity",
                     "type": "object"
                 },
                 "annotations": {
                     "description": "[Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations) to add to the nfd-gc pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
                     "type": "object"
                 },
                 "deploymentAnnotations": {
                     "description": "[Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations) to add to the nfd-gc  Deployment.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
                     "type": "object"
                 },
                 "dnsPolicy": {
@@ -43,12 +43,12 @@
                 },
                 "extraArgs": {
                     "description": "Additional [command line arguments](https://kubernetes-sigs.github.io/node-feature-discovery/master/reference/gc-commandline-reference) to pass to nfd-gc.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.Container/properties/args",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Container/properties/args",
                     "type": "array"
                 },
                 "extraEnvs": {
                     "description": "Additional environment variables to set in the nfd-gc container.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.Container/properties/env",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Container/properties/env",
                     "type": "array"
                 },
                 "hostNetwork": {
@@ -61,7 +61,7 @@
                 },
                 "labels": {
                     "description": "[Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) to add to the nfd-gc pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels",
                     "type": "object"
                 },
                 "livenessProbe": {
@@ -103,11 +103,11 @@
                 },
                 "nodeSelector": {
                     "description": "[Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the nfd-gc pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeSelector",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeSelector",
                     "type": "object"
                 },
                 "podDisruptionBudget": {
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.policy.v1.PodDisruptionBudgetSpec",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.policy.v1.PodDisruptionBudgetSpec",
                     "type": "object",
                     "properties": {
                         "enable": {
@@ -118,7 +118,7 @@
                 },
                 "podSecurityContext": {
                     "description": "[Pod SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) of the nfd-gc pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodSecurityContext",
                     "type": "object"
                 },
                 "port": {
@@ -200,7 +200,7 @@
                     "properties": {
                         "annotations": {
                             "description": "[Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations) to add to the service account.",
-                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
                             "type": "object"
                         },
                         "create": {
@@ -218,7 +218,7 @@
                 },
                 "tolerations": {
                     "description": "[Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the nfd-gc pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations",
                     "type": "array"
                 }
             }
@@ -228,7 +228,7 @@
             "properties": {
                 "imagePullSecrets": {
                     "description": "If `imagePullSecrets` is specified, it takes precedence over `global.imagePullSecrets`. [More info](https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod).",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/imagePullSecrets",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodSpec/properties/imagePullSecrets",
                     "type": "array"
                 }
             }
@@ -260,7 +260,7 @@
         },
         "imagePullSecrets": {
             "description": "Image pull secrets. [More info](https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod).",
-            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/imagePullSecrets",
+            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodSpec/properties/imagePullSecrets",
             "type": "array"
         },
         "master": {
@@ -268,12 +268,12 @@
             "properties": {
                 "affinity": {
                     "description": "[Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the nfd-master pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Affinity",
                     "type": "object"
                 },
                 "annotations": {
                     "description": "[Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations) to add to the nfd-master pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
                     "type": "object"
                 },
                 "config": {
@@ -292,7 +292,7 @@
                 },
                 "deploymentAnnotations": {
                     "description": "[Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations) to add to the nfd-master Deployment.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
                     "type": "object"
                 },
                 "dnsPolicy": {
@@ -309,12 +309,12 @@
                 },
                 "extraArgs": {
                     "description": "Additional [command line arguments](https://kubernetes-sigs.github.io/node-feature-discovery/master/reference/master-commandline-reference) to pass to nfd-master.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.Container/properties/args",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Container/properties/args",
                     "type": "array"
                 },
                 "extraEnvs": {
                     "description": "Additional environment variables to set in the nfd-master container.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.Container/properties/env",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Container/properties/env",
                     "type": "array"
                 },
                 "extraLabelNs": {
@@ -337,7 +337,7 @@
                 },
                 "labels": {
                     "description": "[Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) to add to the nfd-master pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels",
                     "type": "object"
                 },
                 "livenessProbe": {
@@ -388,11 +388,11 @@
                 },
                 "nodeSelector": {
                     "description": "[Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the nfd-master pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeSelector",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeSelector",
                     "type": "object"
                 },
                 "podDisruptionBudget": {
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.policy.v1.PodDisruptionBudgetSpec",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.policy.v1.PodDisruptionBudgetSpec",
                     "type": "object",
                     "properties": {
                         "enable": {
@@ -403,7 +403,7 @@
                 },
                 "podSecurityContext": {
                     "description": "[Pod SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) of the nfd-master pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodSecurityContext",
                     "type": "object"
                 },
                 "port": {
@@ -471,7 +471,7 @@
                     "type": "integer"
                 },
                 "resources": {
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ResourceRequirements",
                     "type": "object"
                 },
                 "resyncPeriod": {
@@ -490,7 +490,7 @@
                 },
                 "securityContext": {
                     "description": "[SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) of the nfd-master container.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SecurityContext",
                     "type": "object"
                 },
                 "serviceAccount": {
@@ -498,7 +498,7 @@
                     "properties": {
                         "annotations": {
                             "description": "[Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations) to add to the service account",
-                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
                             "type": "object"
                         },
                         "create": {
@@ -553,7 +553,7 @@
                 },
                 "tolerations": {
                     "description": "[Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the nfd-master pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations",
                     "type": "array",
                     "items": {
                         "type": "object"
@@ -599,12 +599,12 @@
             "properties": {
                 "affinity": {
                     "description": "[Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the nfd-topology-updater pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Affinity",
                     "type": "object"
                 },
                 "annotations": {
                     "description": "[Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations) to add to the nfd-topology-updater pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
                     "type": "object"
                 },
                 "config": {
@@ -620,7 +620,7 @@
                 },
                 "daemonsetAnnotations": {
                     "description": "[Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations) to add to the nfd-topology-updater DaemonSet.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
                     "type": "object"
                 },
                 "dnsPolicy": {
@@ -633,12 +633,12 @@
                 },
                 "extraArgs": {
                     "description": "Additional [command line arguments](https://kubernetes-sigs.github.io/node-feature-discovery/master/reference/topology-updater-commandline-reference) to pass to nfd-topology-updater.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.Container/properties/args",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Container/properties/args",
                     "type": "array"
                 },
                 "extraEnvs": {
                     "description": "Additional environment variables to set in the nfd-topology-updater container.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.Container/properties/env",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Container/properties/env",
                     "type": "array"
                 },
                 "hostNetwork": {
@@ -665,7 +665,7 @@
                 },
                 "labels": {
                     "description": "[Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) to add to the nfd-topology-updater pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels",
                     "type": "object"
                 },
                 "livenessProbe": {
@@ -707,12 +707,12 @@
                 },
                 "nodeSelector": {
                     "description": "[Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the nfd-topology-updater pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeSelector",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeSelector",
                     "type": "object"
                 },
                 "podSecurityContext": {
                     "description": "[Pod SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) of the nfd-topology-updater pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodSecurityContext",
                     "type": "object"
                 },
                 "podSetFingerprint": {
@@ -780,7 +780,7 @@
                     }
                 },
                 "resources": {
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ResourceRequirements",
                     "type": "object"
                 },
                 "revisionHistoryLimit": {
@@ -792,7 +792,7 @@
                 },
                 "securityContext": {
                     "description": "[SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) of the nfd-topology-updater container.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SecurityContext",
                     "type": "object"
                 },
                 "serviceAccount": {
@@ -800,7 +800,7 @@
                     "properties": {
                         "annotations": {
                             "description": "[Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations) to add to the service account.",
-                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
                             "type": "object"
                         },
                         "create": {
@@ -818,7 +818,7 @@
                 },
                 "tolerations": {
                     "description": "[Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the nfd-topology-updater pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations",
                     "type": "array"
                 },
                 "updateInterval": {
@@ -836,12 +836,12 @@
             "properties": {
                 "affinity": {
                     "description": "[Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the nfd-worker pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Affinity",
                     "type": "object"
                 },
                 "annotations": {
                     "description": "[Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations) to add to the nfd-worker pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
                     "type": "object"
                 },
                 "config": {
@@ -853,7 +853,7 @@
                 },
                 "daemonsetAnnotations": {
                     "description": "[Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations) to add to the nfd-worker DaemonSet.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
                     "type": "object"
                 },
                 "dnsPolicy": {
@@ -866,12 +866,12 @@
                 },
                 "extraArgs": {
                     "description": "Additional [command line arguments](https://kubernetes-sigs.github.io/node-feature-discovery/master/reference/worker-commandline-reference) to pass to nfd-worker.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.Container/properties/args",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Container/properties/args",
                     "type": "array"
                 },
                 "extraEnvs": {
                     "description": "Additional environment variables to set in the nfd-worker container.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.Container/properties/env",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Container/properties/env",
                     "type": "array"
                 },
                 "hostNetwork": {
@@ -880,7 +880,7 @@
                 },
                 "labels": {
                     "description": "[Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) to add to the nfd-worker pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels",
                     "type": "object"
                 },
                 "livenessProbe": {
@@ -926,12 +926,12 @@
                 },
                 "nodeSelector": {
                     "description": "[Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the nfd-worker pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeSelector",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeSelector",
                     "type": "object"
                 },
                 "podSecurityContext": {
                     "description": "[Pod SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) of the nfd-worker pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodSecurityContext",
                     "type": "object"
                 },
                 "port": {
@@ -1002,7 +1002,7 @@
                     }
                 },
                 "resources": {
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ResourceRequirements",
                     "type": "object"
                 },
                 "revisionHistoryLimit": {
@@ -1014,7 +1014,7 @@
                 },
                 "securityContext": {
                     "description": "[SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) of the nfd-worker container.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SecurityContext",
                     "type": "object"
                 },
                 "serviceAccount": {
@@ -1022,7 +1022,7 @@
                     "properties": {
                         "annotations": {
                             "description": "[Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations) to add to the service account",
-                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
                             "type": "object"
                         },
                         "create": {
@@ -1040,13 +1040,3306 @@
                 },
                 "tolerations": {
                     "description": "[Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the nfd-worker pods.",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations",
                     "type": "array"
                 },
                 "updateStrategy": {
                     "description": "Update strategy for the nfd-worker DaemonSet. [More info](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set)",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json#/definitions/io.k8s.api.apps.v1.DaemonSetUpdateStrategy",
+                    "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.apps.v1.DaemonSetUpdateStrategy",
                     "type": "object"
+                }
+            }
+        }
+    },
+    "$defs": {
+        "_definitions.json": {
+            "definitions": {
+                "io.k8s.api.apps.v1.DaemonSetUpdateStrategy": {
+                    "description": "DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.",
+                    "type": "object",
+                    "properties": {
+                        "rollingUpdate": {
+                            "description": "Rolling update config params. Present only if type = \"RollingUpdate\".",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.apps.v1.RollingUpdateDaemonSet"
+                        },
+                        "type": {
+                            "description": "Type of daemon set update. Can be \"RollingUpdate\" or \"OnDelete\". Default is RollingUpdate.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.apps.v1.RollingUpdateDaemonSet": {
+                    "description": "Spec to control the desired behavior of daemon set rolling update.",
+                    "type": "object",
+                    "properties": {
+                        "maxSurge": {
+                            "description": "The maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during during an update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up to a minimum of 1. Default value is 0. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their a new pod created before the old pod is marked as deleted. The update starts by launching new pods on 30% of nodes. Once an updated pod is available (Ready for at least minReadySeconds) the old DaemonSet pod on that node is marked deleted. If the old pod becomes unavailable for any reason (Ready transitions to false, is evicted, or is drained) an updated pod is immediately created on that node without considering surge limits. Allowing surge implies the possibility that the resources consumed by the daemonset on any given node can double if the readiness check fails, and so resource intensive daemonsets should take into account that they may cause evictions during disruption.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
+                        },
+                        "maxUnavailable": {
+                            "description": "The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0 if MaxSurge is 0 Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource": {
+                    "description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
+                    "type": "object",
+                    "required": [
+                        "volumeID"
+                    ],
+                    "properties": {
+                        "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                            "type": "string"
+                        },
+                        "partition": {
+                            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "readOnly": {
+                            "description": "readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                            "type": "boolean"
+                        },
+                        "volumeID": {
+                            "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.Affinity": {
+                    "description": "Affinity is a group of affinity scheduling rules.",
+                    "type": "object",
+                    "properties": {
+                        "nodeAffinity": {
+                            "description": "Describes node affinity scheduling rules for the pod.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.NodeAffinity"
+                        },
+                        "podAffinity": {
+                            "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodAffinity"
+                        },
+                        "podAntiAffinity": {
+                            "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodAntiAffinity"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.AppArmorProfile": {
+                    "description": "AppArmorProfile defines a pod or container's AppArmor settings.",
+                    "type": "object",
+                    "required": [
+                        "type"
+                    ],
+                    "properties": {
+                        "localhostProfile": {
+                            "description": "localhostProfile indicates a profile loaded on the node that should be used. The profile must be preconfigured on the node to work. Must match the loaded name of the profile. Must be set if and only if type is \"Localhost\".",
+                            "type": "string"
+                        },
+                        "type": {
+                            "description": "type indicates which kind of AppArmor profile will be applied. Valid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.AzureDiskVolumeSource": {
+                    "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                    "type": "object",
+                    "required": [
+                        "diskName",
+                        "diskURI"
+                    ],
+                    "properties": {
+                        "cachingMode": {
+                            "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                            "type": "string"
+                        },
+                        "diskName": {
+                            "description": "diskName is the Name of the data disk in the blob storage",
+                            "type": "string"
+                        },
+                        "diskURI": {
+                            "description": "diskURI is the URI of data disk in the blob storage",
+                            "type": "string"
+                        },
+                        "fsType": {
+                            "description": "fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                        },
+                        "kind": {
+                            "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                            "type": "string"
+                        },
+                        "readOnly": {
+                            "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.AzureFileVolumeSource": {
+                    "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                    "type": "object",
+                    "required": [
+                        "secretName",
+                        "shareName"
+                    ],
+                    "properties": {
+                        "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                        },
+                        "secretName": {
+                            "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                            "type": "string"
+                        },
+                        "shareName": {
+                            "description": "shareName is the azure share Name",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.CSIVolumeSource": {
+                    "description": "Represents a source location of a volume to mount, managed by an external CSI driver",
+                    "type": "object",
+                    "required": [
+                        "driver"
+                    ],
+                    "properties": {
+                        "driver": {
+                            "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                            "type": "string"
+                        },
+                        "fsType": {
+                            "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                            "type": "string"
+                        },
+                        "nodePublishSecretRef": {
+                            "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.LocalObjectReference"
+                        },
+                        "readOnly": {
+                            "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                            "type": "boolean"
+                        },
+                        "volumeAttributes": {
+                            "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.Capabilities": {
+                    "description": "Adds and removes POSIX capabilities from running containers.",
+                    "type": "object",
+                    "properties": {
+                        "add": {
+                            "description": "Added capabilities",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "drop": {
+                            "description": "Removed capabilities",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.CephFSVolumeSource": {
+                    "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
+                    "type": "object",
+                    "required": [
+                        "monitors"
+                    ],
+                    "properties": {
+                        "monitors": {
+                            "description": "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "path": {
+                            "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                            "type": "string"
+                        },
+                        "readOnly": {
+                            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "boolean"
+                        },
+                        "secretFile": {
+                            "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "string"
+                        },
+                        "secretRef": {
+                            "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.LocalObjectReference"
+                        },
+                        "user": {
+                            "description": "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.CinderVolumeSource": {
+                    "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
+                    "type": "object",
+                    "required": [
+                        "volumeID"
+                    ],
+                    "properties": {
+                        "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": "string"
+                        },
+                        "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": "boolean"
+                        },
+                        "secretRef": {
+                            "description": "secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.LocalObjectReference"
+                        },
+                        "volumeID": {
+                            "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.ClusterTrustBundleProjection": {
+                    "description": "ClusterTrustBundleProjection describes how to select a set of ClusterTrustBundle objects and project their contents into the pod filesystem.",
+                    "type": "object",
+                    "required": [
+                        "path"
+                    ],
+                    "properties": {
+                        "labelSelector": {
+                            "description": "Select all ClusterTrustBundles that match this label selector.  Only has effect if signerName is set.  Mutually-exclusive with name.  If unset, interpreted as \"match nothing\".  If set but empty, interpreted as \"match everything\".",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+                        },
+                        "name": {
+                            "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive with signerName and labelSelector.",
+                            "type": "string"
+                        },
+                        "optional": {
+                            "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s) aren't available.  If using name, then the named ClusterTrustBundle is allowed not to exist.  If using signerName, then the combination of signerName and labelSelector is allowed to match zero ClusterTrustBundles.",
+                            "type": "boolean"
+                        },
+                        "path": {
+                            "description": "Relative path from the volume root to write the bundle.",
+                            "type": "string"
+                        },
+                        "signerName": {
+                            "description": "Select all ClusterTrustBundles that match this signer name. Mutually-exclusive with name.  The contents of all selected ClusterTrustBundles will be unified and deduplicated.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.ConfigMapEnvSource": {
+                    "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                        },
+                        "optional": {
+                            "description": "Specify whether the ConfigMap must be defined",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.ConfigMapKeySelector": {
+                    "description": "Selects a key from a ConfigMap.",
+                    "type": "object",
+                    "required": [
+                        "key"
+                    ],
+                    "properties": {
+                        "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                        },
+                        "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.ConfigMapProjection": {
+                    "description": "Adapts a ConfigMap into a projected volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.",
+                    "type": "object",
+                    "properties": {
+                        "items": {
+                            "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.KeyToPath"
+                            }
+                        },
+                        "name": {
+                            "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                        },
+                        "optional": {
+                            "description": "optional specify whether the ConfigMap or its keys must be defined",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+                    "description": "Adapts a ConfigMap into a volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.",
+                    "type": "object",
+                    "properties": {
+                        "defaultMode": {
+                            "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "items": {
+                            "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.KeyToPath"
+                            }
+                        },
+                        "name": {
+                            "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                        },
+                        "optional": {
+                            "description": "optional specify whether the ConfigMap or its keys must be defined",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.Container": {
+                    "description": "A single application container that you want to run within a pod.",
+                    "type": "object",
+                    "required": [
+                        "name"
+                    ],
+                    "properties": {
+                        "args": {
+                            "description": "Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "command": {
+                            "description": "Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "env": {
+                            "description": "List of environment variables to set in the container. Cannot be updated.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.EnvVar"
+                            }
+                        },
+                        "envFrom": {
+                            "description": "List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.EnvFromSource"
+                            }
+                        },
+                        "image": {
+                            "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                            "type": "string"
+                        },
+                        "imagePullPolicy": {
+                            "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                            "type": "string"
+                        },
+                        "lifecycle": {
+                            "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Lifecycle"
+                        },
+                        "livenessProbe": {
+                            "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Probe"
+                        },
+                        "name": {
+                            "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+                            "type": "string"
+                        },
+                        "ports": {
+                            "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ContainerPort"
+                            }
+                        },
+                        "readinessProbe": {
+                            "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Probe"
+                        },
+                        "resizePolicy": {
+                            "description": "Resources resize policy for the container.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ContainerResizePolicy"
+                            }
+                        },
+                        "resources": {
+                            "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ResourceRequirements"
+                        },
+                        "restartPolicy": {
+                            "description": "RestartPolicy defines the restart behavior of individual containers in a pod. This overrides the pod-level restart policy. When this field is not specified, the restart behavior is defined by the Pod's restart policy and the container type. Additionally, setting the RestartPolicy as \"Always\" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy \"Always\" will be shut down. This lifecycle differs from normal init containers and is often referred to as a \"sidecar\" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.",
+                            "type": "string"
+                        },
+                        "restartPolicyRules": {
+                            "description": "Represents a list of rules to be checked to determine if the container should be restarted on exit. The rules are evaluated in order. Once a rule matches a container exit condition, the remaining rules are ignored. If no rule matches the container exit condition, the Container-level restart policy determines the whether the container is restarted or not. Constraints on the rules: - At most 20 rules are allowed. - Rules can have the same action. - Identical rules are not forbidden in validations. When rules are specified, container MUST set RestartPolicy explicitly even it if matches the Pod's RestartPolicy.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ContainerRestartRule"
+                            }
+                        },
+                        "securityContext": {
+                            "description": "SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SecurityContext"
+                        },
+                        "startupProbe": {
+                            "description": "StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Probe"
+                        },
+                        "stdin": {
+                            "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                            "type": "boolean"
+                        },
+                        "stdinOnce": {
+                            "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                            "type": "boolean"
+                        },
+                        "terminationMessagePath": {
+                            "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                            "type": "string"
+                        },
+                        "terminationMessagePolicy": {
+                            "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+                            "type": "string"
+                        },
+                        "tty": {
+                            "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                            "type": "boolean"
+                        },
+                        "volumeDevices": {
+                            "description": "volumeDevices is the list of block devices to be used by the container.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.VolumeDevice"
+                            }
+                        },
+                        "volumeMounts": {
+                            "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.VolumeMount"
+                            }
+                        },
+                        "workingDir": {
+                            "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.ContainerPort": {
+                    "description": "ContainerPort represents a network port in a single container.",
+                    "type": "object",
+                    "required": [
+                        "containerPort"
+                    ],
+                    "properties": {
+                        "containerPort": {
+                            "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 \u003c x \u003c 65536.",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "hostIP": {
+                            "description": "What host IP to bind the external port to.",
+                            "type": "string"
+                        },
+                        "hostPort": {
+                            "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 \u003c x \u003c 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "name": {
+                            "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                            "type": "string"
+                        },
+                        "protocol": {
+                            "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.ContainerResizePolicy": {
+                    "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                    "type": "object",
+                    "required": [
+                        "resourceName",
+                        "restartPolicy"
+                    ],
+                    "properties": {
+                        "resourceName": {
+                            "description": "Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.",
+                            "type": "string"
+                        },
+                        "restartPolicy": {
+                            "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.ContainerRestartRule": {
+                    "description": "ContainerRestartRule describes how a container exit is handled.",
+                    "type": "object",
+                    "required": [
+                        "action"
+                    ],
+                    "properties": {
+                        "action": {
+                            "description": "Specifies the action taken on a container exit if the requirements are satisfied. The only possible value is \"Restart\" to restart the container.",
+                            "type": "string"
+                        },
+                        "exitCodes": {
+                            "description": "Represents the exit codes to check on container exits.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ContainerRestartRuleOnExitCodes"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.ContainerRestartRuleOnExitCodes": {
+                    "description": "ContainerRestartRuleOnExitCodes describes the condition for handling an exited container based on its exit codes.",
+                    "type": "object",
+                    "required": [
+                        "operator"
+                    ],
+                    "properties": {
+                        "operator": {
+                            "description": "Represents the relationship between the container exit code(s) and the specified values. Possible values are: - In: the requirement is satisfied if the container exit code is in the\n  set of specified values.\n- NotIn: the requirement is satisfied if the container exit code is\n  not in the set of specified values.",
+                            "type": "string"
+                        },
+                        "values": {
+                            "description": "Specifies the set of values to check for container exit codes. At most 255 elements are allowed.",
+                            "type": "array",
+                            "items": {
+                                "type": "integer",
+                                "format": "int32"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.DownwardAPIProjection": {
+                    "description": "Represents downward API info for projecting into a projected volume. Note that this is identical to a downwardAPI volume source without the default mode.",
+                    "type": "object",
+                    "properties": {
+                        "items": {
+                            "description": "Items is a list of DownwardAPIVolume file",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.DownwardAPIVolumeFile"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.DownwardAPIVolumeFile": {
+                    "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                    "type": "object",
+                    "required": [
+                        "path"
+                    ],
+                    "properties": {
+                        "fieldRef": {
+                            "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ObjectFieldSelector"
+                        },
+                        "mode": {
+                            "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "path": {
+                            "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                            "type": "string"
+                        },
+                        "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ResourceFieldSelector"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+                    "description": "DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.",
+                    "type": "object",
+                    "properties": {
+                        "defaultMode": {
+                            "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "items": {
+                            "description": "Items is a list of downward API volume file",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.DownwardAPIVolumeFile"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.EmptyDirVolumeSource": {
+                    "description": "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
+                    "type": "object",
+                    "properties": {
+                        "medium": {
+                            "description": "medium represents what type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                            "type": "string"
+                        },
+                        "sizeLimit": {
+                            "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.EnvFromSource": {
+                    "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
+                    "type": "object",
+                    "properties": {
+                        "configMapRef": {
+                            "description": "The ConfigMap to select from",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ConfigMapEnvSource"
+                        },
+                        "prefix": {
+                            "description": "Optional text to prepend to the name of each environment variable. May consist of any printable ASCII characters except '='.",
+                            "type": "string"
+                        },
+                        "secretRef": {
+                            "description": "The Secret to select from",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SecretEnvSource"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.EnvVar": {
+                    "description": "EnvVar represents an environment variable present in a Container.",
+                    "type": "object",
+                    "required": [
+                        "name"
+                    ],
+                    "properties": {
+                        "name": {
+                            "description": "Name of the environment variable. May consist of any printable ASCII characters except '='.",
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                            "type": "string"
+                        },
+                        "valueFrom": {
+                            "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.EnvVarSource"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.EnvVarSource": {
+                    "description": "EnvVarSource represents a source for the value of an EnvVar.",
+                    "type": "object",
+                    "properties": {
+                        "configMapKeyRef": {
+                            "description": "Selects a key of a ConfigMap.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ConfigMapKeySelector"
+                        },
+                        "fieldRef": {
+                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ObjectFieldSelector"
+                        },
+                        "fileKeyRef": {
+                            "description": "FileKeyRef selects a key of the env file. Requires the EnvFiles feature gate to be enabled.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.FileKeySelector"
+                        },
+                        "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ResourceFieldSelector"
+                        },
+                        "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SecretKeySelector"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.EphemeralContainer": {
+                    "description": "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.\n\nTo add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.",
+                    "type": "object",
+                    "required": [
+                        "name"
+                    ],
+                    "properties": {
+                        "args": {
+                            "description": "Arguments to the entrypoint. The image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "command": {
+                            "description": "Entrypoint array. Not executed within a shell. The image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "env": {
+                            "description": "List of environment variables to set in the container. Cannot be updated.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.EnvVar"
+                            }
+                        },
+                        "envFrom": {
+                            "description": "List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.EnvFromSource"
+                            }
+                        },
+                        "image": {
+                            "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images",
+                            "type": "string"
+                        },
+                        "imagePullPolicy": {
+                            "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                            "type": "string"
+                        },
+                        "lifecycle": {
+                            "description": "Lifecycle is not allowed for ephemeral containers.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Lifecycle"
+                        },
+                        "livenessProbe": {
+                            "description": "Probes are not allowed for ephemeral containers.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Probe"
+                        },
+                        "name": {
+                            "description": "Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.",
+                            "type": "string"
+                        },
+                        "ports": {
+                            "description": "Ports are not allowed for ephemeral containers.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ContainerPort"
+                            }
+                        },
+                        "readinessProbe": {
+                            "description": "Probes are not allowed for ephemeral containers.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Probe"
+                        },
+                        "resizePolicy": {
+                            "description": "Resources resize policy for the container.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ContainerResizePolicy"
+                            }
+                        },
+                        "resources": {
+                            "description": "Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ResourceRequirements"
+                        },
+                        "restartPolicy": {
+                            "description": "Restart policy for the container to manage the restart behavior of each container within a pod. You cannot set this field on ephemeral containers.",
+                            "type": "string"
+                        },
+                        "restartPolicyRules": {
+                            "description": "Represents a list of rules to be checked to determine if the container should be restarted on exit. You cannot set this field on ephemeral containers.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ContainerRestartRule"
+                            }
+                        },
+                        "securityContext": {
+                            "description": "Optional: SecurityContext defines the security options the ephemeral container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SecurityContext"
+                        },
+                        "startupProbe": {
+                            "description": "Probes are not allowed for ephemeral containers.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Probe"
+                        },
+                        "stdin": {
+                            "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                            "type": "boolean"
+                        },
+                        "stdinOnce": {
+                            "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                            "type": "boolean"
+                        },
+                        "targetContainerName": {
+                            "description": "If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.\n\nThe container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.",
+                            "type": "string"
+                        },
+                        "terminationMessagePath": {
+                            "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                            "type": "string"
+                        },
+                        "terminationMessagePolicy": {
+                            "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+                            "type": "string"
+                        },
+                        "tty": {
+                            "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                            "type": "boolean"
+                        },
+                        "volumeDevices": {
+                            "description": "volumeDevices is the list of block devices to be used by the container.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.VolumeDevice"
+                            }
+                        },
+                        "volumeMounts": {
+                            "description": "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.VolumeMount"
+                            }
+                        },
+                        "workingDir": {
+                            "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.EphemeralVolumeSource": {
+                    "description": "Represents an ephemeral volume that is handled by a normal storage driver.",
+                    "type": "object",
+                    "properties": {
+                        "volumeClaimTemplate": {
+                            "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `\u003cpod name\u003e-\u003cvolume name\u003e` where `\u003cvolume name\u003e` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.\n\nRequired, must not be nil.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PersistentVolumeClaimTemplate"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.ExecAction": {
+                    "description": "ExecAction describes a \"run in container\" action.",
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.FCVolumeSource": {
+                    "description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
+                    "type": "object",
+                    "properties": {
+                        "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                        },
+                        "lun": {
+                            "description": "lun is Optional: FC target lun number",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "readOnly": {
+                            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                        },
+                        "targetWWNs": {
+                            "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "wwids": {
+                            "description": "wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.FileKeySelector": {
+                    "description": "FileKeySelector selects a key of the env file.",
+                    "type": "object",
+                    "required": [
+                        "volumeName",
+                        "path",
+                        "key"
+                    ],
+                    "properties": {
+                        "key": {
+                            "description": "The key within the env file. An invalid key will prevent the pod from starting. The keys defined within a source may consist of any printable ASCII characters except '='. During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.",
+                            "type": "string"
+                        },
+                        "optional": {
+                            "description": "Specify whether the file or its key must be defined. If the file or key does not exist, then the env var is not published. If optional is set to true and the specified key does not exist, the environment variable will not be set in the Pod's containers.\n\nIf optional is set to false and the specified key does not exist, an error will be returned during Pod creation.",
+                            "type": "boolean"
+                        },
+                        "path": {
+                            "description": "The path within the volume from which to select the file. Must be relative and may not contain the '..' path or start with '..'.",
+                            "type": "string"
+                        },
+                        "volumeName": {
+                            "description": "The name of the volume mount containing the env file.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.FlexVolumeSource": {
+                    "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+                    "type": "object",
+                    "required": [
+                        "driver"
+                    ],
+                    "properties": {
+                        "driver": {
+                            "description": "driver is the name of the driver to use for this volume.",
+                            "type": "string"
+                        },
+                        "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                            "type": "string"
+                        },
+                        "options": {
+                            "description": "options is Optional: this field holds extra command options if any.",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "readOnly": {
+                            "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                        },
+                        "secretRef": {
+                            "description": "secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.LocalObjectReference"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.FlockerVolumeSource": {
+                    "description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
+                    "type": "object",
+                    "properties": {
+                        "datasetName": {
+                            "description": "datasetName is Name of the dataset stored as metadata -\u003e name on the dataset for Flocker should be considered as deprecated",
+                            "type": "string"
+                        },
+                        "datasetUUID": {
+                            "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.GCEPersistentDiskVolumeSource": {
+                    "description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
+                    "type": "object",
+                    "required": [
+                        "pdName"
+                    ],
+                    "properties": {
+                        "fsType": {
+                            "description": "fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "string"
+                        },
+                        "partition": {
+                            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "pdName": {
+                            "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "string"
+                        },
+                        "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.GRPCAction": {
+                    "description": "GRPCAction specifies an action involving a GRPC service.",
+                    "type": "object",
+                    "required": [
+                        "port"
+                    ],
+                    "properties": {
+                        "port": {
+                            "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "service": {
+                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.GitRepoVolumeSource": {
+                    "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+                    "type": "object",
+                    "required": [
+                        "repository"
+                    ],
+                    "properties": {
+                        "directory": {
+                            "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+                            "type": "string"
+                        },
+                        "repository": {
+                            "description": "repository is the URL",
+                            "type": "string"
+                        },
+                        "revision": {
+                            "description": "revision is the commit hash for the specified revision.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.GlusterfsVolumeSource": {
+                    "description": "Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.",
+                    "type": "object",
+                    "required": [
+                        "endpoints",
+                        "path"
+                    ],
+                    "properties": {
+                        "endpoints": {
+                            "description": "endpoints is the endpoint name that details Glusterfs topology.",
+                            "type": "string"
+                        },
+                        "path": {
+                            "description": "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                            "type": "string"
+                        },
+                        "readOnly": {
+                            "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.HTTPGetAction": {
+                    "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                    "type": "object",
+                    "required": [
+                        "port"
+                    ],
+                    "properties": {
+                        "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                            "type": "string"
+                        },
+                        "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.HTTPHeader"
+                            }
+                        },
+                        "path": {
+                            "description": "Path to access on the HTTP server.",
+                            "type": "string"
+                        },
+                        "port": {
+                            "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
+                        },
+                        "scheme": {
+                            "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.HTTPHeader": {
+                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                    "type": "object",
+                    "required": [
+                        "name",
+                        "value"
+                    ],
+                    "properties": {
+                        "name": {
+                            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "The header field value",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.HostAlias": {
+                    "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.",
+                    "type": "object",
+                    "required": [
+                        "ip"
+                    ],
+                    "properties": {
+                        "hostnames": {
+                            "description": "Hostnames for the above IP address.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "ip": {
+                            "description": "IP address of the host file entry.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.HostPathVolumeSource": {
+                    "description": "Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.",
+                    "type": "object",
+                    "required": [
+                        "path"
+                    ],
+                    "properties": {
+                        "path": {
+                            "description": "path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                            "type": "string"
+                        },
+                        "type": {
+                            "description": "type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.ISCSIVolumeSource": {
+                    "description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
+                    "type": "object",
+                    "required": [
+                        "targetPortal",
+                        "iqn",
+                        "lun"
+                    ],
+                    "properties": {
+                        "chapAuthDiscovery": {
+                            "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                            "type": "boolean"
+                        },
+                        "chapAuthSession": {
+                            "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                            "type": "boolean"
+                        },
+                        "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+                            "type": "string"
+                        },
+                        "initiatorName": {
+                            "description": "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface \u003ctarget portal\u003e:\u003cvolume name\u003e will be created for the connection.",
+                            "type": "string"
+                        },
+                        "iqn": {
+                            "description": "iqn is the target iSCSI Qualified Name.",
+                            "type": "string"
+                        },
+                        "iscsiInterface": {
+                            "description": "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+                            "type": "string"
+                        },
+                        "lun": {
+                            "description": "lun represents iSCSI Target Lun number.",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "portals": {
+                            "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+                            "type": "boolean"
+                        },
+                        "secretRef": {
+                            "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.LocalObjectReference"
+                        },
+                        "targetPortal": {
+                            "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.ImageVolumeSource": {
+                    "description": "ImageVolumeSource represents a image volume resource.",
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "description": "Policy for pulling OCI objects. Possible values are: Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails. Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present. IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+                            "type": "string"
+                        },
+                        "reference": {
+                            "description": "Required: Image or artifact reference to be used. Behaves in the same way as pod.spec.containers[*].image. Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.KeyToPath": {
+                    "description": "Maps a string key to a path within a volume.",
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "path"
+                    ],
+                    "properties": {
+                        "key": {
+                            "description": "key is the key to project.",
+                            "type": "string"
+                        },
+                        "mode": {
+                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "path": {
+                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.Lifecycle": {
+                    "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
+                    "type": "object",
+                    "properties": {
+                        "postStart": {
+                            "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.LifecycleHandler"
+                        },
+                        "preStop": {
+                            "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.LifecycleHandler"
+                        },
+                        "stopSignal": {
+                            "description": "StopSignal defines which signal will be sent to a container when it is being stopped. If not specified, the default is defined by the container runtime in use. StopSignal can only be set for Pods with a non-empty .spec.os.name",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.LifecycleHandler": {
+                    "description": "LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.",
+                    "type": "object",
+                    "properties": {
+                        "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ExecAction"
+                        },
+                        "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.HTTPGetAction"
+                        },
+                        "sleep": {
+                            "description": "Sleep represents a duration that the container should sleep.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SleepAction"
+                        },
+                        "tcpSocket": {
+                            "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for backward compatibility. There is no validation of this field and lifecycle hooks will fail at runtime when it is specified.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.TCPSocketAction"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.LocalObjectReference": {
+                    "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.NFSVolumeSource": {
+                    "description": "Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.",
+                    "type": "object",
+                    "required": [
+                        "server",
+                        "path"
+                    ],
+                    "properties": {
+                        "path": {
+                            "description": "path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": "string"
+                        },
+                        "readOnly": {
+                            "description": "readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": "boolean"
+                        },
+                        "server": {
+                            "description": "server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.NodeAffinity": {
+                    "description": "Node affinity is a group of node affinity scheduling rules.",
+                    "type": "object",
+                    "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                            "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PreferredSchedulingTerm"
+                            }
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.NodeSelector"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.NodeSelector": {
+                    "description": "A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.",
+                    "type": "object",
+                    "required": [
+                        "nodeSelectorTerms"
+                    ],
+                    "properties": {
+                        "nodeSelectorTerms": {
+                            "description": "Required. A list of node selector terms. The terms are ORed.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.NodeSelectorTerm"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.NodeSelectorRequirement": {
+                    "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "operator"
+                    ],
+                    "properties": {
+                        "key": {
+                            "description": "The label key that the selector applies to.",
+                            "type": "string"
+                        },
+                        "operator": {
+                            "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                            "type": "string"
+                        },
+                        "values": {
+                            "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.NodeSelectorTerm": {
+                    "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                    "type": "object",
+                    "properties": {
+                        "matchExpressions": {
+                            "description": "A list of node selector requirements by node's labels.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.NodeSelectorRequirement"
+                            }
+                        },
+                        "matchFields": {
+                            "description": "A list of node selector requirements by node's fields.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.NodeSelectorRequirement"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.ObjectFieldSelector": {
+                    "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                    "type": "object",
+                    "required": [
+                        "fieldPath"
+                    ],
+                    "properties": {
+                        "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                        },
+                        "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+                    "description": "PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes",
+                    "type": "object",
+                    "properties": {
+                        "accessModes": {
+                            "description": "accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "dataSource": {
+                            "description": "dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.TypedLocalObjectReference"
+                        },
+                        "dataSourceRef": {
+                            "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.TypedObjectReference"
+                        },
+                        "resources": {
+                            "description": "resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.VolumeResourceRequirements"
+                        },
+                        "selector": {
+                            "description": "selector is a label query over volumes to consider for binding.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+                        },
+                        "storageClassName": {
+                            "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                            "type": "string"
+                        },
+                        "volumeAttributesClassName": {
+                            "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim. If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName, it can be changed after the claim is created. An empty string or nil value indicates that no VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state, this field can be reset to its previous value (including nil) to cancel the modification. If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
+                            "type": "string"
+                        },
+                        "volumeMode": {
+                            "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
+                            "type": "string"
+                        },
+                        "volumeName": {
+                            "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+                    "description": "PersistentVolumeClaimTemplate is used to produce PersistentVolumeClaim objects as part of an EphemeralVolumeSource.",
+                    "type": "object",
+                    "required": [
+                        "spec"
+                    ],
+                    "properties": {
+                        "metadata": {
+                            "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+                        },
+                        "spec": {
+                            "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PersistentVolumeClaimSpec"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource": {
+                    "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
+                    "type": "object",
+                    "required": [
+                        "claimName"
+                    ],
+                    "properties": {
+                        "claimName": {
+                            "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                            "type": "string"
+                        },
+                        "readOnly": {
+                            "description": "readOnly Will force the ReadOnly setting in VolumeMounts. Default false.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource": {
+                    "description": "Represents a Photon Controller persistent disk resource.",
+                    "type": "object",
+                    "required": [
+                        "pdID"
+                    ],
+                    "properties": {
+                        "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                        },
+                        "pdID": {
+                            "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.PodAffinity": {
+                    "description": "Pod affinity is a group of inter pod affinity scheduling rules.",
+                    "type": "object",
+                    "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                            "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.WeightedPodAffinityTerm"
+                            }
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodAffinityTerm"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.PodAffinityTerm": {
+                    "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
+                    "type": "object",
+                    "required": [
+                        "topologyKey"
+                    ],
+                    "properties": {
+                        "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods. If it's null, this PodAffinityTerm matches with no Pods.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+                        },
+                        "matchLabelKeys": {
+                            "description": "MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "mismatchLabelKeys": {
+                            "description": "MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+                        },
+                        "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.PodAntiAffinity": {
+                    "description": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
+                    "type": "object",
+                    "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                            "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and subtracting \"weight\" from the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.WeightedPodAffinityTerm"
+                            }
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodAffinityTerm"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.PodCertificateProjection": {
+                    "description": "PodCertificateProjection provides a private key and X.509 certificate in the pod filesystem.",
+                    "type": "object",
+                    "required": [
+                        "signerName",
+                        "keyType"
+                    ],
+                    "properties": {
+                        "certificateChainPath": {
+                            "description": "Write the certificate chain at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath and certificateChainPath, your application needs to check that the key and leaf certificate are consistent, because it is possible to read the files mid-rotation.",
+                            "type": "string"
+                        },
+                        "credentialBundlePath": {
+                            "description": "Write the credential bundle at this path in the projected volume.\n\nThe credential bundle is a single file that contains multiple PEM blocks. The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private key.\n\nThe remaining blocks are CERTIFICATE blocks, containing the issued certificate chain from the signer (leaf and any intermediates).\n\nUsing credentialBundlePath lets your Pod's application code make a single atomic read that retrieves a consistent key and certificate chain.  If you project them to separate files, your application code will need to additionally check that the leaf certificate was issued to the key.",
+                            "type": "string"
+                        },
+                        "keyPath": {
+                            "description": "Write the key at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath and certificateChainPath, your application needs to check that the key and leaf certificate are consistent, because it is possible to read the files mid-rotation.",
+                            "type": "string"
+                        },
+                        "keyType": {
+                            "description": "The type of keypair Kubelet will generate for the pod.\n\nValid values are \"RSA3072\", \"RSA4096\", \"ECDSAP256\", \"ECDSAP384\", \"ECDSAP521\", and \"ED25519\".",
+                            "type": "string"
+                        },
+                        "maxExpirationSeconds": {
+                            "description": "maxExpirationSeconds is the maximum lifetime permitted for the certificate.\n\nKubelet copies this value verbatim into the PodCertificateRequests it generates for this projection.\n\nIf omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver will reject values shorter than 3600 (1 hour).  The maximum allowable value is 7862400 (91 days).\n\nThe signer implementation is then free to issue a certificate with any lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600 seconds (1 hour).  This constraint is enforced by kube-apiserver. `kubernetes.io` signers will never issue certificates with a lifetime longer than 24 hours.",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "signerName": {
+                            "description": "Kubelet's generated CSRs will be addressed to this signer.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.PodDNSConfig": {
+                    "description": "PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.",
+                    "type": "object",
+                    "properties": {
+                        "nameservers": {
+                            "description": "A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "options": {
+                            "description": "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodDNSConfigOption"
+                            }
+                        },
+                        "searches": {
+                            "description": "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.PodDNSConfigOption": {
+                    "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "description": "Name is this DNS resolver option's name. Required.",
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "Value is this DNS resolver option's value.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.PodOS": {
+                    "description": "PodOS defines the OS parameters of a pod.",
+                    "type": "object",
+                    "required": [
+                        "name"
+                    ],
+                    "properties": {
+                        "name": {
+                            "description": "Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.PodReadinessGate": {
+                    "description": "PodReadinessGate contains the reference to a pod condition",
+                    "type": "object",
+                    "required": [
+                        "conditionType"
+                    ],
+                    "properties": {
+                        "conditionType": {
+                            "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.PodResourceClaim": {
+                    "description": "PodResourceClaim references exactly one ResourceClaim, either directly or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim for the pod.\n\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod. Containers that need access to the ResourceClaim reference it with this name.",
+                    "type": "object",
+                    "required": [
+                        "name"
+                    ],
+                    "properties": {
+                        "name": {
+                            "description": "Name uniquely identifies this resource claim inside the pod. This must be a DNS_LABEL.",
+                            "type": "string"
+                        },
+                        "resourceClaimName": {
+                            "description": "ResourceClaimName is the name of a ResourceClaim object in the same namespace as this pod.\n\nExactly one of ResourceClaimName and ResourceClaimTemplateName must be set.",
+                            "type": "string"
+                        },
+                        "resourceClaimTemplateName": {
+                            "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate object in the same namespace as this pod.\n\nThe template will be used to create a new ResourceClaim, which will be bound to this pod. When this pod is deleted, the ResourceClaim will also be deleted. The pod name and resource name, along with a generated component, will be used to form a unique name for the ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.\n\nThis field is immutable and no changes will be made to the corresponding ResourceClaim by the control plane after creating the ResourceClaim.\n\nExactly one of ResourceClaimName and ResourceClaimTemplateName must be set.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.PodSchedulingGate": {
+                    "description": "PodSchedulingGate is associated to a Pod to guard its scheduling.",
+                    "type": "object",
+                    "required": [
+                        "name"
+                    ],
+                    "properties": {
+                        "name": {
+                            "description": "Name of the scheduling gate. Each scheduling gate must have a unique name field.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.PodSecurityContext": {
+                    "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+                    "type": "object",
+                    "properties": {
+                        "appArmorProfile": {
+                            "description": "appArmorProfile is the AppArmor options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.AppArmorProfile"
+                        },
+                        "fsGroup": {
+                            "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:\n\n1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "fsGroupChangePolicy": {
+                            "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "string"
+                        },
+                        "runAsGroup": {
+                            "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "runAsNonRoot": {
+                            "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": "boolean"
+                        },
+                        "runAsUser": {
+                            "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "seLinuxChangePolicy": {
+                            "description": "seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod. It has no effect on nodes that do not support SELinux or to volumes does not support SELinux. Valid values are \"MountOption\" and \"Recursive\".\n\n\"Recursive\" means relabeling of all files on all Pod volumes by the container runtime. This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.\n\n\"MountOption\" mounts all eligible Pod volumes with `-o context` mount option. This requires all Pods that share the same volume to use the same SELinux label. It is not possible to share the same volume among privileged and unprivileged Pods. Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their CSIDriver instance. Other volumes are always re-labelled recursively. \"MountOption\" value is allowed only when SELinuxMount feature gate is enabled.\n\nIf not specified and SELinuxMount feature gate is enabled, \"MountOption\" is used. If not specified and SELinuxMount feature gate is disabled, \"MountOption\" is used for ReadWriteOncePod volumes and \"Recursive\" for all other volumes.\n\nThis field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.\n\nAll Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "string"
+                        },
+                        "seLinuxOptions": {
+                            "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SELinuxOptions"
+                        },
+                        "seccompProfile": {
+                            "description": "The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SeccompProfile"
+                        },
+                        "supplementalGroups": {
+                            "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID and fsGroup (if specified).  If the SupplementalGroupsPolicy feature is enabled, the supplementalGroupsPolicy field determines whether these are in addition to or instead of any group memberships defined in the container image. If unspecified, no additional groups are added, though group memberships defined in the container image may still be used, depending on the supplementalGroupsPolicy field. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "array",
+                            "items": {
+                                "type": "integer",
+                                "format": "int64"
+                            }
+                        },
+                        "supplementalGroupsPolicy": {
+                            "description": "Defines how supplemental groups of the first container processes are calculated. Valid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used. (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled and the container runtime must implement support for this feature. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "string"
+                        },
+                        "sysctls": {
+                            "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Sysctl"
+                            }
+                        },
+                        "windowsOptions": {
+                            "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.WindowsSecurityContextOptions"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.PodSpec": {
+                    "description": "PodSpec is a description of a pod.",
+                    "type": "object",
+                    "required": [
+                        "containers"
+                    ],
+                    "properties": {
+                        "activeDeadlineSeconds": {
+                            "description": "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.",
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "affinity": {
+                            "description": "If specified, the pod's scheduling constraints",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Affinity"
+                        },
+                        "automountServiceAccountToken": {
+                            "description": "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.",
+                            "type": "boolean"
+                        },
+                        "containers": {
+                            "description": "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Container"
+                            }
+                        },
+                        "dnsConfig": {
+                            "description": "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodDNSConfig"
+                        },
+                        "dnsPolicy": {
+                            "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.",
+                            "type": "string"
+                        },
+                        "enableServiceLinks": {
+                            "description": "EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Defaults to true.",
+                            "type": "boolean"
+                        },
+                        "ephemeralContainers": {
+                            "description": "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.EphemeralContainer"
+                            }
+                        },
+                        "hostAliases": {
+                            "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.HostAlias"
+                            }
+                        },
+                        "hostIPC": {
+                            "description": "Use the host's ipc namespace. Optional: Default to false.",
+                            "type": "boolean"
+                        },
+                        "hostNetwork": {
+                            "description": "Host networking requested for this pod. Use the host's network namespace. When using HostNetwork you should specify ports so the scheduler is aware. When `hostNetwork` is true, specified `hostPort` fields in port definitions must match `containerPort`, and unspecified `hostPort` fields in port definitions are defaulted to match `containerPort`. Default to false.",
+                            "type": "boolean"
+                        },
+                        "hostPID": {
+                            "description": "Use the host's pid namespace. Optional: Default to false.",
+                            "type": "boolean"
+                        },
+                        "hostUsers": {
+                            "description": "Use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new userns is created for the pod. Setting false is useful for mitigating container breakout vulnerabilities even allowing users to run their containers as root without actually having root privileges on the host. This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.",
+                            "type": "boolean"
+                        },
+                        "hostname": {
+                            "description": "Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.",
+                            "type": "string"
+                        },
+                        "hostnameOverride": {
+                            "description": "HostnameOverride specifies an explicit override for the pod's hostname as perceived by the pod. This field only specifies the pod's hostname and does not affect its DNS records. When this field is set to a non-empty string: - It takes precedence over the values set in `hostname` and `subdomain`. - The Pod's hostname will be set to this value. - `setHostnameAsFQDN` must be nil or set to false. - `hostNetwork` must be set to false.\n\nThis field must be a valid DNS subdomain as defined in RFC 1123 and contain at most 64 characters. Requires the HostnameOverride feature gate to be enabled.",
+                            "type": "string"
+                        },
+                        "imagePullSecrets": {
+                            "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.LocalObjectReference"
+                            }
+                        },
+                        "initContainers": {
+                            "description": "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Container"
+                            }
+                        },
+                        "nodeName": {
+                            "description": "NodeName indicates in which node this pod is scheduled. If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName. Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod. This field should not be used to express a desire for the pod to be scheduled on a specific node. https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename",
+                            "type": "string"
+                        },
+                        "nodeSelector": {
+                            "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "os": {
+                            "description": "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.\n\nIf the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions\n\nIf the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.resources - spec.securityContext.appArmorProfile - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.securityContext.supplementalGroupsPolicy - spec.containers[*].securityContext.appArmorProfile - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodOS"
+                        },
+                        "overhead": {
+                            "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md",
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+                            }
+                        },
+                        "preemptionPolicy": {
+                            "description": "PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
+                            "type": "string"
+                        },
+                        "priority": {
+                            "description": "The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "priorityClassName": {
+                            "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
+                            "type": "string"
+                        },
+                        "readinessGates": {
+                            "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodReadinessGate"
+                            }
+                        },
+                        "resourceClaims": {
+                            "description": "ResourceClaims defines which ResourceClaims must be allocated and reserved before the Pod is allowed to start. The resources will be made available to those containers which consume them by name.\n\nThis is an alpha field and requires enabling the DynamicResourceAllocation feature gate.\n\nThis field is immutable.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodResourceClaim"
+                            }
+                        },
+                        "resources": {
+                            "description": "Resources is the total amount of CPU and Memory resources required by all containers in the pod. It supports specifying Requests and Limits for \"cpu\", \"memory\" and \"hugepages-\" resource names only. ResourceClaims are not supported.\n\nThis field enables fine-grained control over resource allocation for the entire pod, allowing resource sharing among containers in a pod.\n\nThis is an alpha field and requires enabling the PodLevelResources feature gate.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ResourceRequirements"
+                        },
+                        "restartPolicy": {
+                            "description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy",
+                            "type": "string"
+                        },
+                        "runtimeClassName": {
+                            "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class",
+                            "type": "string"
+                        },
+                        "schedulerName": {
+                            "description": "If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.",
+                            "type": "string"
+                        },
+                        "schedulingGates": {
+                            "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod. If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the scheduler will not attempt to schedule the pod.\n\nSchedulingGates can only be set at pod creation time, and be removed only afterwards.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodSchedulingGate"
+                            }
+                        },
+                        "securityContext": {
+                            "description": "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodSecurityContext"
+                        },
+                        "serviceAccount": {
+                            "description": "DeprecatedServiceAccount is a deprecated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.",
+                            "type": "string"
+                        },
+                        "serviceAccountName": {
+                            "description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+                            "type": "string"
+                        },
+                        "setHostnameAsFQDN": {
+                            "description": "If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname). In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\\\SYSTEM\\\\CurrentControlSet\\\\Services\\\\Tcpip\\\\Parameters to FQDN. If a pod does not have FQDN, this has no effect. Default to false.",
+                            "type": "boolean"
+                        },
+                        "shareProcessNamespace": {
+                            "description": "Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.",
+                            "type": "boolean"
+                        },
+                        "subdomain": {
+                            "description": "If specified, the fully qualified Pod hostname will be \"\u003chostname\u003e.\u003csubdomain\u003e.\u003cpod namespace\u003e.svc.\u003ccluster domain\u003e\". If not specified, the pod will not have a domainname at all.",
+                            "type": "string"
+                        },
+                        "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.",
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "tolerations": {
+                            "description": "If specified, the pod's tolerations.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Toleration"
+                            }
+                        },
+                        "topologySpreadConstraints": {
+                            "description": "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.TopologySpreadConstraint"
+                            }
+                        },
+                        "volumes": {
+                            "description": "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Volume"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.PortworxVolumeSource": {
+                    "description": "PortworxVolumeSource represents a Portworx volume resource.",
+                    "type": "object",
+                    "required": [
+                        "volumeID"
+                    ],
+                    "properties": {
+                        "fsType": {
+                            "description": "fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                        },
+                        "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                        },
+                        "volumeID": {
+                            "description": "volumeID uniquely identifies a Portworx volume",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+                    "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                    "type": "object",
+                    "required": [
+                        "weight",
+                        "preference"
+                    ],
+                    "properties": {
+                        "preference": {
+                            "description": "A node selector term, associated with the corresponding weight.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.NodeSelectorTerm"
+                        },
+                        "weight": {
+                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.Probe": {
+                    "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                    "type": "object",
+                    "properties": {
+                        "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ExecAction"
+                        },
+                        "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "grpc": {
+                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.GRPCAction"
+                        },
+                        "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.HTTPGetAction"
+                        },
+                        "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "tcpSocket": {
+                            "description": "TCPSocket specifies a connection to a TCP port.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.TCPSocketAction"
+                        },
+                        "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.ProjectedVolumeSource": {
+                    "description": "Represents a projected volume source",
+                    "type": "object",
+                    "properties": {
+                        "defaultMode": {
+                            "description": "defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "sources": {
+                            "description": "sources is the list of volume projections. Each entry in this list handles one source.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.VolumeProjection"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.QuobyteVolumeSource": {
+                    "description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
+                    "type": "object",
+                    "required": [
+                        "registry",
+                        "volume"
+                    ],
+                    "properties": {
+                        "group": {
+                            "description": "group to map volume access to Default is no group",
+                            "type": "string"
+                        },
+                        "readOnly": {
+                            "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+                            "type": "boolean"
+                        },
+                        "registry": {
+                            "description": "registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+                            "type": "string"
+                        },
+                        "tenant": {
+                            "description": "tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                            "type": "string"
+                        },
+                        "user": {
+                            "description": "user to map volume access to Defaults to serivceaccount user",
+                            "type": "string"
+                        },
+                        "volume": {
+                            "description": "volume is a string that references an already created Quobyte volume by name.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.RBDVolumeSource": {
+                    "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
+                    "type": "object",
+                    "required": [
+                        "monitors",
+                        "image"
+                    ],
+                    "properties": {
+                        "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+                            "type": "string"
+                        },
+                        "image": {
+                            "description": "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                        },
+                        "keyring": {
+                            "description": "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                        },
+                        "monitors": {
+                            "description": "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "pool": {
+                            "description": "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                        },
+                        "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "boolean"
+                        },
+                        "secretRef": {
+                            "description": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.LocalObjectReference"
+                        },
+                        "user": {
+                            "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.ResourceClaim": {
+                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                    "type": "object",
+                    "required": [
+                        "name"
+                    ],
+                    "properties": {
+                        "name": {
+                            "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                            "type": "string"
+                        },
+                        "request": {
+                            "description": "Request is the name chosen for a request in the referenced claim. If empty, everything from the claim is made available, otherwise only the result of this request.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.ResourceFieldSelector": {
+                    "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                    "type": "object",
+                    "required": [
+                        "resource"
+                    ],
+                    "properties": {
+                        "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                        },
+                        "divisor": {
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+                        },
+                        "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.ResourceRequirements": {
+                    "description": "ResourceRequirements describes the compute resource requirements.",
+                    "type": "object",
+                    "properties": {
+                        "claims": {
+                            "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.\n\nThis field depends on the DynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ResourceClaim"
+                            }
+                        },
+                        "limits": {
+                            "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+                            }
+                        },
+                        "requests": {
+                            "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.SELinuxOptions": {
+                    "description": "SELinuxOptions are the labels to be applied to the container",
+                    "type": "object",
+                    "properties": {
+                        "level": {
+                            "description": "Level is SELinux level label that applies to the container.",
+                            "type": "string"
+                        },
+                        "role": {
+                            "description": "Role is a SELinux role label that applies to the container.",
+                            "type": "string"
+                        },
+                        "type": {
+                            "description": "Type is a SELinux type label that applies to the container.",
+                            "type": "string"
+                        },
+                        "user": {
+                            "description": "User is a SELinux user label that applies to the container.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.ScaleIOVolumeSource": {
+                    "description": "ScaleIOVolumeSource represents a persistent ScaleIO volume",
+                    "type": "object",
+                    "required": [
+                        "gateway",
+                        "system",
+                        "secretRef"
+                    ],
+                    "properties": {
+                        "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+                            "type": "string"
+                        },
+                        "gateway": {
+                            "description": "gateway is the host address of the ScaleIO API Gateway.",
+                            "type": "string"
+                        },
+                        "protectionDomain": {
+                            "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                            "type": "string"
+                        },
+                        "readOnly": {
+                            "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                        },
+                        "secretRef": {
+                            "description": "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.LocalObjectReference"
+                        },
+                        "sslEnabled": {
+                            "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                            "type": "boolean"
+                        },
+                        "storageMode": {
+                            "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+                            "type": "string"
+                        },
+                        "storagePool": {
+                            "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                            "type": "string"
+                        },
+                        "system": {
+                            "description": "system is the name of the storage system as configured in ScaleIO.",
+                            "type": "string"
+                        },
+                        "volumeName": {
+                            "description": "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.SeccompProfile": {
+                    "description": "SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.",
+                    "type": "object",
+                    "required": [
+                        "type"
+                    ],
+                    "properties": {
+                        "localhostProfile": {
+                            "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
+                            "type": "string"
+                        },
+                        "type": {
+                            "description": "type indicates which kind of seccomp profile will be applied. Valid options are:\n\nLocalhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.SecretEnvSource": {
+                    "description": "SecretEnvSource selects a Secret to populate the environment variables with.\n\nThe contents of the target Secret's Data field will represent the key-value pairs as environment variables.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                        },
+                        "optional": {
+                            "description": "Specify whether the Secret must be defined",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.SecretKeySelector": {
+                    "description": "SecretKeySelector selects a key of a Secret.",
+                    "type": "object",
+                    "required": [
+                        "key"
+                    ],
+                    "properties": {
+                        "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                        },
+                        "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.SecretProjection": {
+                    "description": "Adapts a secret into a projected volume.\n\nThe contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.",
+                    "type": "object",
+                    "properties": {
+                        "items": {
+                            "description": "items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.KeyToPath"
+                            }
+                        },
+                        "name": {
+                            "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                        },
+                        "optional": {
+                            "description": "optional field specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.SecretVolumeSource": {
+                    "description": "Adapts a Secret into a volume.\n\nThe contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.",
+                    "type": "object",
+                    "properties": {
+                        "defaultMode": {
+                            "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "items": {
+                            "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.KeyToPath"
+                            }
+                        },
+                        "optional": {
+                            "description": "optional field specify whether the Secret or its keys must be defined",
+                            "type": "boolean"
+                        },
+                        "secretName": {
+                            "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.SecurityContext": {
+                    "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+                    "type": "object",
+                    "properties": {
+                        "allowPrivilegeEscalation": {
+                            "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "boolean"
+                        },
+                        "appArmorProfile": {
+                            "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile overrides the pod's appArmorProfile. Note that this field cannot be set when spec.os.name is windows.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.AppArmorProfile"
+                        },
+                        "capabilities": {
+                            "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Capabilities"
+                        },
+                        "privileged": {
+                            "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "boolean"
+                        },
+                        "procMount": {
+                            "description": "procMount denotes the type of proc mount to use for the containers. The default value is Default which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "string"
+                        },
+                        "readOnlyRootFilesystem": {
+                            "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "boolean"
+                        },
+                        "runAsGroup": {
+                            "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "runAsNonRoot": {
+                            "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": "boolean"
+                        },
+                        "runAsUser": {
+                            "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "seLinuxOptions": {
+                            "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SELinuxOptions"
+                        },
+                        "seccompProfile": {
+                            "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod \u0026 container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SeccompProfile"
+                        },
+                        "windowsOptions": {
+                            "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.WindowsSecurityContextOptions"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.ServiceAccountTokenProjection": {
+                    "description": "ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).",
+                    "type": "object",
+                    "required": [
+                        "path"
+                    ],
+                    "properties": {
+                        "audience": {
+                            "description": "audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+                            "type": "string"
+                        },
+                        "expirationSeconds": {
+                            "description": "expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "path": {
+                            "description": "path is the path relative to the mount point of the file to project the token into.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.SleepAction": {
+                    "description": "SleepAction describes a \"sleep\" action.",
+                    "type": "object",
+                    "required": [
+                        "seconds"
+                    ],
+                    "properties": {
+                        "seconds": {
+                            "description": "Seconds is the number of seconds to sleep.",
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.StorageOSVolumeSource": {
+                    "description": "Represents a StorageOS persistent volume resource.",
+                    "type": "object",
+                    "properties": {
+                        "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                        },
+                        "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                        },
+                        "secretRef": {
+                            "description": "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.LocalObjectReference"
+                        },
+                        "volumeName": {
+                            "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+                            "type": "string"
+                        },
+                        "volumeNamespace": {
+                            "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.Sysctl": {
+                    "description": "Sysctl defines a kernel parameter to be set",
+                    "type": "object",
+                    "required": [
+                        "name",
+                        "value"
+                    ],
+                    "properties": {
+                        "name": {
+                            "description": "Name of a property to set",
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "Value of a property to set",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.TCPSocketAction": {
+                    "description": "TCPSocketAction describes an action based on opening a socket",
+                    "type": "object",
+                    "required": [
+                        "port"
+                    ],
+                    "properties": {
+                        "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                            "type": "string"
+                        },
+                        "port": {
+                            "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.Toleration": {
+                    "description": "The pod this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+                    "type": "object",
+                    "properties": {
+                        "effect": {
+                            "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                            "type": "string"
+                        },
+                        "key": {
+                            "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                            "type": "string"
+                        },
+                        "operator": {
+                            "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                            "type": "string"
+                        },
+                        "tolerationSeconds": {
+                            "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "value": {
+                            "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.TopologySpreadConstraint": {
+                    "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                    "type": "object",
+                    "required": [
+                        "maxSkew",
+                        "topologyKey",
+                        "whenUnsatisfiable"
+                    ],
+                    "properties": {
+                        "labelSelector": {
+                            "description": "LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+                        },
+                        "matchLabelKeys": {
+                            "description": "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "maxSkew": {
+                            "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "minDomains": {
+                            "description": "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.",
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "nodeAffinityPolicy": {
+                            "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.",
+                            "type": "string"
+                        },
+                        "nodeTaintsPolicy": {
+                            "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.",
+                            "type": "string"
+                        },
+                        "topologyKey": {
+                            "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each \u003ckey, value\u003e as a \"bucket\", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology. And, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology. It's a required field.",
+                            "type": "string"
+                        },
+                        "whenUnsatisfiable": {
+                            "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.TypedLocalObjectReference": {
+                    "description": "TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.",
+                    "type": "object",
+                    "required": [
+                        "kind",
+                        "name"
+                    ],
+                    "properties": {
+                        "apiGroup": {
+                            "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                            "type": "string"
+                        },
+                        "kind": {
+                            "description": "Kind is the type of resource being referenced",
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "Name is the name of resource being referenced",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.TypedObjectReference": {
+                    "description": "TypedObjectReference contains enough information to let you locate the typed referenced object",
+                    "type": "object",
+                    "required": [
+                        "kind",
+                        "name"
+                    ],
+                    "properties": {
+                        "apiGroup": {
+                            "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                            "type": "string"
+                        },
+                        "kind": {
+                            "description": "Kind is the type of resource being referenced",
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "Name is the name of resource being referenced",
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "description": "Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.Volume": {
+                    "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                    "type": "object",
+                    "required": [
+                        "name"
+                    ],
+                    "properties": {
+                        "awsElasticBlockStore": {
+                            "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource"
+                        },
+                        "azureDisk": {
+                            "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod. Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type are redirected to the disk.csi.azure.com CSI driver.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.AzureDiskVolumeSource"
+                        },
+                        "azureFile": {
+                            "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod. Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type are redirected to the file.csi.azure.com CSI driver.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.AzureFileVolumeSource"
+                        },
+                        "cephfs": {
+                            "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime. Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.CephFSVolumeSource"
+                        },
+                        "cinder": {
+                            "description": "cinder represents a cinder volume attached and mounted on kubelets host machine. Deprecated: Cinder is deprecated. All operations for the in-tree cinder type are redirected to the cinder.csi.openstack.org CSI driver. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.CinderVolumeSource"
+                        },
+                        "configMap": {
+                            "description": "configMap represents a configMap that should populate this volume",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ConfigMapVolumeSource"
+                        },
+                        "csi": {
+                            "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.CSIVolumeSource"
+                        },
+                        "downwardAPI": {
+                            "description": "downwardAPI represents downward API about the pod that should populate this volume",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.DownwardAPIVolumeSource"
+                        },
+                        "emptyDir": {
+                            "description": "emptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.EmptyDirVolumeSource"
+                        },
+                        "ephemeral": {
+                            "description": "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.\n\nUse this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.\n\nA pod can use both types of ephemeral volumes and persistent volumes at the same time.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.EphemeralVolumeSource"
+                        },
+                        "fc": {
+                            "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.FCVolumeSource"
+                        },
+                        "flexVolume": {
+                            "description": "flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.FlexVolumeSource"
+                        },
+                        "flocker": {
+                            "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running. Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.FlockerVolumeSource"
+                        },
+                        "gcePersistentDisk": {
+                            "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.GCEPersistentDiskVolumeSource"
+                        },
+                        "gitRepo": {
+                            "description": "gitRepo represents a git repository at a particular revision. Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.GitRepoVolumeSource"
+                        },
+                        "glusterfs": {
+                            "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.GlusterfsVolumeSource"
+                        },
+                        "hostPath": {
+                            "description": "hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.HostPathVolumeSource"
+                        },
+                        "image": {
+                            "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine. The volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails. - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present. - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation. A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message. The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field. The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images. The volume will be mounted read-only (ro) and non-executable files (noexec). Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33. The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ImageVolumeSource"
+                        },
+                        "iscsi": {
+                            "description": "iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ISCSIVolumeSource"
+                        },
+                        "name": {
+                            "description": "name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                        },
+                        "nfs": {
+                            "description": "nfs represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.NFSVolumeSource"
+                        },
+                        "persistentVolumeClaim": {
+                            "description": "persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource"
+                        },
+                        "photonPersistentDisk": {
+                            "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine. Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource"
+                        },
+                        "portworxVolume": {
+                            "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine. Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate is on.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PortworxVolumeSource"
+                        },
+                        "projected": {
+                            "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ProjectedVolumeSource"
+                        },
+                        "quobyte": {
+                            "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime. Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.QuobyteVolumeSource"
+                        },
+                        "rbd": {
+                            "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.RBDVolumeSource"
+                        },
+                        "scaleIO": {
+                            "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes. Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ScaleIOVolumeSource"
+                        },
+                        "secret": {
+                            "description": "secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SecretVolumeSource"
+                        },
+                        "storageos": {
+                            "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes. Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.StorageOSVolumeSource"
+                        },
+                        "vsphereVolume": {
+                            "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine. Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type are redirected to the csi.vsphere.vmware.com CSI driver.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.VolumeDevice": {
+                    "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                    "type": "object",
+                    "required": [
+                        "name",
+                        "devicePath"
+                    ],
+                    "properties": {
+                        "devicePath": {
+                            "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "name must match the name of a persistentVolumeClaim in the pod",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.VolumeMount": {
+                    "description": "VolumeMount describes a mounting of a Volume within a container.",
+                    "type": "object",
+                    "required": [
+                        "name",
+                        "mountPath"
+                    ],
+                    "properties": {
+                        "mountPath": {
+                            "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                            "type": "string"
+                        },
+                        "mountPropagation": {
+                            "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10. When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified (which defaults to None).",
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "This must match the Name of a Volume.",
+                            "type": "string"
+                        },
+                        "readOnly": {
+                            "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                            "type": "boolean"
+                        },
+                        "recursiveReadOnly": {
+                            "description": "RecursiveReadOnly specifies whether read-only mounts should be handled recursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made recursively read-only.  If this field is set to IfPossible, the mount is made recursively read-only, if it is supported by the container runtime.  If this field is set to Enabled, the mount is made recursively read-only if it is supported by the container runtime, otherwise the pod will not be started and an error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to None (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                            "type": "string"
+                        },
+                        "subPath": {
+                            "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                            "type": "string"
+                        },
+                        "subPathExpr": {
+                            "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.VolumeProjection": {
+                    "description": "Projection that may be projected along with other supported volume types. Exactly one of these fields must be set.",
+                    "type": "object",
+                    "properties": {
+                        "clusterTrustBundle": {
+                            "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field of ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the combination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written into the pod filesystem.  Esoteric PEM features such as inter-block comments and block headers are stripped.  Certificates are deduplicated. The ordering of certificates within the file is arbitrary, and Kubelet may change the order over time.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ClusterTrustBundleProjection"
+                        },
+                        "configMap": {
+                            "description": "configMap information about the configMap data to project",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ConfigMapProjection"
+                        },
+                        "downwardAPI": {
+                            "description": "downwardAPI information about the downwardAPI data to project",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.DownwardAPIProjection"
+                        },
+                        "podCertificate": {
+                            "description": "Projects an auto-rotating credential bundle (private key and certificate chain) that the pod can use either as a TLS client or server.\n\nKubelet generates a private key and uses it to send a PodCertificateRequest to the named signer.  Once the signer approves the request and issues a certificate chain, Kubelet writes the key and certificate chain to the pod filesystem.  The pod does not start until certificates have been issued for each podCertificate projected volume source in its spec.\n\nKubelet will begin trying to rotate the certificate at the time indicated by the signer using the PodCertificateRequest.Status.BeginRefreshAt timestamp.\n\nKubelet can write a single file, indicated by the credentialBundlePath field, or separate files, indicated by the keyPath and certificateChainPath fields.\n\nThe credential bundle is a single file in PEM format.  The first PEM entry is the private key (in PKCS#8 format), and the remaining PEM entries are the certificate chain issued by the signer (typically, signers will return their certificate chain in leaf-to-root order).\n\nPrefer using the credential bundle format, since your application code can read it atomically.  If you use keyPath and certificateChainPath, your application must make two separate file reads. If these coincide with a certificate rotation, it is possible that the private key and leaf certificate you read may not correspond to each other.  Your application will need to check for this condition, and re-read until they are consistent.\n\nThe named signer controls chooses the format of the certificate it issues; consult the signer implementation's documentation to learn how to use the certificates it issues.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodCertificateProjection"
+                        },
+                        "secret": {
+                            "description": "secret information about the secret data to project",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SecretProjection"
+                        },
+                        "serviceAccountToken": {
+                            "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ServiceAccountTokenProjection"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.VolumeResourceRequirements": {
+                    "description": "VolumeResourceRequirements describes the storage resource requirements for a volume.",
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+                            }
+                        },
+                        "requests": {
+                            "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource": {
+                    "description": "Represents a vSphere volume resource.",
+                    "type": "object",
+                    "required": [
+                        "volumePath"
+                    ],
+                    "properties": {
+                        "fsType": {
+                            "description": "fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                        },
+                        "storagePolicyID": {
+                            "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                            "type": "string"
+                        },
+                        "storagePolicyName": {
+                            "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                            "type": "string"
+                        },
+                        "volumePath": {
+                            "description": "volumePath is the path that identifies vSphere volume vmdk",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                    "type": "object",
+                    "required": [
+                        "weight",
+                        "podAffinityTerm"
+                    ],
+                    "properties": {
+                        "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PodAffinityTerm"
+                        },
+                        "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    }
+                },
+                "io.k8s.api.core.v1.WindowsSecurityContextOptions": {
+                    "description": "WindowsSecurityContextOptions contain Windows-specific options and credentials.",
+                    "type": "object",
+                    "properties": {
+                        "gmsaCredentialSpec": {
+                            "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                            "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                            "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                            "type": "string"
+                        },
+                        "hostProcess": {
+                            "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                            "type": "boolean"
+                        },
+                        "runAsUserName": {
+                            "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.api.policy.v1.PodDisruptionBudgetSpec": {
+                    "description": "PodDisruptionBudgetSpec is a description of a PodDisruptionBudget.",
+                    "type": "object",
+                    "properties": {
+                        "maxUnavailable": {
+                            "description": "An eviction is allowed if at most \"maxUnavailable\" pods selected by \"selector\" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with \"minAvailable\".",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
+                        },
+                        "minAvailable": {
+                            "description": "An eviction is allowed if at least \"minAvailable\" pods selected by \"selector\" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying \"100%\".",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
+                        },
+                        "selector": {
+                            "description": "Label query over pods whose evictions are managed by the disruption budget. A null selector will match no pods, while an empty ({}) selector will select all pods within the namespace.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+                        },
+                        "unhealthyPodEvictionPolicy": {
+                            "description": "UnhealthyPodEvictionPolicy defines the criteria for when unhealthy pods should be considered for eviction. Current implementation considers healthy pods, as pods that have status.conditions item with type=\"Ready\",status=\"True\".\n\nValid policies are IfHealthyBudget and AlwaysAllow. If no policy is specified, the default behavior will be used, which corresponds to the IfHealthyBudget policy.\n\nIfHealthyBudget policy means that running pods (status.phase=\"Running\"), but not yet healthy can be evicted only if the guarded application is not disrupted (status.currentHealthy is at least equal to status.desiredHealthy). Healthy pods will be subject to the PDB for eviction.\n\nAlwaysAllow policy means that all running pods (status.phase=\"Running\"), but not yet healthy are considered disrupted and can be evicted regardless of whether the criteria in a PDB is met. This means perspective running pods of a disrupted application might not get a chance to become healthy. Healthy pods will be subject to the PDB for eviction.\n\nAdditional policies may be added in the future. Clients making eviction decisions should disallow eviction of unhealthy pods if they encounter an unrecognized policy in this field.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.apimachinery.pkg.api.resource.Quantity": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
+                    "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+                    "type": "object"
+                },
+                "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                    "type": "object",
+                    "properties": {
+                        "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+                            }
+                        },
+                        "matchLabels": {
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "type": "object",
+                    "required": [
+                        "key",
+                        "operator"
+                    ],
+                    "properties": {
+                        "key": {
+                            "description": "key is the label key that the selector applies to.",
+                            "type": "string"
+                        },
+                        "operator": {
+                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                            "type": "string"
+                        },
+                        "values": {
+                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry": {
+                    "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+                    "type": "object",
+                    "properties": {
+                        "apiVersion": {
+                            "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+                            "type": "string"
+                        },
+                        "fieldsType": {
+                            "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+                            "type": "string"
+                        },
+                        "fieldsV1": {
+                            "description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1"
+                        },
+                        "manager": {
+                            "description": "Manager is an identifier of the workflow managing these fields.",
+                            "type": "string"
+                        },
+                        "operation": {
+                            "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+                            "type": "string"
+                        },
+                        "subresource": {
+                            "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+                            "type": "string"
+                        },
+                        "time": {
+                            "description": "Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over.",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+                        }
+                    }
+                },
+                "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                    "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "creationTimestamp": {
+                            "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+                        },
+                        "deletionGracePeriodSeconds": {
+                            "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "deletionTimestamp": {
+                            "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+                        },
+                        "finalizers": {
+                            "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "generateName": {
+                            "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                            "type": "string"
+                        },
+                        "generation": {
+                            "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "labels": {
+                            "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "managedFields": {
+                            "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
+                            }
+                        },
+                        "name": {
+                            "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces",
+                            "type": "string"
+                        },
+                        "ownerReferences": {
+                            "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
+                            }
+                        },
+                        "resourceVersion": {
+                            "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                            "type": "string"
+                        },
+                        "selfLink": {
+                            "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+                            "type": "string"
+                        },
+                        "uid": {
+                            "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
+                    "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+                    "type": "object",
+                    "required": [
+                        "apiVersion",
+                        "kind",
+                        "name",
+                        "uid"
+                    ],
+                    "properties": {
+                        "apiVersion": {
+                            "description": "API version of the referent.",
+                            "type": "string"
+                        },
+                        "blockOwnerDeletion": {
+                            "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                            "type": "boolean"
+                        },
+                        "controller": {
+                            "description": "If true, this reference points to the managing controller.",
+                            "type": "boolean"
+                        },
+                        "kind": {
+                            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+                            "type": "string"
+                        },
+                        "uid": {
+                            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                            "type": "string"
+                        }
+                    }
+                },
+                "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                    "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "io.k8s.apimachinery.pkg.util.intstr.IntOrString": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ]
                 }
             }
         }


### PR DESCRIPTION
## What this PR does

Enable schema bundling in `helm-values-schema-json` configuration to inline all external Kubernetes JSON Schema `$ref` definitions into the `values.schema.json` file under `$defs`.

## Why we need it

Previously, the schema contained 51 external HTTP references to `raw.githubusercontent.com` which required network access during Helm install validation. This caused failures in air-gapped/disconnected environments with errors like:

```
Error: values don't meet the specifications of the schema(s)...
failing loading "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.1/_definitions.json"
```

## Changes

- Updated `.schema.yaml` to enable `bundle: true` and `bundleWithoutID: true`
- Regenerated `values.schema.json` with all Kubernetes type definitions inlined in `$defs`

## Results

| Metric | Before | After |
|--------|--------|-------|
| External `$ref` URLs | 51 | 0 |
| Schema file size | ~40KB | ~328KB |
| Air-gapped install | ❌ Fails | ✅ Works |
| Validation functionality | Full | Full |

## Testing

- [x] `make helm-schema` - regenerates schema successfully
- [x] `make helm-lint` - passes
- [x] `helm template` - renders successfully

Fixes #2398