### PR TITLE
Remove default CPU limits

### DIFF
--- a/deployment/base/gc/gc.yaml
+++ b/deployment/base/gc/gc.yaml
@@ -31,7 +31,6 @@ spec:
             initialDelaySeconds: 5
           resources:
             limits:
-              cpu: 20m
               memory: 1Gi
             requests:
               cpu: 10m

--- a/deployment/base/master/master-deployment.yaml
+++ b/deployment/base/master/master-deployment.yaml
@@ -28,7 +28,6 @@ spec:
                 resource: limits.memory
           resources:
             limits:
-              cpu: 300m
               memory: 4Gi
             requests:
               cpu: 100m

--- a/deployment/base/topologyupdater-daemonset/topologyupdater-daemonset.yaml
+++ b/deployment/base/topologyupdater-daemonset/topologyupdater-daemonset.yaml
@@ -37,7 +37,6 @@ spec:
           args: []
           resources:
             limits:
-              cpu: 100m
               memory: 60Mi
             requests:
               cpu: 50m

--- a/deployment/base/worker-daemonset/worker-daemonset.yaml
+++ b/deployment/base/worker-daemonset/worker-daemonset.yaml
@@ -41,7 +41,6 @@ spec:
             - "nfd-worker"
           resources:
             limits:
-              cpu: 200m
               memory: 512Mi
             requests:
               cpu: 5m


### PR DESCRIPTION
This was already done for Helm: https://github.com/kubernetes-sigs/node-feature-discovery/pull/1728

This brings makes Kustomization deployments in line with Helm by removing CPU limits by default, for the same reasons (<https://github.com/kubernetes-sigs/node-feature-discovery/issues/1724>, <https://home.robusta.dev/blog/stop-using-cpu-limits>)