### PR TITLE
cpu: return "none" when Control Program is not found in /proc/sysinfo

### DIFF
--- a/source/cpu/cpu.go
+++ b/source/cpu/cpu.go
@@ -324,7 +324,7 @@ func getHypervisorFromProcSysinfo() (string, error) {
 		return "", err
 	}
 
-	hypervisor := "PR/SM"
+	hypervisor := ""
 	for _, line := range strings.Split(string(data), "\n") {
 		if strings.Contains(line, "Control Program:") {
 			parts := strings.SplitN(line, ":", 2)
@@ -333,6 +333,9 @@ func getHypervisorFromProcSysinfo() (string, error) {
 			}
 			break
 		}
+	}
+	if hypervisor == "" {
+		return "none", nil
 	}
 	// Replace forbidden symbols
 	fullRegex := regexp.MustCompile("[^-A-Za-z0-9_.]+")


### PR DESCRIPTION
Currently getHypervisorFromProcSysinfo() defaults the hypervisor to "PR/SM" when no "Control Program:" entry is found.

On s390x, "PR/SM" represents the bare metal case. However, defaulting to "PR/SM" when the Control Program field is not explicitly present may result in misleading reporting on systems where no hypervisor information is available.

This change is implemented based on: https://github.com/kubernetes-sigs/node-feature-discovery/pull/2441#issuecomment-3943690469
cc @marquiz 