### PR TITLE
safely remove existing buildx builder before recreate

### DIFF
--- a/hack/init-buildx.sh
+++ b/hack/init-buildx.sh
@@ -19,7 +19,7 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 
 # We can skip setup if the current builder already has multi-arch
 # AND if it isn't the docker driver, which doesn't work
-current_builder="$(docker buildx inspect nfd-builder || true)"
+current_builder="$(docker buildx inspect nfd-builder 2>/dev/null || true)"
 # linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
 if ! grep -Eq "^Driver:\s*docker$"  <<<"${current_builder}" && \
      grep -q "linux/amd64" <<<"${current_builder}" && \
@@ -36,7 +36,9 @@ if [ "$(uname)" == 'Linux' ]; then
 fi
 
 # Ensure we use a builder that can leverage it (the default on linux will not)
-docker buildx rm nfd-builder || true
+if docker buildx inspect nfd-builder >/dev/null 2>&1; then
+  docker buildx rm -f nfd-builder || true
+fi
 docker buildx create --use --name=nfd-builder                 \
   ${http_proxy:+--driver-opt env.http_proxy="$http_proxy"}    \
   ${HTTP_PROXY:+--driver-opt env.HTTP_PROXY="$HTTP_PROXY"}    \


### PR DESCRIPTION
Check if nfd-builder exists before attempting removal to avoid unnecessary cleanup error

We see below errors when running
./hack/init-buildx.sh

failed to remove nfd-builder: no builder "nfd-builder" found
**ERROR: failed to remove one or more builders**

reference: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_node-feature-discovery/2428/pull-node-feature-discovery-build-image-cross-generic/2019112349893398528

Changes in this PR:
- Check if nfd-builder exists before removing it
