### PR TITLE
fix: rename gomega.go to gomega_test.go

### DIFF
--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	taintutils "k8s.io/kubernetes/pkg/util/taints"
+)
+
+// getNonControlPlaneNodes gets the nodes that are not tainted for exclusive control-plane usage
+func getNonControlPlaneNodes(ctx context.Context, cli clientset.Interface) ([]corev1.Node, error) {
+	nodeList, err := cli.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if len(nodeList.Items) == 0 {
+		return nil, fmt.Errorf("no nodes found in the cluster")
+	}
+
+	controlPlaneTaint := corev1.Taint{
+		Effect: corev1.TaintEffectNoSchedule,
+		Key:    "node-role.kubernetes.io/control-plane",
+	}
+	out := []corev1.Node{}
+	for _, node := range nodeList.Items {
+		if !taintutils.TaintExists(node.Spec.Taints, &controlPlaneTaint) {
+			out = append(out, node)
+		}
+	}
+
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no non-control-plane nodes found in the cluster")
+	}
+	return out, nil
+}
+
+// getNode returns a node from the list by name, or an empty node if not found
+func getNode(nodes []corev1.Node, nodeName string) corev1.Node {
+	for _, node := range nodes {
+		if node.Name == nodeName {
+			return node
+		}
+	}
+	return corev1.Node{}
+}

--- a/test/e2e/node_feature_discovery_test.go
+++ b/test/e2e/node_feature_discovery_test.go
@@ -1284,39 +1284,3 @@ restrictions:
 		})
 	})
 })
-
-// getNonControlPlaneNodes gets the nodes that are not tainted for exclusive control-plane usage
-func getNonControlPlaneNodes(ctx context.Context, cli clientset.Interface) ([]corev1.Node, error) {
-	nodeList, err := cli.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-	if len(nodeList.Items) == 0 {
-		return nil, fmt.Errorf("no nodes found in the cluster")
-	}
-
-	controlPlaneTaint := corev1.Taint{
-		Effect: corev1.TaintEffectNoSchedule,
-		Key:    "node-role.kubernetes.io/control-plane",
-	}
-	out := []corev1.Node{}
-	for _, node := range nodeList.Items {
-		if !taintutils.TaintExists(node.Spec.Taints, &controlPlaneTaint) {
-			out = append(out, node)
-		}
-	}
-
-	if len(out) == 0 {
-		return nil, fmt.Errorf("no non-control-plane nodes found in the cluster")
-	}
-	return out, nil
-}
-
-func getNode(nodes []corev1.Node, nodeName string) corev1.Node {
-	for _, node := range nodes {
-		if node.Name == nodeName {
-			return node
-		}
-	}
-	return corev1.Node{}
-}


### PR DESCRIPTION
## Summary

## Problem description

The file ztest/e2e/gomega.goz references functions (`getNonControlPlaneNodes`, `getNode`) defined in `_test.go` files. Since go build excludes `_test.go` files, it fails with:

```
test/e2e/gomega.go:41:10: undefined: getNonControlPlaneNodes
test/e2e/gomega.go:181:14: undefined: getNode
```

## Solution

Fix go build `./test/e2e/...` failure by renaming `gomega.go` to `gomega_test.go`.

The file contains custom Gomega matchers used exclusively by tests, so it should be a test file.

## Test

```
go build ./test/e2e/... # Now passes
go test -c ./test/e2e/... # Still works
```