### PR TITLE
Add ttlSecondsAfterFinished to Jobs

### DIFF
--- a/deployment/base/worker-job/worker-job.yaml
+++ b/deployment/base/worker-job/worker-job.yaml
@@ -5,6 +5,7 @@ metadata:
     app: nfd
   name: nfd-worker
 spec:
+  ttlSecondsAfterFinished: 3600
   completions: NUM_NODES
   parallelism: NUM_NODES
   template:

--- a/deployment/helm/node-feature-discovery/templates/post-delete-job.yaml
+++ b/deployment/helm/node-feature-discovery/templates/post-delete-job.yaml
@@ -60,6 +60,7 @@ metadata:
     "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  ttlSecondsAfterFinished: 3600
   template:
     metadata:
       labels:

--- a/deployment/overlays/prune/master-job.yaml
+++ b/deployment/overlays/prune/master-job.yaml
@@ -6,6 +6,7 @@ metadata:
     app: nfd
 spec:
   completions: 1
+  ttlSecondsAfterFinished: 3600
   template:
     metadata:
       labels:


### PR DESCRIPTION
kube-linter complains that `Job.spec.ttlSecondsAfterFinished` is unset.

This PR sets the value to 1 hour.

Source: https://github.com/stackrox/kube-linter