### PR TITLE
add --load flag to docker buildx build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,9 +113,8 @@ image: yamls
 	$(IMAGE_BUILD_CMD) $(IMAGE_BUILD_ARGS) $(IMAGE_BUILD_ARGS_MINIMAL)
 
 image-all: ensure-buildx yamls
-# --load : not implemented yet, see: https://github.com/docker/buildx/issues/59
-	$(IMAGE_BUILDX_CMD) $(IMAGE_BUILD_ARGS) $(IMAGE_BUILD_ARGS_FULL)
-	$(IMAGE_BUILDX_CMD) $(IMAGE_BUILD_ARGS) $(IMAGE_BUILD_ARGS_MINIMAL)
+	$(IMAGE_BUILDX_CMD) --load $(IMAGE_BUILD_ARGS) $(IMAGE_BUILD_ARGS_FULL)
+	$(IMAGE_BUILDX_CMD) --load $(IMAGE_BUILD_ARGS) $(IMAGE_BUILD_ARGS_MINIMAL)
 
 # clean NFD labels on all nodes
 # devel only


### PR DESCRIPTION
Export the built image to the local Docker daemon so it is available for subsequent steps, example docker images. By default, buildx builds images using BuildKit and leaves the result in the build cache without exporting it anywhere.

_Note_: building images for multi arch with `--load`parameter is now supported and fixed in docker buildx. See https://github.com/docker/buildx/issues/59.
