### PR TITLE
Fix: RBAC question for NodeFeatureGroup in v0.18.3

### DIFF
--- a/deployment/base/rbac/master-clusterrole.yaml
+++ b/deployment/base/rbac/master-clusterrole.yaml
@@ -33,7 +33,7 @@ rules:
 - apiGroups:
   - nfd.k8s-sigs.io
   resources:
-  - nodefeaturegroup/status
+  - nodefeaturegroups/status
   verbs:
   - patch
   - update


### PR DESCRIPTION
RBAC question for NodeFeatureGroup in v0.18.3: 
Spelling error. Modify `nodefeaturegroup/status` to `nodefeaturegroups/status`

fixed #2445 