### PR TITLE
Change serviceAccount to serviceAccountName in kustomize manifests

### DIFF
--- a/deployment/base/gc/gc.yaml
+++ b/deployment/base/gc/gc.yaml
@@ -14,7 +14,7 @@ spec:
         app: nfd-gc
     spec:
       dnsPolicy: ClusterFirstWithHostNet
-      serviceAccount: nfd-gc
+      serviceAccountName: nfd-gc
       containers:
         - name: nfd-gc
           image: gcr.io/k8s-staging-nfd/node-feature-discovery:master

--- a/deployment/base/master/master-deployment.yaml
+++ b/deployment/base/master/master-deployment.yaml
@@ -14,7 +14,7 @@ spec:
       labels:
         app: nfd-master
     spec:
-      serviceAccount: nfd-master
+      serviceAccountName: nfd-master
       enableServiceLinks: false
       tolerations: []
       containers:

--- a/deployment/base/topologyupdater-daemonset/topologyupdater-daemonset.yaml
+++ b/deployment/base/topologyupdater-daemonset/topologyupdater-daemonset.yaml
@@ -14,7 +14,7 @@ spec:
         app: nfd-topology-updater
     spec:
       dnsPolicy: ClusterFirstWithHostNet
-      serviceAccount: nfd-topology-updater
+      serviceAccountName: nfd-topology-updater
       containers:
         - name: nfd-topology-updater
           image: gcr.io/k8s-staging-nfd/node-feature-discovery:master

--- a/deployment/base/worker-daemonset/worker-daemonset.yaml
+++ b/deployment/base/worker-daemonset/worker-daemonset.yaml
@@ -13,7 +13,7 @@ spec:
       labels:
         app: nfd-worker
     spec:
-      serviceAccount: nfd-worker
+      serviceAccountName: nfd-worker
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: nfd-worker

--- a/deployment/base/worker-job/worker-job.yaml
+++ b/deployment/base/worker-job/worker-job.yaml
@@ -13,7 +13,7 @@ spec:
       labels:
         app: nfd-worker
     spec:
-      serviceAccount: nfd-worker
+      serviceAccountName: nfd-worker
       dnsPolicy: ClusterFirstWithHostNet
       restartPolicy: Never
       affinity:

--- a/deployment/overlays/prune/master-job.yaml
+++ b/deployment/overlays/prune/master-job.yaml
@@ -12,7 +12,7 @@ spec:
       labels:
         app: nfd-prune
     spec:
-      serviceAccount: nfd-master
+      serviceAccountName: nfd-master
       tolerations: []
       containers:
         - name: nfd-master


### PR DESCRIPTION
`serviceAccount` is deprecated. Helm chart already does `serviceAccountName`.