### PR TITLE
build: disable CGO for multi-arch builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ all: image
 BUILD_BINARIES := nfd-master nfd-worker nfd-topology-updater nfd-gc kubectl-nfd nfd
 
 build-%:
-	$(GO_CMD) build -v -o bin/ $(BUILD_FLAGS) ./cmd/$*
+	CGO_ENABLED=0 $(GO_CMD) build -v -o bin/ $(BUILD_FLAGS) ./cmd/$*
 
 build:	$(foreach bin, $(BUILD_BINARIES), build-$(bin))
 


### PR DESCRIPTION
Add `CGO_ENABLED=0` to Makefile to prevent GCC invocation during cross-compilation. This is an attempt to fix the build failure caused by GCC internal compiler error (segfault in cc1) when compiling runtime/cgo.