### PR TITLE
ci: reduce presubmit build platforms to amd64+arm64

### DIFF
--- a/scripts/test-infra/build-image-cross.sh
+++ b/scripts/test-infra/build-image-cross.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
 # cross build
-IMAGE_ALL_PLATFORMS=linux/amd64,linux/arm64,linux/s390x,linux/ppc64le make image-all
+IMAGE_ALL_PLATFORMS=linux/amd64,linux/arm64 make image-all


### PR DESCRIPTION
Addresses  #2419 as a phase 1

Once this PR gets merged, we will work on the next step solutions

## Summary
- Remove s390x and ppc64le from `build-image-cross.sh` presubmit job
- Reduces QEMU emulation flakiness (~80% of CI failures)
- Full platform coverage maintained via `push-image.sh` on release

## Solution
Reduce presubmit platforms from 4 to 2 (amd64+arm64). arm64 QEMU is
mature/stable. s390x/ppc64le issues are rare (<5%) and will be caught
by push-image job on merge.

## Changes
- `scripts/test-infra/build-image-cross.sh`: `linux/amd64,linux/arm64` only

## Testing
- [x] Script syntax valid
- [x] push-image.sh unchanged (still builds all platforms)
- [x] Makefile default unchanged