### PR TITLE
scripts/test-infra: fix periodic e2e

### DIFF
--- a/scripts/test-infra/test-e2e.sh
+++ b/scripts/test-infra/test-e2e.sh
@@ -1,7 +1,9 @@
 #!/bin/bash -e
+set -o pipefail
 
 # Configure environment
 export KIND_VERSION="v0.23.0"
+export HELM_VERSION="v3.17.3"
 export KIND_NODE_IMAGE="kindest/node:v1.30.2"
 export CLUSTER_NAME="nfd-e2e"
 export KUBECONFIG=`pwd`/kubeconfig
@@ -10,6 +12,9 @@ export E2E_TEST_FULL_IMAGE=true
 
 # Install kind
 go install sigs.k8s.io/kind@$KIND_VERSION
+
+# Install helm (required for helm e2e tests)
+curl -sfL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash -s -- --version $HELM_VERSION
 
 # create a cluster with the local registry enabled in containerd
 cat <<EOF | kind create cluster --kubeconfig $KUBECONFIG --image $KIND_NODE_IMAGE --config=-


### PR DESCRIPTION
Install Helm which is now needed by e2e tests.

Look at:
https://testgrid.k8s.io/sig-node-node-feature-discovery#periodic-e2e-test-master