### PR TITLE
topology-updater: wait for NodeResourceTopology CRD at startup

### DIFF
--- a/deployment/base/rbac-topologyupdater/topologyupdater-clusterrole.yaml
+++ b/deployment/base/rbac-topologyupdater/topologyupdater-clusterrole.yaml
@@ -36,3 +36,11 @@ rules:
   - create
   - get
   - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/deployment/helm/node-feature-discovery/README.md
+++ b/deployment/helm/node-feature-discovery/README.md
@@ -267,7 +267,7 @@ NFD.
 |-----|------|---------|-------------|
 | topologyUpdater.config | string | `nil` | Configuration for the topology updater. See the [configuration reference](https://kubernetes-sigs.github.io/node-feature-discovery/master/reference/topology-updater-configuration-reference) for details. |
 | topologyUpdater.enable | bool | `false` | Specifies whether nfd-topology-updater should be deployed. |
-| topologyUpdater.createCRDs | bool | `false` | Create CustomResourceDefinitions for the TopologyUpdater. |
+| topologyUpdater.createCRDs | bool | `false` | Create the NodeResourceTopology CRD. This MUST be set to true when 'enable' is true, unless the CRD is installed separately (e.g., by another Helm release or external tool). If the CRD is missing, the topology-updater pods will fail with "NodeResourceTopology CRD is not installed" error. |
 | topologyUpdater.extraArgs | list | `[]` | Additional [command line arguments](https://kubernetes-sigs.github.io/node-feature-discovery/master/reference/topology-updater-commandline-reference) to pass to nfd-topology-updater. |
 | topologyUpdater.extraEnvs | list | `[]` | Additional environment variables to set in the nfd-topology-updater container. |
 | topologyUpdater.hostNetwork | bool | `false` | Run the container in the host's network namespace. |

--- a/deployment/helm/node-feature-discovery/templates/clusterrole.yaml
+++ b/deployment/helm/node-feature-discovery/templates/clusterrole.yaml
@@ -99,6 +99,14 @@ rules:
   - create
   - get
   - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
 {{- end }}
 
 {{- if and .Values.gc.enable .Values.gc.rbac.create }}

--- a/deployment/helm/node-feature-discovery/values.schema.json
+++ b/deployment/helm/node-feature-discovery/values.schema.json
@@ -615,7 +615,7 @@
                     ]
                 },
                 "createCRDs": {
-                    "description": "Create CustomResourceDefinitions for the TopologyUpdater.",
+                    "description": "Create the NodeResourceTopology CRD. This MUST be set to true when 'enable' is true, unless the CRD is installed separately (e.g., by another Helm release or external tool). If the CRD is missing, the topology-updater pods will fail with \"NodeResourceTopology CRD is not installed\" error.",
                     "type": "boolean"
                 },
                 "daemonsetAnnotations": {

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -754,7 +754,10 @@ topologyUpdater:
   # -- Specifies whether nfd-topology-updater should be deployed.
   # @section -- NFD-Topology-Updater
   enable: false
-  # -- Create CustomResourceDefinitions for the TopologyUpdater.
+  # -- Create the NodeResourceTopology CRD. This MUST be set to true when
+  # 'enable' is true, unless the CRD is installed separately (e.g., by another
+  # Helm release or external tool). If the CRD is missing, the topology-updater
+  # pods will fail with "NodeResourceTopology CRD is not installed" error.
   # @section -- NFD-Topology-Updater
   createCRDs: false
   # @schema $ref: $k8s/_definitions.json#/definitions/io.k8s.api.core.v1.Container/properties/args

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -285,7 +285,7 @@ NFD.
 |-----|------|---------|-------------|
 | topologyUpdater.config | string | `nil` | Configuration for the topology updater. See the [configuration reference](https://kubernetes-sigs.github.io/node-feature-discovery/master/reference/topology-updater-configuration-reference) for details. |
 | topologyUpdater.enable | bool | `false` | Specifies whether nfd-topology-updater should be deployed. |
-| topologyUpdater.createCRDs | bool | `false` | Create CustomResourceDefinitions for the TopologyUpdater. |
+| topologyUpdater.createCRDs | bool | `false` | Create the NodeResourceTopology CRD. This MUST be set to true when 'enable' is true, unless the CRD is installed separately (e.g., by another Helm release or external tool). If the CRD is missing, the topology-updater pods will fail with "NodeResourceTopology CRD is not installed" error. |
 | topologyUpdater.extraArgs | list | `[]` | Additional [command line arguments](https://kubernetes-sigs.github.io/node-feature-discovery/master/reference/topology-updater-commandline-reference) to pass to nfd-topology-updater. |
 | topologyUpdater.extraEnvs | list | `[]` | Additional environment variables to set in the nfd-topology-updater container. |
 | topologyUpdater.hostNetwork | bool | `false` | Run the container in the host's network namespace. |

--- a/docs/usage/nfd-topology-updater.md
+++ b/docs/usage/nfd-topology-updater.md
@@ -56,6 +56,29 @@ Preceding Kubernetes v1.23, the `kubelet` must be started with
 Starting from Kubernetes v1.23, the `KubeletPodResourcesGetAllocatable`
 [feature gate][feature-gate].  is enabled by default
 
+### NodeResourceTopology CRD
+
+The NFD-Topology-Updater requires the `NodeResourceTopology` Custom Resource
+Definition (CRD) to be installed in the cluster. Without this CRD, the
+topology-updater pods will fail with an error:
+
+```plaintext
+NodeResourceTopology CRD "noderesourcetopologies.topology.node.k8s.io" is not installed
+```
+
+When deploying with Helm, you **must** set `topologyUpdater.createCRDs=true`
+along with `topologyUpdater.enable=true`:
+
+```bash
+helm install nfd node-feature-discovery \
+  --set topologyUpdater.enable=true \
+  --set topologyUpdater.createCRDs=true
+```
+
+If you manage CRDs separately (e.g., through a dedicated CRD management tool or
+another Helm release), ensure the `NodeResourceTopology` CRD is installed before
+deploying the topology-updater
+
 ## Topology-Updater Configuration
 
 NFD-Topology-Updater supports configuration through a configuration file. The


### PR DESCRIPTION
## What this PR does / why we need it

This fixes an issue where `nfd-topology-updater` pods would crash repeatedly (CrashLoopBackOff) when the `NodeResourceTopology` CRD was not installed, providing an unhelpful error message.

## Changes

- Add `waitForNodeResourceTopologyCRD()` that waits with exponential backoff (5s to 60s max) for the CRD to become available
- Move HTTP server startup earlier so health probes pass during CRD wait
- Add RBAC permission for topology-updater to read CRDs
- Handle Forbidden errors gracefully (skip wait if no permission)
- Improve error message when NRT creation fails due to missing CRD
- Update documentation with CRD requirements section

## How it works

```
Pod starts → HTTP server starts (health OK) → Check CRD
                                                   ↓
                                            CRD missing?
                                            ↙         ↘
                                         Yes           No
                                          ↓             ↓
                                   Wait & retry    Continue normal operation
                                   (5s→10s→...→60s)
```

This handles:
- Race conditions during deployment where CRD is created after topology-updater starts
- System admin scenarios where CRD is installed separately
- Graceful degradation when RBAC permissions are missing

## Which issue(s) this PR fixes

Fixes #2145

## Special notes for your reviewer

- The HTTP server is now started earlier in the initialization sequence so that health probes pass while waiting for the CRD
- RBAC permissions to read CRDs are added to both Helm chart and kustomize base
- If the ServiceAccount lacks permission to check CRDs (Forbidden error), the wait is skipped and the actual NRT creation will fail with a descriptive error

## Does this PR introduce a user-facing change?

```release-note
nfd-topology-updater now waits for the NodeResourceTopology CRD to be available at startup instead of crashing, handling deployment race conditions gracefully.
```