### PR TITLE
nfd-master: prevent label removal on incomplete cache sync

### DIFF
--- a/pkg/nfd-master/nfd-master-internal_test.go
+++ b/pkg/nfd-master/nfd-master-internal_test.go
@@ -210,7 +210,7 @@ func TestUpdateNodeObject(t *testing.T) {
 		fakeMaster := newFakeMaster(WithKubernetesClient(fakeCli))
 
 		Convey("When I successfully update the node with feature labels", func() {
-			err := fakeMaster.updateNodeObject(fakeCli, testNode, featureLabels, featureAnnotations, featureExtResources, nil)
+			err := fakeMaster.updateNodeObject(fakeCli, testNode, featureLabels, featureAnnotations, featureExtResources, nil, false)
 			Convey("Error is nil", func() {
 				So(err, ShouldBeNil)
 			})
@@ -242,7 +242,7 @@ func TestUpdateNodeObject(t *testing.T) {
 			fakeCli.CoreV1().(*fakecorev1client.FakeCoreV1).PrependReactor("patch", "nodes", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
 				return true, &corev1.Node{}, errors.New("Fake error when patching node")
 			})
-			err := fakeMaster.updateNodeObject(fakeCli, testNode, nil, featureAnnotations, ExtendedResources{"": ""}, nil)
+			err := fakeMaster.updateNodeObject(fakeCli, testNode, nil, featureAnnotations, ExtendedResources{"": ""}, nil, false)
 
 			Convey("Error is produced", func() {
 				So(err, ShouldBeError)


### PR DESCRIPTION
## What this PR does / why we need it

This PR fixes an issue where nfd-master would remove all NFD-managed labels from nodes when NodeFeature objects were missing from the informer cache. This commonly occurs in large clusters (1k+ nodes) during startup due to pagination failures (410 Expired errors) when syncing the informer cache.

## Root Cause

When nfd-master starts or when the informer cache needs to re-sync, it iterates through all nodes and looks up their corresponding NodeFeature objects from the cache. If a NodeFeature is not found in the cache (due to incomplete sync, pagination failure, or watch reconnection), the code previously interpreted this as "no features" and removed all NFD labels from the node.

This is problematic because:
1. During startup, the cache may be incomplete due to pagination
2. The API server can return `410 Expired` errors during large list operations
3. Watch reconnections can temporarily leave the cache in an incomplete state

## Solution

The fix introduces a **pending delete tracking mechanism**:

1. When a NodeFeature is explicitly deleted (via `DeleteFunc` event handler), the corresponding node name is marked as having a "pending delete"
2. When processing a node update in `nfdAPIUpdateOneNode()`:
   - If no NodeFeature is found in cache AND there's a pending delete marker → proceed with label removal (intentional delete)
   - If no NodeFeature is found in cache AND there's NO pending delete marker → skip label removal (cache miss)

This ensures labels are only removed when a NodeFeature is **actually deleted**, not when it's simply missing due to an incomplete cache.

## Changes

- Added `pendingDeletes` set with mutex protection in `nfdMaster` struct
- Added `markPendingDelete()` and `consumePendingDelete()` helper methods
- Modified `nfdAPIUpdateOneNode()` to check pending delete status before removing labels
- Added `OnNodeFeatureDelete` callback to `nfdApiControllerOptions`
- Wired up the callback in the `DeleteFunc` handler

## Testing

- [x] Unit tests pass
- [x] `go vet` passes
- [x] `golangci-lint` passes
- [x] Manually tested on minikube (3 nodes) - verified that deleting NodeFeature removes labels only when triggered by actual delete event

## Related Issues

Fixes #2408
Related to #1802

/kind bug