### PR TITLE
nfd-master: prevent label removal on incomplete cache sync

### DIFF
--- a/api/nfd/v1alpha1/feature.go
+++ b/api/nfd/v1alpha1/feature.go
@@ -80,6 +80,15 @@ func (f *Features) InsertAttributeFeatures(domain, feature string, values map[st
 	maps.Copy(f.Attributes[key].Elements, values)
 }
 
+// HasFeatures returns true if the NodeFeature object contains any features
+// (labels, flag features, attribute features, or instance features).
+func (n *NodeFeature) HasFeatures() bool {
+	return len(n.Spec.Labels) > 0 ||
+		len(n.Spec.Features.Attributes) > 0 ||
+		len(n.Spec.Features.Flags) > 0 ||
+		len(n.Spec.Features.Instances) > 0
+}
+
 // MergeInto merges two FeatureSpecs into one. Data in the input object takes
 // precedence (overwrite) over data of the existing object we're merging into.
 func (in *NodeFeatureSpec) MergeInto(out *NodeFeatureSpec) {

--- a/pkg/nfd-master/nfd-api-controller.go
+++ b/pkg/nfd-master/nfd-api-controller.go
@@ -49,6 +49,11 @@ type nfdController struct {
 	updateNodeFeatureGroupChan     chan string
 
 	namespaceLister *NamespaceLister
+
+	// onDelete is called when a NodeFeature is deleted. This allows the
+	// nfdMaster to track pending deletes and distinguish between "NodeFeature
+	// was deleted" vs "NodeFeature is missing from incomplete cache".
+	onDelete func(nodeName string)
 }
 
 type nfdApiControllerOptions struct {
@@ -57,6 +62,9 @@ type nfdApiControllerOptions struct {
 	K8sClient                    k8sclient.Interface
 	NodeFeatureNamespaceSelector *metav1.LabelSelector
 	ListSize                     int64
+	// OnNodeFeatureDelete is called when a NodeFeature is deleted, before
+	// queuing the node for update. This allows tracking pending deletes.
+	OnNodeFeatureDelete func(nodeName string)
 }
 
 func init() {
@@ -70,6 +78,7 @@ func newNfdController(config *restclient.Config, nfdApiControllerOptions nfdApiC
 		updateOneNodeChan:              make(chan string),
 		updateAllNodeFeatureGroupsChan: make(chan struct{}, 1),
 		updateNodeFeatureGroupChan:     make(chan string),
+		onDelete:                       nfdApiControllerOptions.OnNodeFeatureDelete,
 	}
 
 	if nfdApiControllerOptions.NodeFeatureNamespaceSelector != nil {
@@ -145,6 +154,22 @@ func newNfdController(config *restclient.Config, nfdApiControllerOptions nfdApiC
 			}
 
 			klog.V(2).InfoS("NodeFeature deleted", "nodefeature", klog.KObj(nfr))
+			// Mark the node as having a pending delete before queuing update.
+			// This allows nfdAPIUpdateOneNode to distinguish between
+			// "NodeFeature was deleted" vs "cache is incomplete".
+			if c.onDelete != nil {
+				nodeName, err := getNodeNameForObj(nfr)
+				if err != nil {
+					// Fallback: use the NodeFeature's name as the node name.
+					// By convention, nfd-worker creates NodeFeatures with name == nodeName.
+					// This may mark a wrong node for pending delete (for third-party
+					// NodeFeatures), but that's harmless—it just gets consumed without effect.
+					klog.V(2).InfoS("failed to get node name from label, falling back to object name",
+						"nodefeature", klog.KObj(nfr), "error", err)
+					nodeName = nfr.Name
+				}
+				c.onDelete(nodeName)
+			}
 			c.updateOneNode("NodeFeature", nfr)
 			if !nfdApiControllerOptions.DisableNodeFeatureGroup {
 				c.updateAllNodeFeatureGroups()

--- a/pkg/nfd-master/nfd-master-internal_test.go
+++ b/pkg/nfd-master/nfd-master-internal_test.go
@@ -209,7 +209,7 @@ func TestUpdateNodeObject(t *testing.T) {
 		fakeMaster := newFakeMaster(WithKubernetesClient(fakeCli))
 
 		Convey("When I successfully update the node with feature labels", func() {
-			err := fakeMaster.updateNodeObject(fakeCli, testNode, featureLabels, featureAnnotations, featureExtResources, nil)
+			err := fakeMaster.updateNodeObject(fakeCli, testNode, featureLabels, featureAnnotations, featureExtResources, nil, false)
 			Convey("Error is nil", func() {
 				So(err, ShouldBeNil)
 			})
@@ -241,7 +241,7 @@ func TestUpdateNodeObject(t *testing.T) {
 			fakeCli.CoreV1().(*fakecorev1client.FakeCoreV1).PrependReactor("patch", "nodes", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
 				return true, &corev1.Node{}, errors.New("Fake error when patching node")
 			})
-			err := fakeMaster.updateNodeObject(fakeCli, testNode, nil, featureAnnotations, ExtendedResources{"": ""}, nil)
+			err := fakeMaster.updateNodeObject(fakeCli, testNode, nil, featureAnnotations, ExtendedResources{"": ""}, nil, false)
 
 			Convey("Error is produced", func() {
 				So(err, ShouldBeError)
@@ -864,4 +864,119 @@ func TestGetDynamicValue(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPendingDeleteTracking(t *testing.T) {
+	Convey("When tracking pending deletes", t, func() {
+		fakeMaster := newFakeMaster()
+
+		Convey("markPendingDelete should add node to pending set", func() {
+			fakeMaster.markPendingDelete("test-node-1")
+
+			So(fakeMaster.pendingDeletes.Has("test-node-1"), ShouldBeTrue)
+		})
+
+		Convey("consumePendingDelete should return true and remove node if marked", func() {
+			fakeMaster.markPendingDelete("test-node-2")
+
+			result := fakeMaster.consumePendingDelete("test-node-2")
+
+			So(result, ShouldBeTrue)
+			So(fakeMaster.pendingDeletes.Has("test-node-2"), ShouldBeFalse)
+		})
+
+		Convey("consumePendingDelete should return false if node not marked", func() {
+			result := fakeMaster.consumePendingDelete("unmarked-node")
+
+			So(result, ShouldBeFalse)
+		})
+
+		Convey("consumePendingDelete should be idempotent", func() {
+			fakeMaster.markPendingDelete("test-node-3")
+
+			first := fakeMaster.consumePendingDelete("test-node-3")
+			second := fakeMaster.consumePendingDelete("test-node-3")
+
+			So(first, ShouldBeTrue)
+			So(second, ShouldBeFalse)
+		})
+
+		Convey("multiple nodes can be tracked independently", func() {
+			fakeMaster.markPendingDelete("node-a")
+			fakeMaster.markPendingDelete("node-b")
+
+			So(fakeMaster.pendingDeletes.Has("node-a"), ShouldBeTrue)
+			So(fakeMaster.pendingDeletes.Has("node-b"), ShouldBeTrue)
+
+			fakeMaster.consumePendingDelete("node-a")
+
+			So(fakeMaster.pendingDeletes.Has("node-a"), ShouldBeFalse)
+			So(fakeMaster.pendingDeletes.Has("node-b"), ShouldBeTrue)
+		})
+	})
+}
+
+func TestUpdateNodeObjectSkipLabelRemoval(t *testing.T) {
+	Convey("When updating node with skipLabelRemoval=true", t, func() {
+		testNode := newTestNode()
+		// Set up node with existing NFD labels
+		testNode.Labels[nfdv1alpha1.FeatureLabelNs+"/existing-label"] = "existing-value"
+		testNode.Annotations[nfdv1alpha1.FeatureLabelsAnnotation] = "existing-label"
+
+		//nolint:staticcheck // See issue #2400 for migration to NewClientset
+		fakeCli := fakeclient.NewSimpleClientset(testNode)
+		fakeMaster := newFakeMaster(WithKubernetesClient(fakeCli))
+
+		Convey("existing labels should NOT be removed when skipLabelRemoval=true", func() {
+			// Update with empty labels but skip removal
+			err := fakeMaster.updateNodeObject(fakeCli, testNode, Labels{}, Annotations{}, ExtendedResources{}, nil, true)
+			So(err, ShouldBeNil)
+
+			// Get the updated node
+			updatedNode, err := fakeCli.CoreV1().Nodes().Get(context.TODO(), testNodeName, metav1.GetOptions{})
+			So(err, ShouldBeNil)
+
+			// Existing label should still be present
+			So(updatedNode.Labels[nfdv1alpha1.FeatureLabelNs+"/existing-label"], ShouldEqual, "existing-value")
+		})
+
+		Convey("new labels should still be added when skipLabelRemoval=true", func() {
+			newLabels := Labels{nfdv1alpha1.FeatureLabelNs + "/new-label": "new-value"}
+
+			err := fakeMaster.updateNodeObject(fakeCli, testNode, newLabels, Annotations{}, ExtendedResources{}, nil, true)
+			So(err, ShouldBeNil)
+
+			// Get the updated node
+			updatedNode, err := fakeCli.CoreV1().Nodes().Get(context.TODO(), testNodeName, metav1.GetOptions{})
+			So(err, ShouldBeNil)
+
+			// New label should be added
+			So(updatedNode.Labels[nfdv1alpha1.FeatureLabelNs+"/new-label"], ShouldEqual, "new-value")
+			// Existing label should still be present
+			So(updatedNode.Labels[nfdv1alpha1.FeatureLabelNs+"/existing-label"], ShouldEqual, "existing-value")
+		})
+
+		Convey("existing labels should be removed when skipLabelRemoval=false", func() {
+			// Reset the test node
+			testNode2 := newTestNode()
+			testNode2.Labels[nfdv1alpha1.FeatureLabelNs+"/old-label"] = "old-value"
+			testNode2.Annotations[nfdv1alpha1.FeatureLabelsAnnotation] = "old-label"
+
+			//nolint:staticcheck // See issue #2400 for migration to NewClientset
+			fakeCli2 := fakeclient.NewSimpleClientset(testNode2)
+			fakeMaster2 := newFakeMaster(WithKubernetesClient(fakeCli2))
+
+			// Update with empty labels and don't skip removal
+			err := fakeMaster2.updateNodeObject(fakeCli2, testNode2, Labels{}, Annotations{}, ExtendedResources{}, nil, false)
+			So(err, ShouldBeNil)
+
+			// Get the updated node
+			updatedNode, err := fakeCli2.CoreV1().Nodes().Get(context.TODO(), testNodeName, metav1.GetOptions{})
+			So(err, ShouldBeNil)
+
+			// Old label should be removed
+			_, exists := updatedNode.Labels[nfdv1alpha1.FeatureLabelNs+"/old-label"]
+			So(exists, ShouldBeFalse)
+		})
+	})
 }

--- a/pkg/nfd-master/nfd-master-internal_test.go
+++ b/pkg/nfd-master/nfd-master-internal_test.go
@@ -916,8 +916,8 @@ func TestPendingDeleteTracking(t *testing.T) {
 	})
 }
 
-func TestUpdateNodeObjectSkipLabelRemoval(t *testing.T) {
-	Convey("When updating node with skipLabelRemoval=true", t, func() {
+func TestUpdateNodeObjectSkipRemoval(t *testing.T) {
+	Convey("When updating node with skipRemoval=true", t, func() {
 		testNode := newTestNode()
 		// Set up node with existing NFD labels
 		testNode.Labels[nfdv1alpha1.FeatureLabelNs+"/existing-label"] = "existing-value"
@@ -927,7 +927,7 @@ func TestUpdateNodeObjectSkipLabelRemoval(t *testing.T) {
 		fakeCli := fakeclient.NewSimpleClientset(testNode)
 		fakeMaster := newFakeMaster(WithKubernetesClient(fakeCli))
 
-		Convey("existing labels should NOT be removed when skipLabelRemoval=true", func() {
+		Convey("existing labels should NOT be removed when skipRemoval=true", func() {
 			// Update with empty labels but skip removal
 			err := fakeMaster.updateNodeObject(fakeCli, testNode, Labels{}, Annotations{}, ExtendedResources{}, nil, true)
 			So(err, ShouldBeNil)
@@ -940,7 +940,7 @@ func TestUpdateNodeObjectSkipLabelRemoval(t *testing.T) {
 			So(updatedNode.Labels[nfdv1alpha1.FeatureLabelNs+"/existing-label"], ShouldEqual, "existing-value")
 		})
 
-		Convey("new labels should still be added when skipLabelRemoval=true", func() {
+		Convey("new labels should still be added when skipRemoval=true", func() {
 			newLabels := Labels{nfdv1alpha1.FeatureLabelNs + "/new-label": "new-value"}
 
 			err := fakeMaster.updateNodeObject(fakeCli, testNode, newLabels, Annotations{}, ExtendedResources{}, nil, true)
@@ -956,7 +956,7 @@ func TestUpdateNodeObjectSkipLabelRemoval(t *testing.T) {
 			So(updatedNode.Labels[nfdv1alpha1.FeatureLabelNs+"/existing-label"], ShouldEqual, "existing-value")
 		})
 
-		Convey("existing labels should be removed when skipLabelRemoval=false", func() {
+		Convey("existing labels should be removed when skipRemoval=false", func() {
 			// Reset the test node
 			testNode2 := newTestNode()
 			testNode2.Labels[nfdv1alpha1.FeatureLabelNs+"/old-label"] = "old-value"

--- a/pkg/nfd-master/nfd-master-internal_test.go
+++ b/pkg/nfd-master/nfd-master-internal_test.go
@@ -1071,3 +1071,62 @@ func TestCreateExtendedResourcePatchesSkipRemoval(t *testing.T) {
 		})
 	})
 }
+
+func TestSetTaintsSkipRemoval(t *testing.T) {
+	Convey("When setting taints with skipRemoval", t, func() {
+		testNode := newTestNode()
+
+		// Set up existing taint on node
+		existingTaint := corev1.Taint{Key: "nfd.node.kubernetes.io/old-taint", Value: "true", Effect: corev1.TaintEffectNoSchedule}
+		testNode.Spec.Taints = []corev1.Taint{existingTaint}
+		testNode.Annotations[nfdv1alpha1.NodeTaintsAnnotation] = existingTaint.ToString()
+
+		//nolint:staticcheck
+		fakeCli := fakeclient.NewSimpleClientset(testNode)
+		fakeMaster := newFakeMaster(WithKubernetesClient(fakeCli))
+
+		Convey("existing taints should NOT be removed when skipRemoval=true", func() {
+			err := fakeMaster.setTaints(fakeCli, []corev1.Taint{}, testNode, true)
+			So(err, ShouldBeNil)
+
+			updatedNode, err := fakeCli.CoreV1().Nodes().Get(context.TODO(), testNodeName, metav1.GetOptions{})
+			So(err, ShouldBeNil)
+
+			found := false
+			for _, t := range updatedNode.Spec.Taints {
+				if t.Key == existingTaint.Key {
+					found = true
+				}
+			}
+			So(found, ShouldBeTrue)
+		})
+
+		Convey("new taints should be added when skipRemoval=true", func() {
+			newTaint := corev1.Taint{Key: "nfd.node.kubernetes.io/new-taint", Value: "v", Effect: corev1.TaintEffectNoSchedule}
+			err := fakeMaster.setTaints(fakeCli, []corev1.Taint{newTaint}, testNode, true)
+			So(err, ShouldBeNil)
+
+			updatedNode, err := fakeCli.CoreV1().Nodes().Get(context.TODO(), testNodeName, metav1.GetOptions{})
+			So(err, ShouldBeNil)
+
+			keys := map[string]bool{}
+			for _, t := range updatedNode.Spec.Taints {
+				keys[t.Key] = true
+			}
+			So(keys[existingTaint.Key], ShouldBeTrue)
+			So(keys[newTaint.Key], ShouldBeTrue)
+		})
+
+		Convey("existing taints should be removed when skipRemoval=false", func() {
+			err := fakeMaster.setTaints(fakeCli, []corev1.Taint{}, testNode, false)
+			So(err, ShouldBeNil)
+
+			updatedNode, err := fakeCli.CoreV1().Nodes().Get(context.TODO(), testNodeName, metav1.GetOptions{})
+			So(err, ShouldBeNil)
+
+			for _, t := range updatedNode.Spec.Taints {
+				So(t.Key, ShouldNotEqual, existingTaint.Key)
+			}
+		})
+	})
+}

--- a/pkg/nfd-master/nfd-master-internal_test.go
+++ b/pkg/nfd-master/nfd-master-internal_test.go
@@ -1130,3 +1130,35 @@ func TestSetTaintsSkipRemoval(t *testing.T) {
 		})
 	})
 }
+
+func TestProcessedOnceNodeGetsLabelsRemovedOnReprocess(t *testing.T) {
+	Convey("When reprocessing a node that was previously processed", t, func() {
+		testNode := newTestNode()
+		// Node has existing NFD labels from a previous run
+		testNode.Labels[nfdv1alpha1.FeatureLabelNs+"/stale-label"] = "stale-value"
+		testNode.Annotations[nfdv1alpha1.FeatureLabelsAnnotation] = "stale-label"
+
+		//nolint:staticcheck
+		fakeCli := fakeclient.NewSimpleClientset(testNode)
+		fakeMaster := newFakeMaster(WithKubernetesClient(fakeCli))
+
+		Convey("labels should be removed on second processing with no NodeFeature", func() {
+			// Simulate: node was already processed once during startup
+			// resolveNodeState marks the node as processed (inserts into processedOnce)
+			fakeMaster.resolveNodeState(testNodeName)
+
+			// Process with empty labels and skipRemoval=false.
+			// This is the path taken by periodic reconciliation for a node
+			// whose NodeFeature was genuinely deleted before startup.
+			err := fakeMaster.updateNodeObject(fakeCli, testNode, Labels{}, Annotations{}, ExtendedResources{}, nil, false)
+			So(err, ShouldBeNil)
+
+			updatedNode, err := fakeCli.CoreV1().Nodes().Get(context.TODO(), testNodeName, metav1.GetOptions{})
+			So(err, ShouldBeNil)
+
+			// Stale label should be removed
+			_, exists := updatedNode.Labels[nfdv1alpha1.FeatureLabelNs+"/stale-label"]
+			So(exists, ShouldBeFalse)
+		})
+	})
+}

--- a/pkg/nfd-master/nfd-master-internal_test.go
+++ b/pkg/nfd-master/nfd-master-internal_test.go
@@ -304,7 +304,7 @@ func TestAddingExtResources(t *testing.T) {
 		Convey("When there are no matching labels", func() {
 			testNode := newTestNode()
 			extendedResources := ExtendedResources{}
-			patches := fakeMaster.createExtendedResourcePatches(testNode, extendedResources)
+			patches := fakeMaster.createExtendedResourcePatches(testNode, extendedResources, false)
 			So(len(patches), ShouldEqual, 0)
 		})
 
@@ -315,7 +315,7 @@ func TestAddingExtResources(t *testing.T) {
 				utils.NewJsonPatch("add", "/status/capacity", "feature-1", "1"),
 				utils.NewJsonPatch("add", "/status/capacity", "feature-2", "2"),
 			}
-			patches := fakeMaster.createExtendedResourcePatches(testNode, extendedResources)
+			patches := fakeMaster.createExtendedResourcePatches(testNode, extendedResources, false)
 			So(sortJsonPatches(patches), ShouldResemble, sortJsonPatches(expectedPatches))
 		})
 
@@ -323,7 +323,7 @@ func TestAddingExtResources(t *testing.T) {
 			testNode := newTestNode()
 			testNode.Status.Capacity[corev1.ResourceName(nfdv1alpha1.FeatureLabelNs+"/feature-1")] = *resource.NewQuantity(1, resource.BinarySI)
 			extendedResources := ExtendedResources{nfdv1alpha1.FeatureLabelNs + "/feature-1": "1"}
-			patches := fakeMaster.createExtendedResourcePatches(testNode, extendedResources)
+			patches := fakeMaster.createExtendedResourcePatches(testNode, extendedResources, false)
 			So(len(patches), ShouldEqual, 0)
 		})
 
@@ -335,7 +335,7 @@ func TestAddingExtResources(t *testing.T) {
 				utils.NewJsonPatch("replace", "/status/capacity", "feature-1", "1"),
 				utils.NewJsonPatch("replace", "/status/allocatable", "feature-1", "1"),
 			}
-			patches := fakeMaster.createExtendedResourcePatches(testNode, extendedResources)
+			patches := fakeMaster.createExtendedResourcePatches(testNode, extendedResources, false)
 			So(sortJsonPatches(patches), ShouldResemble, sortJsonPatches(expectedPatches))
 		})
 	})
@@ -350,7 +350,7 @@ func TestRemovingExtResources(t *testing.T) {
 			testNode.Annotations[nfdv1alpha1.AnnotationNs+"/extended-resources"] = "feature-1,feature-2"
 			testNode.Status.Capacity[corev1.ResourceName(nfdv1alpha1.FeatureLabelNs+"/feature-1")] = *resource.NewQuantity(1, resource.BinarySI)
 			testNode.Status.Capacity[corev1.ResourceName(nfdv1alpha1.FeatureLabelNs+"/feature-2")] = *resource.NewQuantity(2, resource.BinarySI)
-			patches := fakeMaster.createExtendedResourcePatches(testNode, extendedResources)
+			patches := fakeMaster.createExtendedResourcePatches(testNode, extendedResources, false)
 			So(len(patches), ShouldEqual, 0)
 		})
 		Convey("When the related label is gone", func() {
@@ -359,7 +359,7 @@ func TestRemovingExtResources(t *testing.T) {
 			testNode.Annotations[nfdv1alpha1.AnnotationNs+"/extended-resources"] = "feature-4,feature-2"
 			testNode.Status.Capacity[corev1.ResourceName(nfdv1alpha1.FeatureLabelNs+"/feature-4")] = *resource.NewQuantity(4, resource.BinarySI)
 			testNode.Status.Capacity[corev1.ResourceName(nfdv1alpha1.FeatureLabelNs+"/feature-2")] = *resource.NewQuantity(2, resource.BinarySI)
-			patches := fakeMaster.createExtendedResourcePatches(testNode, extendedResources)
+			patches := fakeMaster.createExtendedResourcePatches(testNode, extendedResources, false)
 			So(len(patches), ShouldBeGreaterThan, 0)
 		})
 		Convey("When the extended resource is no longer wanted", func() {
@@ -368,7 +368,7 @@ func TestRemovingExtResources(t *testing.T) {
 			testNode.Status.Capacity[corev1.ResourceName(nfdv1alpha1.FeatureLabelNs+"/feature-2")] = *resource.NewQuantity(2, resource.BinarySI)
 			extendedResources := ExtendedResources{nfdv1alpha1.FeatureLabelNs + "/feature-2": "2"}
 			testNode.Annotations[nfdv1alpha1.AnnotationNs+"/extended-resources"] = "feature-1,feature-2"
-			patches := fakeMaster.createExtendedResourcePatches(testNode, extendedResources)
+			patches := fakeMaster.createExtendedResourcePatches(testNode, extendedResources, false)
 			So(len(patches), ShouldBeGreaterThan, 0)
 		})
 	})
@@ -1023,6 +1023,51 @@ func TestUpdateNodeObjectSkipRemoval(t *testing.T) {
 			// Old label should be removed
 			_, exists := updatedNode.Labels[nfdv1alpha1.FeatureLabelNs+"/old-label"]
 			So(exists, ShouldBeFalse)
+		})
+	})
+}
+
+func TestCreateExtendedResourcePatchesSkipRemoval(t *testing.T) {
+	Convey("When creating extended resource patches with skipRemoval", t, func() {
+		fakeMaster := newFakeMaster()
+
+		testNode := newTestNode()
+		// Simulate existing extended resource on node
+		testNode.Status.Capacity[corev1.ResourceName(nfdv1alpha1.FeatureLabelNs+"/gpu")] = resource.MustParse("1")
+		testNode.Annotations[nfdv1alpha1.ExtendedResourceAnnotation] = "gpu"
+
+		Convey("existing resources should NOT be removed when skipRemoval=true", func() {
+			patches := fakeMaster.createExtendedResourcePatches(testNode, ExtendedResources{}, true)
+
+			for _, p := range patches {
+				So(p.Op, ShouldNotEqual, "remove")
+			}
+		})
+
+		Convey("new resources should still be added when skipRemoval=true", func() {
+			newResources := ExtendedResources{nfdv1alpha1.FeatureLabelNs + "/fpga": "2"}
+			patches := fakeMaster.createExtendedResourcePatches(testNode, newResources, true)
+
+			hasAdd := false
+			for _, p := range patches {
+				if p.Op == "add" {
+					hasAdd = true
+				}
+				So(p.Op, ShouldNotEqual, "remove")
+			}
+			So(hasAdd, ShouldBeTrue)
+		})
+
+		Convey("existing resources should be removed when skipRemoval=false", func() {
+			patches := fakeMaster.createExtendedResourcePatches(testNode, ExtendedResources{}, false)
+
+			hasRemove := false
+			for _, p := range patches {
+				if p.Op == "remove" {
+					hasRemove = true
+				}
+			}
+			So(hasRemove, ShouldBeTrue)
 		})
 	})
 }

--- a/pkg/nfd-master/nfd-master-internal_test.go
+++ b/pkg/nfd-master/nfd-master-internal_test.go
@@ -916,6 +916,52 @@ func TestPendingDeleteTracking(t *testing.T) {
 	})
 }
 
+func TestResolveNodeState(t *testing.T) {
+	Convey("When resolving node state atomically", t, func() {
+		fakeMaster := newFakeMaster()
+
+		Convey("returns false/false for unknown node and marks it processed", func() {
+			hasPending, alreadyProcessed := fakeMaster.resolveNodeState("new-node")
+
+			So(hasPending, ShouldBeFalse)
+			So(alreadyProcessed, ShouldBeFalse)
+			_, alreadyProcessed2 := fakeMaster.resolveNodeState("new-node")
+			So(alreadyProcessed2, ShouldBeTrue)
+		})
+
+		Convey("consumes pending delete and returns true/false on first call", func() {
+			fakeMaster.markPendingDelete("pending-node")
+
+			hasPending, alreadyProcessed := fakeMaster.resolveNodeState("pending-node")
+
+			So(hasPending, ShouldBeTrue)
+			So(alreadyProcessed, ShouldBeFalse)
+			hasPending2, alreadyProcessed2 := fakeMaster.resolveNodeState("pending-node")
+			So(hasPending2, ShouldBeFalse)
+			So(alreadyProcessed2, ShouldBeTrue)
+		})
+
+		Convey("returns false/true for already-processed node with no pending delete", func() {
+			fakeMaster.resolveNodeState("processed-node")
+
+			hasPending, alreadyProcessed := fakeMaster.resolveNodeState("processed-node")
+
+			So(hasPending, ShouldBeFalse)
+			So(alreadyProcessed, ShouldBeTrue)
+		})
+
+		Convey("handles pending delete on already-processed node", func() {
+			fakeMaster.resolveNodeState("reprocess-node")
+			fakeMaster.markPendingDelete("reprocess-node")
+
+			hasPending, alreadyProcessed := fakeMaster.resolveNodeState("reprocess-node")
+
+			So(hasPending, ShouldBeTrue)
+			So(alreadyProcessed, ShouldBeTrue)
+		})
+	})
+}
+
 func TestUpdateNodeObjectSkipRemoval(t *testing.T) {
 	Convey("When updating node with skipRemoval=true", t, func() {
 		testNode := newTestNode()

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -29,6 +29,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -154,14 +155,29 @@ type nfdMaster struct {
 
 	// isLeader indicates if this instance is the leader, changing dynamically
 	isLeader bool
+
+	// pendingDeletesMu protects pendingDeletes and processedOnce
+	pendingDeletesMu sync.Mutex
+	// pendingDeletes tracks nodes that have pending NodeFeature delete events.
+	// This is used to distinguish between "NodeFeature was deleted" vs
+	// "NodeFeature is missing from cache due to incomplete sync".
+	// Only nodes in this set should have their labels removed when no
+	// NodeFeature is found.
+	pendingDeletes sets.Set[string]
+	// processedOnce tracks nodes that have been processed at least once.
+	// This is used to allow label removal on subsequent processing even if
+	// no NodeFeature exists (e.g., when NodeFeatureRules are deleted).
+	processedOnce sets.Set[string]
 }
 
 // NewNfdMaster creates a new NfdMaster server instance.
 func NewNfdMaster(opts ...NfdMasterOption) (NfdMaster, error) {
 	nfd := &nfdMaster{
-		nodeName:  utils.NodeName(),
-		namespace: utils.GetKubernetesNamespace(),
-		stop:      make(chan struct{}),
+		nodeName:       utils.NodeName(),
+		namespace:      utils.GetKubernetesNamespace(),
+		stop:           make(chan struct{}),
+		pendingDeletes: sets.New[string](),
+		processedOnce:  sets.New[string](),
 	}
 
 	for _, o := range opts {
@@ -421,7 +437,7 @@ func (m *nfdMaster) prune() error {
 		klog.InfoS("pruning node...", "nodeName", node.Name)
 
 		// Prune labels and extended resources
-		err := m.updateNodeObject(m.k8sClient, &node, Labels{}, Annotations{}, ExtendedResources{}, []corev1.Taint{})
+		err := m.updateNodeObject(m.k8sClient, &node, Labels{}, Annotations{}, ExtendedResources{}, []corev1.Taint{}, false)
 		if err != nil {
 			nodeUpdateFailures.Inc()
 			return fmt.Errorf("failed to prune node %q: %v", node.Name, err)
@@ -587,7 +603,10 @@ func (m *nfdMaster) nfdAPIUpdateAllNodes() error {
 
 // getAndMergeNodeFeatures merges the NodeFeature objects of the given node into a single NodeFeatureSpec.
 // The Name field of the returned NodeFeatureSpec contains the node name.
-func (m *nfdMaster) getAndMergeNodeFeatures(nodeName string) (*nfdv1alpha1.NodeFeature, error) {
+// The second return value indicates whether any NodeFeature objects were found in the cache
+// (before namespace filtering). This helps distinguish between "no NodeFeature exists" and
+// "NodeFeature exists but is filtered out by namespace selector".
+func (m *nfdMaster) getAndMergeNodeFeatures(nodeName string) (*nfdv1alpha1.NodeFeature, bool, error) {
 	nodeFeatures := &nfdv1alpha1.NodeFeature{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,
@@ -597,8 +616,11 @@ func (m *nfdMaster) getAndMergeNodeFeatures(nodeName string) (*nfdv1alpha1.NodeF
 	sel := k8slabels.SelectorFromSet(k8slabels.Set{nfdv1alpha1.NodeFeatureObjNodeNameLabel: nodeName})
 	objs, err := m.featureLister.List(sel)
 	if err != nil {
-		return &nfdv1alpha1.NodeFeature{}, fmt.Errorf("failed to get NodeFeature resources for node %q: %w", nodeName, err)
+		return &nfdv1alpha1.NodeFeature{}, false, fmt.Errorf("failed to get NodeFeature resources for node %q: %w", nodeName, err)
 	}
+
+	// Track whether we found any objects in the cache (before namespace filtering)
+	foundInCache := len(objs) > 0
 
 	filteredObjs := []*nfdv1alpha1.NodeFeature{}
 	for _, obj := range objs {
@@ -607,9 +629,9 @@ func (m *nfdMaster) getAndMergeNodeFeatures(nodeName string) (*nfdv1alpha1.NodeF
 		}
 	}
 
-	// Node without a running NFD-Worker
+	// Node without a running NFD-Worker or all NodeFeatures filtered by namespace
 	if len(filteredObjs) == 0 {
-		return &nfdv1alpha1.NodeFeature{}, nil
+		return &nfdv1alpha1.NodeFeature{}, foundInCache, nil
 	}
 
 	// Sort our objects
@@ -665,7 +687,7 @@ func (m *nfdMaster) getAndMergeNodeFeatures(nodeName string) (*nfdv1alpha1.NodeF
 		klog.V(4).InfoS("merged nodeFeatureSpecs", "newNodeFeatureSpec", utils.DelayedDumper(features))
 	}
 
-	return nodeFeatures, nil
+	return nodeFeatures, foundInCache, nil
 }
 
 // isThirdPartyNodeFeature determines whether a node feature is a third party one or created by nfd-worker
@@ -674,20 +696,107 @@ func (m *nfdMaster) isThirdPartyNodeFeature(nodeFeature nfdv1alpha1.NodeFeature,
 }
 
 func (m *nfdMaster) nfdAPIUpdateOneNode(cli k8sclient.Interface, node *corev1.Node) error {
-	// Merge all NodeFeature objects into a single NodeFeatureSpec
-	nodeFeatures, err := m.getAndMergeNodeFeatures(node.Name)
+	// Merge all NodeFeature objects into a single NodeFeatureSpec.
+	// foundInCache indicates whether any NodeFeature objects were found in the
+	// informer cache (before namespace filtering).
+	nodeFeatures, foundInCache, err := m.getAndMergeNodeFeatures(node.Name)
 	if err != nil {
 		return fmt.Errorf("failed to merge NodeFeature objects for node %q: %w", node.Name, err)
 	}
 
+	// Check if we have any features for this node
+	hasFeatures := len(nodeFeatures.Spec.Labels) > 0 ||
+		len(nodeFeatures.Spec.Features.Attributes) > 0 ||
+		len(nodeFeatures.Spec.Features.Flags) > 0 ||
+		len(nodeFeatures.Spec.Features.Instances) > 0
+
+	// Determine if we should skip removing NodeFeature-sourced labels.
+	// This is needed to handle cache-miss scenarios during startup where
+	// pagination failures (410 Expired errors) can cause NodeFeatures to be
+	// missing from the informer cache.
+	//
+	// We skip label removal only when ALL of these are true:
+	// - No NodeFeature found in cache (!foundInCache)
+	// - No pending delete marker (not an explicit deletion)
+	// - This node hasn't been processed before (first time during startup)
+	//
+	// After initial processing, subsequent updates proceed normally to allow
+	// label cleanup when NodeFeatureRules are deleted.
+	skipNodeFeatureLabelRemoval := false
+	if !hasFeatures {
+		hasPendingDelete := m.consumePendingDelete(node.Name)
+		alreadyProcessed := m.wasNodeProcessedOnce(node.Name)
+		if !hasPendingDelete && !foundInCache && !alreadyProcessed {
+			// First time processing this node with no NodeFeature and no pending delete.
+			// Could be cache miss during startup, skip label removal this time only.
+			skipNodeFeatureLabelRemoval = true
+			klog.V(2).InfoS("first processing of node with no NodeFeature in cache, "+
+				"skipping label removal (possible startup cache miss)",
+				"nodeName", node.Name)
+		} else if hasPendingDelete {
+			klog.V(2).InfoS("NodeFeature deleted, proceeding with label removal",
+				"nodeName", node.Name)
+		}
+	} else {
+		// Features exist, so we'll update normally. Clean up any stale pending
+		// delete marker that might exist (e.g., if a NodeFeature was deleted
+		// but a new one was created before we processed the update).
+		m.consumePendingDelete(node.Name)
+	}
+	// Mark node as processed for subsequent updates
+	m.markNodeProcessedOnce(node.Name)
+
 	// Update node labels et al. This may also mean removing all NFD-owned
-	// labels (et al.), for example  in the case no NodeFeature objects are
-	// present.
-	if err := m.refreshNodeFeatures(cli, node, nodeFeatures.Spec.Labels, &nodeFeatures.Spec.Features); err != nil {
+	// labels (et al.), for example in the case no NodeFeature objects are
+	// present and we have a confirmed delete event.
+	if err := m.refreshNodeFeatures(cli, node, nodeFeatures.Spec.Labels, &nodeFeatures.Spec.Features, skipNodeFeatureLabelRemoval); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// markPendingDelete marks a node as having a pending NodeFeature delete event.
+// This should be called from the DeleteFunc handler in the informer.
+func (m *nfdMaster) markPendingDelete(nodeName string) {
+	m.pendingDeletesMu.Lock()
+	defer m.pendingDeletesMu.Unlock()
+	m.pendingDeletes.Insert(nodeName)
+	klog.V(3).InfoS("marked node for pending delete", "nodeName", nodeName)
+}
+
+// consumePendingDelete checks if a node has a pending delete and removes it
+// from the set. Returns true if the node was in the pending deletes set.
+func (m *nfdMaster) consumePendingDelete(nodeName string) bool {
+	m.pendingDeletesMu.Lock()
+	defer m.pendingDeletesMu.Unlock()
+	if m.pendingDeletes.Has(nodeName) {
+		m.pendingDeletes.Delete(nodeName)
+		return true
+	}
+	return false
+}
+
+// wasNodeProcessedOnce returns true if the node has been processed at least once.
+func (m *nfdMaster) wasNodeProcessedOnce(nodeName string) bool {
+	m.pendingDeletesMu.Lock()
+	defer m.pendingDeletesMu.Unlock()
+	return m.processedOnce.Has(nodeName)
+}
+
+// markNodeProcessedOnce marks a node as having been processed at least once.
+func (m *nfdMaster) markNodeProcessedOnce(nodeName string) {
+	m.pendingDeletesMu.Lock()
+	defer m.pendingDeletesMu.Unlock()
+	m.processedOnce.Insert(nodeName)
+}
+
+// clearNodeProcessedOnce removes a node from the processedOnce set.
+// This is called when a node no longer exists to prevent memory leaks.
+func (m *nfdMaster) clearNodeProcessedOnce(nodeName string) {
+	m.pendingDeletesMu.Lock()
+	defer m.pendingDeletesMu.Unlock()
+	m.processedOnce.Delete(nodeName)
 }
 
 func (m *nfdMaster) nfdAPIUpdateAllNodeFeatureGroups() error {
@@ -720,7 +829,7 @@ func (m *nfdMaster) nfdAPIUpdateNodeFeatureGroup(nfdClient nfdclientset.Interfac
 	nodeFeaturesList := make([]*nfdv1alpha1.Features, 0)
 	for _, node := range nodes.Items {
 		// Merge all NodeFeature objects into a single NodeFeatureSpec
-		nodeFeatures, err := m.getAndMergeNodeFeatures(node.Name)
+		nodeFeatures, _, err := m.getAndMergeNodeFeatures(node.Name)
 		if err != nil {
 			return fmt.Errorf("failed to merge NodeFeature objects for node %q: %w", node.Name, err)
 		}
@@ -816,7 +925,7 @@ func filterExtendedResource(name, value string, features *nfdv1alpha1.Features) 
 	return filteredValue, nil
 }
 
-func (m *nfdMaster) refreshNodeFeatures(cli k8sclient.Interface, node *corev1.Node, labels map[string]string, features *nfdv1alpha1.Features) error {
+func (m *nfdMaster) refreshNodeFeatures(cli k8sclient.Interface, node *corev1.Node, labels map[string]string, features *nfdv1alpha1.Features, skipNodeFeatureLabelRemoval bool) error {
 	if !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.DisableAutoPrefix) {
 		labels = addNsToMapKeys(labels, nfdv1alpha1.FeatureLabelNs)
 	} else if labels == nil {
@@ -851,7 +960,7 @@ func (m *nfdMaster) refreshNodeFeatures(cli k8sclient.Interface, node *corev1.No
 		return nil
 	}
 
-	err := m.updateNodeObject(cli, node, labels, annotations, extendedResources, taints)
+	err := m.updateNodeObject(cli, node, labels, annotations, extendedResources, taints, skipNodeFeatureLabelRemoval)
 	if err != nil {
 		klog.ErrorS(err, "failed to update node", "nodeName", node.Name)
 		return err
@@ -1000,7 +1109,10 @@ func (m *nfdMaster) processNodeFeatureRule(nodeName string, features *nfdv1alpha
 // updateNodeObject ensures the Kubernetes node object is up to date,
 // creating new labels and extended resources where necessary and removing
 // outdated ones. Also updates the corresponding annotations.
-func (m *nfdMaster) updateNodeObject(cli k8sclient.Interface, node *corev1.Node, labels Labels, featureAnnotations Annotations, extendedResources ExtendedResources, taints []corev1.Taint) error {
+// If skipLabelRemoval is true, existing labels will not be removed (but new
+// labels will still be added). This is used when the informer cache may be
+// incomplete to avoid removing labels that should still exist.
+func (m *nfdMaster) updateNodeObject(cli k8sclient.Interface, node *corev1.Node, labels Labels, featureAnnotations Annotations, extendedResources ExtendedResources, taints []corev1.Taint, skipLabelRemoval bool) error {
 	annotations := make(Annotations)
 
 	// Store names of labels in an annotation
@@ -1041,15 +1153,33 @@ func (m *nfdMaster) updateNodeObject(cli k8sclient.Interface, node *corev1.Node,
 	// Create JSON patches for changes in labels and annotations
 	oldLabels := stringToNsNames(node.Annotations[m.instanceAnnotation(nfdv1alpha1.FeatureLabelsAnnotation)], nfdv1alpha1.FeatureLabelNs)
 	oldAnnotations := stringToNsNames(node.Annotations[m.instanceAnnotation(nfdv1alpha1.FeatureAnnotationsTrackingAnnotation)], nfdv1alpha1.FeatureAnnotationNs)
-	patches := createPatches(sets.New(oldLabels...), node.Labels, labels, "/metadata/labels", m.config.Restrictions.AllowOverwrite)
-	oldAnnotations = append(oldAnnotations, []string{
-		m.instanceAnnotation(nfdv1alpha1.FeatureLabelsAnnotation),
-		m.instanceAnnotation(nfdv1alpha1.ExtendedResourceAnnotation),
-		m.instanceAnnotation(nfdv1alpha1.FeatureAnnotationsTrackingAnnotation),
-		// Clean up deprecated/stale nfd version annotations
-		m.instanceAnnotation(nfdv1alpha1.MasterVersionAnnotation),
-		m.instanceAnnotation(nfdv1alpha1.WorkerVersionAnnotation)}...)
-	patches = append(patches, createPatches(sets.New(oldAnnotations...), node.Annotations, annotations, "/metadata/annotations", m.config.Restrictions.AllowOverwrite)...)
+
+	// When skipLabelRemoval is true, we don't want to remove any existing labels
+	// or annotations. This is used when the informer cache may be incomplete
+	// (e.g., during startup or watch reconnection) to avoid removing labels that
+	// should still exist. We still add new labels from NodeFeatureRules.
+	var labelsToRemove sets.Set[string]
+	var annotationsToRemove sets.Set[string]
+	if skipLabelRemoval {
+		labelsToRemove = sets.New[string]()
+		annotationsToRemove = sets.New[string]()
+		klog.V(2).InfoS("skipping label/annotation removal due to potential cache miss",
+			"nodeName", node.Name)
+	} else {
+		labelsToRemove = sets.New(oldLabels...)
+		annotationsToRemove = sets.New(oldAnnotations...)
+		annotationsToRemove.Insert(
+			m.instanceAnnotation(nfdv1alpha1.FeatureLabelsAnnotation),
+			m.instanceAnnotation(nfdv1alpha1.ExtendedResourceAnnotation),
+			m.instanceAnnotation(nfdv1alpha1.FeatureAnnotationsTrackingAnnotation),
+			// Clean up deprecated/stale nfd version annotations
+			m.instanceAnnotation(nfdv1alpha1.MasterVersionAnnotation),
+			m.instanceAnnotation(nfdv1alpha1.WorkerVersionAnnotation),
+		)
+	}
+
+	patches := createPatches(labelsToRemove, node.Labels, labels, "/metadata/labels", m.config.Restrictions.AllowOverwrite)
+	patches = append(patches, createPatches(annotationsToRemove, node.Annotations, annotations, "/metadata/annotations", m.config.Restrictions.AllowOverwrite)...)
 
 	// patch node status with extended resource changes
 	statusPatches := m.createExtendedResourcePatches(node, extendedResources)
@@ -1303,6 +1433,7 @@ func (m *nfdMaster) startNfdApiController() error {
 		NodeFeatureNamespaceSelector: m.config.Restrictions.NodeFeatureNamespaceSelector,
 		DisableNodeFeatureGroup:      !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.NodeFeatureGroupAPI),
 		ListSize:                     m.config.InformerPageSize,
+		OnNodeFeatureDelete:          m.markPendingDelete,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize CRD controller: %w", err)

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -361,6 +361,18 @@ func (m *nfdMaster) nfdAPIUpdateHandler() {
 	nodeFeatureGroup := make(map[string]struct{})
 	updateAllNodeFeatureGroups := false
 	rateLimit := time.After(time.Second)
+
+	// Periodic reconciliation: re-process all nodes at the resync interval
+	// to catch nodes whose NodeFeatures were genuinely absent (not cache misses).
+	// A nil channel blocks forever in select, effectively disabling the case
+	// when ResyncPeriod is zero (which would panic in time.NewTicker).
+	var resyncTickerC <-chan time.Time
+	if m.config.ResyncPeriod.Duration > 0 {
+		resyncTicker := time.NewTicker(m.config.ResyncPeriod.Duration)
+		defer resyncTicker.Stop()
+		resyncTickerC = resyncTicker.C
+	}
+
 	for {
 		select {
 		case <-m.updateAllNodesChan:
@@ -371,6 +383,9 @@ func (m *nfdMaster) nfdAPIUpdateHandler() {
 			updateAllNodeFeatureGroups = true
 		case nodeFeatureGroupName := <-m.updateNodeFeatureGroupChan:
 			nodeFeatureGroup[nodeFeatureGroupName] = struct{}{}
+		case <-resyncTickerC:
+			klog.V(1).InfoS("periodic reconciliation triggered")
+			updateAll = true
 		case <-rateLimit:
 			// If we're not the leader, don't do anything, sleep a bit longer
 			if !m.isLeader {

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -725,18 +725,19 @@ func (m *nfdMaster) nfdAPIUpdateOneNode(cli k8sclient.Interface, node *corev1.No
 		len(nodeFeatures.Spec.Features.Flags) > 0 ||
 		len(nodeFeatures.Spec.Features.Instances) > 0
 
-	// Determine if we should skip removing NodeFeature-sourced labels.
-	// This is needed to handle cache-miss scenarios during startup where
-	// pagination failures (410 Expired errors) can cause NodeFeatures to be
-	// missing from the informer cache.
+	// Determine if we should skip removing NFD-managed node properties
+	// (labels, annotations, extended resources, taints). This is needed to
+	// handle cache-miss scenarios during startup where pagination failures
+	// (410 Expired errors) can cause NodeFeatures to be missing from the
+	// informer cache.
 	//
-	// We skip label removal only when ALL of these are true:
+	// We skip removal only when ALL of these are true:
 	// - No NodeFeature found in cache (!foundInCache)
 	// - No pending delete marker (not an explicit deletion)
 	// - This node hasn't been processed before (first time during startup)
 	//
 	// After initial processing, subsequent updates proceed normally to allow
-	// label cleanup when NodeFeatureRules are deleted.
+	// cleanup when NodeFeatures are deleted or NodeFeatureRules change.
 	// Atomically resolve pending-delete and processed-once state.
 	// This consumes any pending delete marker and marks the node as processed.
 	hasPendingDelete, alreadyProcessed := m.resolveNodeState(node.Name)
@@ -775,6 +776,8 @@ func (m *nfdMaster) markPendingDelete(nodeName string) {
 
 // consumePendingDelete checks if a node has a pending delete and removes it
 // from the set. Returns true if the node was in the pending deletes set.
+// Retained for use in updater-pool.go cleanup path; the normal processing
+// path uses resolveNodeState instead for atomic state resolution.
 func (m *nfdMaster) consumePendingDelete(nodeName string) bool {
 	m.pendingDeletesMu.Lock()
 	defer m.pendingDeletesMu.Unlock()
@@ -1039,6 +1042,7 @@ func (m *nfdMaster) setTaints(cli k8sclient.Interface, taints []corev1.Taint, no
 		allTaintStrs := []string{}
 		if val, ok := node.Annotations[nfdv1alpha1.NodeTaintsAnnotation]; ok && val != "" {
 			for _, s := range strings.Split(val, ",") {
+				s = strings.TrimSpace(s)
 				if _, exists := taintSet[s]; !exists {
 					taintSet[s] = struct{}{}
 					allTaintStrs = append(allTaintStrs, s)
@@ -1167,7 +1171,10 @@ func (m *nfdMaster) updateNodeObject(cli k8sclient.Interface, node *corev1.Node,
 		annotations[m.instanceAnnotation(nfdv1alpha1.FeatureLabelsAnnotation)] = strings.Join(labelKeys, ",")
 	}
 
-	// Store names of extended resources in an annotation
+	// Store names of extended resources in an annotation.
+	// Note: when skipRemoval=true, this only tracks the current set of new
+	// resource keys (not merged with old). This is acceptable because the next
+	// normal pass (after processedOnce=true) will rebuild the annotation fully.
 	if len(extendedResources) > 0 {
 		extendedResourceKeys := make([]string, 0, len(extendedResources))
 		for key := range extendedResources {

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -722,29 +722,22 @@ func (m *nfdMaster) nfdAPIUpdateOneNode(cli k8sclient.Interface, node *corev1.No
 	//
 	// After initial processing, subsequent updates proceed normally to allow
 	// label cleanup when NodeFeatureRules are deleted.
+	// Atomically resolve pending-delete and processed-once state.
+	// This consumes any pending delete marker and marks the node as processed.
+	hasPendingDelete, alreadyProcessed := m.resolveNodeState(node.Name)
+
 	skipRemoval := false
 	if !hasFeatures {
-		hasPendingDelete := m.consumePendingDelete(node.Name)
-		alreadyProcessed := m.wasNodeProcessedOnce(node.Name)
 		if !hasPendingDelete && !foundInCache && !alreadyProcessed {
-			// First time processing this node with no NodeFeature and no pending delete.
-			// Could be cache miss during startup, skip label removal this time only.
 			skipRemoval = true
 			klog.V(2).InfoS("first processing of node with no NodeFeature in cache, "+
-				"skipping label removal (possible startup cache miss)",
+				"skipping removal (possible startup cache miss)",
 				"nodeName", node.Name)
 		} else if hasPendingDelete {
-			klog.V(2).InfoS("NodeFeature deleted, proceeding with label removal",
+			klog.V(2).InfoS("NodeFeature deleted, proceeding with removal",
 				"nodeName", node.Name)
 		}
-	} else {
-		// Features exist, so we'll update normally. Clean up any stale pending
-		// delete marker that might exist (e.g., if a NodeFeature was deleted
-		// but a new one was created before we processed the update).
-		m.consumePendingDelete(node.Name)
 	}
-	// Mark node as processed for subsequent updates
-	m.markNodeProcessedOnce(node.Name)
 
 	// Update node labels et al. This may also mean removing all NFD-owned
 	// labels (et al.), for example in the case no NodeFeature objects are
@@ -777,18 +770,22 @@ func (m *nfdMaster) consumePendingDelete(nodeName string) bool {
 	return false
 }
 
-// wasNodeProcessedOnce returns true if the node has been processed at least once.
-func (m *nfdMaster) wasNodeProcessedOnce(nodeName string) bool {
+// resolveNodeState atomically checks and updates the pending-delete and
+// processed-once state for a node. This combines what would otherwise be
+// three separate lock/unlock cycles into one atomic operation.
+// Both pendingDeletes and processedOnce are protected by pendingDeletesMu.
+func (m *nfdMaster) resolveNodeState(nodeName string) (hasPendingDelete, alreadyProcessed bool) {
 	m.pendingDeletesMu.Lock()
 	defer m.pendingDeletesMu.Unlock()
-	return m.processedOnce.Has(nodeName)
-}
 
-// markNodeProcessedOnce marks a node as having been processed at least once.
-func (m *nfdMaster) markNodeProcessedOnce(nodeName string) {
-	m.pendingDeletesMu.Lock()
-	defer m.pendingDeletesMu.Unlock()
+	hasPendingDelete = m.pendingDeletes.Has(nodeName)
+	if hasPendingDelete {
+		m.pendingDeletes.Delete(nodeName)
+	}
+	alreadyProcessed = m.processedOnce.Has(nodeName)
 	m.processedOnce.Insert(nodeName)
+
+	return
 }
 
 // clearNodeProcessedOnce removes a node from the processedOnce set.

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -1179,7 +1179,7 @@ func (m *nfdMaster) updateNodeObject(cli k8sclient.Interface, node *corev1.Node,
 	patches = append(patches, createPatches(annotationsToRemove, node.Annotations, annotations, "/metadata/annotations", m.config.Restrictions.AllowOverwrite)...)
 
 	// patch node status with extended resource changes
-	statusPatches := m.createExtendedResourcePatches(node, extendedResources)
+	statusPatches := m.createExtendedResourcePatches(node, extendedResources, skipRemoval)
 	err := patchNodeStatus(cli, node.Name, statusPatches)
 	if err != nil {
 		return fmt.Errorf("error while patching extended resources: %w", err)
@@ -1236,19 +1236,21 @@ func createPatches(removeKeys sets.Set[string], oldItems map[string]string, newI
 
 // createExtendedResourcePatches returns a slice of operations to perform on
 // the node status
-func (m *nfdMaster) createExtendedResourcePatches(n *corev1.Node, extendedResources ExtendedResources) []utils.JsonPatch {
+func (m *nfdMaster) createExtendedResourcePatches(n *corev1.Node, extendedResources ExtendedResources, skipRemoval bool) []utils.JsonPatch {
 	patches := []utils.JsonPatch{}
 
 	// Form a list of namespaced resource names managed by us
 	oldResources := stringToNsNames(n.Annotations[m.instanceAnnotation(nfdv1alpha1.ExtendedResourceAnnotation)], nfdv1alpha1.FeatureLabelNs)
 
 	// figure out which resources to remove
-	for _, resource := range oldResources {
-		if _, ok := n.Status.Capacity[corev1.ResourceName(resource)]; ok {
-			// check if the ext resource is still needed
-			if _, extResNeeded := extendedResources[resource]; !extResNeeded {
-				patches = append(patches, utils.NewJsonPatch("remove", "/status/capacity", resource, ""))
-				patches = append(patches, utils.NewJsonPatch("remove", "/status/allocatable", resource, ""))
+	if !skipRemoval {
+		for _, resource := range oldResources {
+			if _, ok := n.Status.Capacity[corev1.ResourceName(resource)]; ok {
+				// check if the ext resource is still needed
+				if _, extResNeeded := extendedResources[resource]; !extResNeeded {
+					patches = append(patches, utils.NewJsonPatch("remove", "/status/capacity", resource, ""))
+					patches = append(patches, utils.NewJsonPatch("remove", "/status/allocatable", resource, ""))
+				}
 			}
 		}
 	}

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -969,7 +969,7 @@ func (m *nfdMaster) refreshNodeFeatures(cli k8sclient.Interface, node *corev1.No
 // setTaints sets node taints and annotations based on the taints passed via
 // nodeFeatureRule custom resorce. If empty list of taints is passed, currently
 // NFD owned taints and annotations are removed from the node.
-func (m *nfdMaster) setTaints(cli k8sclient.Interface, taints []corev1.Taint, node *corev1.Node) error {
+func (m *nfdMaster) setTaints(cli k8sclient.Interface, taints []corev1.Taint, node *corev1.Node, skipRemoval bool) error {
 	// De-serialize the taints annotation into corev1.Taint type for comparision below.
 	var err error
 	oldTaints := []corev1.Taint{}
@@ -984,17 +984,19 @@ func (m *nfdMaster) setTaints(cli k8sclient.Interface, taints []corev1.Taint, no
 	// Delete old nfd-managed taints that are not found in the set of new taints.
 	taintsUpdated := false
 	newNode := node.DeepCopy()
-	for _, taintToRemove := range oldTaints {
-		if taintutils.TaintExists(taints, &taintToRemove) {
-			continue
-		}
+	if !skipRemoval {
+		for _, taintToRemove := range oldTaints {
+			if taintutils.TaintExists(taints, &taintToRemove) {
+				continue
+			}
 
-		newTaints, removed := taintutils.DeleteTaint(newNode.Spec.Taints, &taintToRemove)
-		if !removed {
-			klog.V(1).InfoS("taint already deleted from node", "taint", taintToRemove)
+			newTaints, removed := taintutils.DeleteTaint(newNode.Spec.Taints, &taintToRemove)
+			if !removed {
+				klog.V(1).InfoS("taint already deleted from node", "taint", taintToRemove)
+			}
+			taintsUpdated = taintsUpdated || removed
+			newNode.Spec.Taints = newTaints
 		}
-		taintsUpdated = taintsUpdated || removed
-		newNode.Spec.Taints = newTaints
 	}
 
 	// Add new taints found in the set of new taints.
@@ -1016,17 +1018,44 @@ func (m *nfdMaster) setTaints(cli k8sclient.Interface, taints []corev1.Taint, no
 
 	// Update node annotation that holds the taints managed by us
 	newAnnotations := map[string]string{}
-	if len(taints) > 0 {
-		// Serialize the new taints into string and update the annotation
-		// with that string.
-		taintStrs := make([]string, 0, len(taints))
-		for _, taint := range taints {
-			taintStrs = append(taintStrs, taint.ToString())
+	if skipRemoval {
+		// Merge: keep existing taints in annotation, add new ones (deduplicated)
+		taintSet := make(map[string]struct{})
+		allTaintStrs := []string{}
+		if val, ok := node.Annotations[nfdv1alpha1.NodeTaintsAnnotation]; ok && val != "" {
+			for _, s := range strings.Split(val, ",") {
+				if _, exists := taintSet[s]; !exists {
+					taintSet[s] = struct{}{}
+					allTaintStrs = append(allTaintStrs, s)
+				}
+			}
 		}
-		newAnnotations[nfdv1alpha1.NodeTaintsAnnotation] = strings.Join(taintStrs, ",")
+		for _, taint := range taints {
+			s := taint.ToString()
+			if _, exists := taintSet[s]; !exists {
+				taintSet[s] = struct{}{}
+				allTaintStrs = append(allTaintStrs, s)
+			}
+		}
+		if len(allTaintStrs) > 0 {
+			newAnnotations[nfdv1alpha1.NodeTaintsAnnotation] = strings.Join(allTaintStrs, ",")
+		}
+	} else {
+		if len(taints) > 0 {
+			taintStrs := make([]string, 0, len(taints))
+			for _, taint := range taints {
+				taintStrs = append(taintStrs, taint.ToString())
+			}
+			newAnnotations[nfdv1alpha1.NodeTaintsAnnotation] = strings.Join(taintStrs, ",")
+		}
 	}
 
-	patches := createPatches(sets.New([]string{nfdv1alpha1.NodeTaintsAnnotation}...),
+	// When skipRemoval=true, don't remove the taint annotation
+	removeSet := sets.New([]string{nfdv1alpha1.NodeTaintsAnnotation}...)
+	if skipRemoval {
+		removeSet = sets.New[string]()
+	}
+	patches := createPatches(removeSet,
 		node.Annotations, newAnnotations,
 		"/metadata/annotations",
 		m.config.Restrictions.AllowOverwrite,
@@ -1199,7 +1228,7 @@ func (m *nfdMaster) updateNodeObject(cli k8sclient.Interface, node *corev1.Node,
 	}
 
 	// Set taints
-	err = m.setTaints(cli, taints, node)
+	err = m.setTaints(cli, taints, node, skipRemoval)
 	if err != nil {
 		return err
 	}

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -722,14 +722,14 @@ func (m *nfdMaster) nfdAPIUpdateOneNode(cli k8sclient.Interface, node *corev1.No
 	//
 	// After initial processing, subsequent updates proceed normally to allow
 	// label cleanup when NodeFeatureRules are deleted.
-	skipNodeFeatureLabelRemoval := false
+	skipRemoval := false
 	if !hasFeatures {
 		hasPendingDelete := m.consumePendingDelete(node.Name)
 		alreadyProcessed := m.wasNodeProcessedOnce(node.Name)
 		if !hasPendingDelete && !foundInCache && !alreadyProcessed {
 			// First time processing this node with no NodeFeature and no pending delete.
 			// Could be cache miss during startup, skip label removal this time only.
-			skipNodeFeatureLabelRemoval = true
+			skipRemoval = true
 			klog.V(2).InfoS("first processing of node with no NodeFeature in cache, "+
 				"skipping label removal (possible startup cache miss)",
 				"nodeName", node.Name)
@@ -749,7 +749,7 @@ func (m *nfdMaster) nfdAPIUpdateOneNode(cli k8sclient.Interface, node *corev1.No
 	// Update node labels et al. This may also mean removing all NFD-owned
 	// labels (et al.), for example in the case no NodeFeature objects are
 	// present and we have a confirmed delete event.
-	if err := m.refreshNodeFeatures(cli, node, nodeFeatures.Spec.Labels, &nodeFeatures.Spec.Features, skipNodeFeatureLabelRemoval); err != nil {
+	if err := m.refreshNodeFeatures(cli, node, nodeFeatures.Spec.Labels, &nodeFeatures.Spec.Features, skipRemoval); err != nil {
 		return err
 	}
 
@@ -925,7 +925,7 @@ func filterExtendedResource(name, value string, features *nfdv1alpha1.Features) 
 	return filteredValue, nil
 }
 
-func (m *nfdMaster) refreshNodeFeatures(cli k8sclient.Interface, node *corev1.Node, labels map[string]string, features *nfdv1alpha1.Features, skipNodeFeatureLabelRemoval bool) error {
+func (m *nfdMaster) refreshNodeFeatures(cli k8sclient.Interface, node *corev1.Node, labels map[string]string, features *nfdv1alpha1.Features, skipRemoval bool) error {
 	if !nfdfeatures.NFDFeatureGate.Enabled(nfdfeatures.DisableAutoPrefix) {
 		labels = addNsToMapKeys(labels, nfdv1alpha1.FeatureLabelNs)
 	} else if labels == nil {
@@ -960,7 +960,7 @@ func (m *nfdMaster) refreshNodeFeatures(cli k8sclient.Interface, node *corev1.No
 		return nil
 	}
 
-	err := m.updateNodeObject(cli, node, labels, annotations, extendedResources, taints, skipNodeFeatureLabelRemoval)
+	err := m.updateNodeObject(cli, node, labels, annotations, extendedResources, taints, skipRemoval)
 	if err != nil {
 		klog.ErrorS(err, "failed to update node", "nodeName", node.Name)
 		return err
@@ -1109,10 +1109,10 @@ func (m *nfdMaster) processNodeFeatureRule(nodeName string, features *nfdv1alpha
 // updateNodeObject ensures the Kubernetes node object is up to date,
 // creating new labels and extended resources where necessary and removing
 // outdated ones. Also updates the corresponding annotations.
-// If skipLabelRemoval is true, existing labels will not be removed (but new
-// labels will still be added). This is used when the informer cache may be
-// incomplete to avoid removing labels that should still exist.
-func (m *nfdMaster) updateNodeObject(cli k8sclient.Interface, node *corev1.Node, labels Labels, featureAnnotations Annotations, extendedResources ExtendedResources, taints []corev1.Taint, skipLabelRemoval bool) error {
+// If skipRemoval is true, existing labels, annotations, extended resources,
+// and taints will not be removed (but new ones will still be added).
+// This is used when the informer cache may be incomplete.
+func (m *nfdMaster) updateNodeObject(cli k8sclient.Interface, node *corev1.Node, labels Labels, featureAnnotations Annotations, extendedResources ExtendedResources, taints []corev1.Taint, skipRemoval bool) error {
 	annotations := make(Annotations)
 
 	// Store names of labels in an annotation
@@ -1154,16 +1154,16 @@ func (m *nfdMaster) updateNodeObject(cli k8sclient.Interface, node *corev1.Node,
 	oldLabels := stringToNsNames(node.Annotations[m.instanceAnnotation(nfdv1alpha1.FeatureLabelsAnnotation)], nfdv1alpha1.FeatureLabelNs)
 	oldAnnotations := stringToNsNames(node.Annotations[m.instanceAnnotation(nfdv1alpha1.FeatureAnnotationsTrackingAnnotation)], nfdv1alpha1.FeatureAnnotationNs)
 
-	// When skipLabelRemoval is true, we don't want to remove any existing labels
+	// When skipRemoval is true, we don't want to remove any existing labels
 	// or annotations. This is used when the informer cache may be incomplete
 	// (e.g., during startup or watch reconnection) to avoid removing labels that
 	// should still exist. We still add new labels from NodeFeatureRules.
 	var labelsToRemove sets.Set[string]
 	var annotationsToRemove sets.Set[string]
-	if skipLabelRemoval {
+	if skipRemoval {
 		labelsToRemove = sets.New[string]()
 		annotationsToRemove = sets.New[string]()
-		klog.V(2).InfoS("skipping label/annotation removal due to potential cache miss",
+		klog.V(2).InfoS("skipping removal due to potential cache miss",
 			"nodeName", node.Name)
 	} else {
 		labelsToRemove = sets.New(oldLabels...)

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -719,12 +719,6 @@ func (m *nfdMaster) nfdAPIUpdateOneNode(cli k8sclient.Interface, node *corev1.No
 		return fmt.Errorf("failed to merge NodeFeature objects for node %q: %w", node.Name, err)
 	}
 
-	// Check if we have any features for this node
-	hasFeatures := len(nodeFeatures.Spec.Labels) > 0 ||
-		len(nodeFeatures.Spec.Features.Attributes) > 0 ||
-		len(nodeFeatures.Spec.Features.Flags) > 0 ||
-		len(nodeFeatures.Spec.Features.Instances) > 0
-
 	// Determine if we should skip removing NFD-managed node properties
 	// (labels, annotations, extended resources, taints). This is needed to
 	// handle cache-miss scenarios during startup where pagination failures
@@ -743,15 +737,17 @@ func (m *nfdMaster) nfdAPIUpdateOneNode(cli k8sclient.Interface, node *corev1.No
 	hasPendingDelete, alreadyProcessed := m.resolveNodeState(node.Name)
 
 	skipRemoval := false
-	if !hasFeatures {
-		if !hasPendingDelete && !foundInCache && !alreadyProcessed {
-			skipRemoval = true
-			klog.V(2).InfoS("first processing of node with no NodeFeature in cache, "+
-				"skipping removal (possible startup cache miss)",
-				"nodeName", node.Name)
-		} else if hasPendingDelete {
+	if !nodeFeatures.HasFeatures() {
+		if hasPendingDelete {
 			klog.V(2).InfoS("NodeFeature deleted, proceeding with removal",
 				"nodeName", node.Name)
+		} else {
+			if !foundInCache && !alreadyProcessed {
+				skipRemoval = true
+				klog.V(2).InfoS("first processing of node with no NodeFeature in cache, "+
+					"skipping removal (possible startup cache miss)",
+					"nodeName", node.Name)
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes an issue where nfd-master would remove all NFD-managed labels from nodes when NodeFeature objects were missing from the informer cache. This commonly occurs in large clusters (1k+ nodes) during startup due to pagination failures (410 Expired errors) when syncing the informer cache.

The fix introduces a pending delete tracking mechanism:
- When a NodeFeature is explicitly deleted (DeleteFunc), the node is marked as having a pending delete
- When processing a node update, if no NodeFeature is found in cache:
  - If there's a pending delete marker: proceed with label removal
  - If no pending delete marker: skip label removal (cache miss)

Additionally, a 'processedOnce' mechanism ensures that label removal is only skipped for nodes that haven't been successfully processed before. This prevents regressions where labels from deleted NodeFeatureRules wouldn't be cleaned up.

Also includes:
- Fallback to object name in DeleteFunc when node-name label is missing
- Cleanup of stale pendingDeletes/processedOnce when nodes are deleted
- Comprehensive unit and E2E tests

Fixes: #2408