### PR TITLE
feat: Add additional DMI attributes to system feature source

### DIFF
--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -996,8 +996,22 @@ The following features are available for matching:
 | **`system.osrelease`** | attribute |       |            | System identification data from `/etc/os-release` |
 |                  |              | **`<parameter>`** | string | One parameter from `/etc/os-release` |
 | **`system.dmiid`** | attribute |       |            | DMI identification data from `/sys/devices/virtual/dmi/id/` |
-|                  |              | **`sys_vendor`** | string | Vendor name from `/sys/devices/virtual/dmi/id/sys_vendor` |
-|                  |              | **`product_name`** | string | Product name from `/sys/devices/virtual/dmi/id/product_name` |
+|                  |              | **`bios_date`** | string | BIOS release date |
+|                  |              | **`bios_vendor`** | string | BIOS vendor name |
+|                  |              | **`bios_version`** | string | BIOS version |
+|                  |              | **`board_asset_tag`** | string | Baseboard asset tag |
+|                  |              | **`board_name`** | string | Baseboard name |
+|                  |              | **`board_vendor`** | string | Baseboard vendor name |
+|                  |              | **`board_version`** | string | Baseboard version |
+|                  |              | **`chassis_asset_tag`** | string | Chassis asset tag |
+|                  |              | **`chassis_type`** | string | Chassis type (numeric, e.g. 1=Other, 17=Laptop) |
+|                  |              | **`chassis_vendor`** | string | Chassis vendor name |
+|                  |              | **`chassis_version`** | string | Chassis version |
+|                  |              | **`product_family`** | string | Product family |
+|                  |              | **`product_name`** | string | Product name |
+|                  |              | **`product_sku`** | string | Product SKU |
+|                  |              | **`product_version`** | string | Product version |
+|                  |              | **`sys_vendor`** | string | System vendor name |
 | **`system.name`** | attribute   |          |            | System name information |
 |                  |              | **`nodename`** | string | Name of the kubernetes node object |
 | **`usb.device`** | instance     |          |            | USB devices present in the system |

--- a/examples/nodefeature.yaml
+++ b/examples/nodefeature.yaml
@@ -67,6 +67,21 @@ spec:
           VERSION_ID.minor: "04"
       system.dmiid:
         elements:
+          bios_date: "01/01/2024"
+          bios_vendor: BIOSVendor
+          bios_version: "1.0.0"
+          board_asset_tag: ""
+          board_name: BaseBoard
+          board_vendor: BoardVendor
+          board_version: "1.0"
+          chassis_asset_tag: ""
+          chassis_type: "17"
+          chassis_vendor: ChassisVendor
+          chassis_version: N/A
+          product_family: ProductFamily
+          product_name: ProductName
+          product_sku: SKU-001
+          product_version: N/A
           sys_vendor: VendorUnknown
     flags:
       cpu.cpuid:

--- a/source/system/system.go
+++ b/source/system/system.go
@@ -102,8 +102,26 @@ func (s *systemSource) Discover() error {
 		}
 	}
 
-	// Get DMI ID attributes
-	dmiIDAttributeNames := []string{"sys_vendor", "product_name"}
+	// Get DMI ID attributes (publicly readable files under /sys/devices/virtual/dmi/id/).
+	// Serial numbers and product_uuid are excluded as they require root access.
+	dmiIDAttributeNames := []string{
+		"bios_date",
+		"bios_vendor",
+		"bios_version",
+		"board_asset_tag",
+		"board_name",
+		"board_vendor",
+		"board_version",
+		"chassis_asset_tag",
+		"chassis_type",
+		"chassis_vendor",
+		"chassis_version",
+		"product_family",
+		"product_name",
+		"product_sku",
+		"product_version",
+		"sys_vendor",
+	}
 	dmiAttrs := make(map[string]string)
 	for _, name := range dmiIDAttributeNames {
 		val, err := getDmiIDAttribute(name)

--- a/source/system/system_test.go
+++ b/source/system/system_test.go
@@ -17,9 +17,13 @@ limitations under the License.
 package system
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath"
 )
 
 func TestSystemSource(t *testing.T) {
@@ -31,5 +35,88 @@ func TestSystemSource(t *testing.T) {
 
 	assert.Nil(t, err, err)
 	assert.Empty(t, l)
+}
 
+func TestGetDmiIDAttribute(t *testing.T) {
+	origSysfsDir := hostpath.SysfsDir
+	t.Cleanup(func() { hostpath.SysfsDir = origSysfsDir })
+
+	dmiDir := t.TempDir()
+	hostpath.SysfsDir = hostpath.HostDir(dmiDir)
+
+	dmiIDDir := filepath.Join(dmiDir, "devices", "virtual", "dmi", "id")
+	err := os.MkdirAll(dmiIDDir, 0755)
+	assert.Nil(t, err)
+
+	t.Run("reads attribute value with trimmed whitespace", func(t *testing.T) {
+		err := os.WriteFile(filepath.Join(dmiIDDir, "sys_vendor"), []byte("LENOVO\n"), 0644)
+		assert.Nil(t, err)
+
+		val, err := getDmiIDAttribute("sys_vendor")
+		assert.Nil(t, err)
+		assert.Equal(t, "LENOVO", val)
+	})
+
+	t.Run("returns error for non-existent attribute", func(t *testing.T) {
+		_, err := getDmiIDAttribute("nonexistent")
+		assert.NotNil(t, err)
+	})
+}
+
+func TestDmiIDAttributeNames(t *testing.T) {
+	origSysfsDir := hostpath.SysfsDir
+	origEtcDir := hostpath.EtcDir
+	t.Cleanup(func() {
+		hostpath.SysfsDir = origSysfsDir
+		hostpath.EtcDir = origEtcDir
+	})
+
+	tmpDir := t.TempDir()
+	hostpath.SysfsDir = hostpath.HostDir(tmpDir)
+	hostpath.EtcDir = hostpath.HostDir(tmpDir)
+
+	dmiIDDir := filepath.Join(tmpDir, "devices", "virtual", "dmi", "id")
+	err := os.MkdirAll(dmiIDDir, 0755)
+	assert.Nil(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpDir, "os-release"), []byte("ID=test\nVERSION_ID=1.0\n"), 0644)
+	assert.Nil(t, err)
+
+	expectedAttrs := map[string]string{
+		"bios_date":         "01/01/2024",
+		"bios_vendor":       "TestBIOSVendor",
+		"bios_version":      "1.0.0",
+		"board_asset_tag":   "BoardAsset123",
+		"board_name":        "TestBoard",
+		"board_vendor":      "TestBoardVendor",
+		"board_version":     "Rev 1.0",
+		"chassis_asset_tag": "ChassisAsset456",
+		"chassis_type":      "17",
+		"chassis_vendor":    "TestChassisVendor",
+		"chassis_version":   "N/A",
+		"product_family":    "TestFamily",
+		"product_name":      "TestProduct",
+		"product_sku":       "SKU-001",
+		"product_version":   "2.0",
+		"sys_vendor":        "TestVendor",
+	}
+
+	for name, value := range expectedAttrs {
+		err := os.WriteFile(filepath.Join(dmiIDDir, name), []byte(value+"\n"), 0644)
+		assert.Nil(t, err)
+	}
+
+	s := &systemSource{}
+	err = s.Discover()
+	assert.Nil(t, err)
+
+	features := s.GetFeatures()
+	dmiFeatures := features.Attributes[DmiIdFeature]
+	assert.NotNil(t, dmiFeatures)
+
+	for name, expected := range expectedAttrs {
+		actual, exists := dmiFeatures.Elements[name]
+		assert.True(t, exists, "DMI attribute %q should exist", name)
+		assert.Equal(t, expected, actual, "DMI attribute %q value mismatch", name)
+	}
 }


### PR DESCRIPTION
Expand the set of DMI attributes discovered from /sys/devices/virtual/dmi/id/ from 2 (sys_vendor, product_name) to 16, covering BIOS, baseboard, chassis, and product metadata. Serial numbers and product_uuid are excluded as they require root access.
Fixes: https://github.com/kubernetes-sigs/node-feature-discovery/issues/1629