### PR TITLE
fix flag passing to config override informerpagesize

### DIFF
--- a/cmd/nfd-master/main.go
+++ b/cmd/nfd-master/main.go
@@ -73,6 +73,8 @@ func main() {
 			args.Overrides.ResyncPeriod = overrides.ResyncPeriod
 		case "nfd-api-parallelism":
 			args.Overrides.NfdApiParallelism = overrides.NfdApiParallelism
+		case "informer-page-size":
+			args.Overrides.InformerPageSize = overrides.InformerPageSize
 		}
 	})
 


### PR DESCRIPTION
fix flag passing to config override informerpagesize, it never gets set to the overrides and essentially ends up getting ignored