### PR TITLE
kubectl-nfd: Add NodeFeatureGroup dryrun, validation and test

### DIFF
--- a/cmd/kubectl-nfd/subcmd/dryrun.go
+++ b/cmd/kubectl-nfd/subcmd/dryrun.go
@@ -26,34 +26,31 @@ import (
 
 var dryrunCmd = &cobra.Command{
 	Use:   "dryrun",
-	Short: "Process a NodeFeatureRule file against a NodeFeature file",
-	Long:  `Process a NodeFeatureRule file against a local NodeFeature file to dry run the rule against a node before applying it to a cluster`,
+	Short: "Process a NodeFeatureRule or NodeFeatureGroup file against a NodeFeature file",
+	Long:  `Process a NodeFeatureRule or NodeFeatureGroup file against a local NodeFeature file to dry run the rule against a node before applying it to a cluster`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("Evaluating NodeFeatureRule %q against NodeFeature %q\n", nodefeaturerule, nodefeature)
-		err := kubectlnfd.DryRun(nodefeaturerule, nodefeature)
-		if len(err) > 0 {
-			fmt.Printf("NodeFeatureRule %q is not valid for NodeFeature %q\n", nodefeaturerule, nodefeature)
-			for _, e := range err {
+		fmt.Printf("Evaluating %q against NodeFeature %q\n", rule, nodefeature)
+		errs := kubectlnfd.DryRun(rule, nodefeature)
+		if len(errs) > 0 {
+			fmt.Printf("%q is not valid for NodeFeature %q\n", rule, nodefeature)
+			for _, e := range errs {
 				cmd.PrintErrln(e)
 			}
-			// Return non-zero exit code to indicate failure
 			os.Exit(1)
 		}
-		fmt.Printf("NodeFeatureRule %q is valid for NodeFeature %q\n", nodefeaturerule, nodefeature)
+		fmt.Printf("%q is valid for NodeFeature %q\n", rule, nodefeature)
 	},
 }
 
 func init() {
 	RootCmd.AddCommand(dryrunCmd)
 
-	dryrunCmd.Flags().StringVarP(&nodefeaturerule, "nodefeaturerule-file", "f", "", "Path to the NodeFeatureRule file to validate")
-	dryrunCmd.Flags().StringVarP(&nodefeature, "nodefeature-file", "n", "", "Path to the NodeFeature file to validate against")
-	err := dryrunCmd.MarkFlagRequired("nodefeaturerule-file")
-	if err != nil {
+	dryrunCmd.Flags().StringVarP(&rule, "rule-file", "f", "", "Path to the NodeFeatureRule or NodeFeatureGroup file to dry run")
+	dryrunCmd.Flags().StringVarP(&nodefeature, "nodefeature-file", "n", "", "Path to the NodeFeature file to dry run against")
+	if err := dryrunCmd.MarkFlagRequired("rule-file"); err != nil {
 		panic(err)
 	}
-	err = dryrunCmd.MarkFlagRequired("nodefeature-file")
-	if err != nil {
+	if err := dryrunCmd.MarkFlagRequired("nodefeature-file"); err != nil {
 		panic(err)
 	}
 }

--- a/cmd/kubectl-nfd/subcmd/root.go
+++ b/cmd/kubectl-nfd/subcmd/root.go
@@ -24,8 +24,8 @@ import (
 )
 
 var (
-	// Path to the NodeFeatureRule file to validate
-	nodefeaturerule string
+	// Path to the NodeFeatureRule or NodeFeatureGroup file
+	rule string
 	// Path to the NodeFeature file to run against the NodeFeatureRule
 	nodefeature string
 	// Node to validate against

--- a/cmd/kubectl-nfd/subcmd/test.go
+++ b/cmd/kubectl-nfd/subcmd/test.go
@@ -26,30 +26,29 @@ import (
 
 var testCmd = &cobra.Command{
 	Use:   "test",
-	Short: "Test a NodeFeatureRule file against a Node",
-	Long:  `Test a NodeFeatureRule file against a Node to ensure it is valid before applying it to a cluster`,
+	Short: "Test a NodeFeatureRule or NodeFeatureGroup file against a Node",
+	Long:  `Test a NodeFeatureRule or NodeFeatureGroup file against a Node to ensure it is valid before applying it to a cluster`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("Evaluating NodeFeatureRule against Node %s\n", node)
-		err := kubectlnfd.Test(nodefeaturerule, node, kubeconfig)
-		if len(err) > 0 {
-			fmt.Printf("NodeFeatureRule is not valid for Node %s\n", node)
-			for _, e := range err {
+		fmt.Printf("Evaluating %s against Node %s\n", rule, node)
+		errs := kubectlnfd.Test(rule, node, kubeconfig)
+		if len(errs) > 0 {
+			fmt.Printf("%s is not valid for Node %s\n", rule, node)
+			for _, e := range errs {
 				cmd.PrintErrln(e)
 			}
-			// Return non-zero exit code to indicate failure
 			os.Exit(1)
 		}
-		fmt.Printf("NodeFeatureRule is valid for Node %s\n", node)
+		fmt.Printf("%s is valid for Node %s\n", rule, node)
 	},
 }
 
 func init() {
 	RootCmd.AddCommand(testCmd)
 
-	testCmd.Flags().StringVarP(&nodefeaturerule, "nodefeaturerule-file", "f", "", "Path to the NodeFeatureRule file to validate")
-	testCmd.Flags().StringVarP(&node, "nodename", "n", "", "Node to validate against")
+	testCmd.Flags().StringVarP(&rule, "rule-file", "f", "", "Path to the NodeFeatureRule or NodeFeatureGroup file to test")
+	testCmd.Flags().StringVarP(&node, "nodename", "n", "", "Node to test against")
 	testCmd.Flags().StringVarP(&kubeconfig, "kubeconfig", "k", "", "kubeconfig file to use")
-	if err := testCmd.MarkFlagRequired("nodefeaturerule-file"); err != nil {
+	if err := testCmd.MarkFlagRequired("rule-file"); err != nil {
 		panic(err)
 	}
 	if err := testCmd.MarkFlagRequired("nodename"); err != nil {

--- a/cmd/kubectl-nfd/subcmd/validate.go
+++ b/cmd/kubectl-nfd/subcmd/validate.go
@@ -26,29 +26,27 @@ import (
 
 var validateCmd = &cobra.Command{
 	Use:   "validate",
-	Short: "Validate a NodeFeatureRule file",
-	Long:  `Validate a NodeFeatureRule file to ensure it is valid before applying it to a cluster`,
+	Short: "Validate a NodeFeatureRule or NodeFeatureGroup file",
+	Long:  `Validate a NodeFeatureRule or NodeFeatureGroup file to ensure it is valid before applying it to a cluster`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("Validating NodeFeatureRule %s\n", nodefeaturerule)
-		err := kubectlnfd.ValidateNFR(nodefeaturerule)
-		if len(err) > 0 {
-			fmt.Printf("NodeFeatureRule %s is not valid\n", nodefeaturerule)
-			for _, e := range err {
+		fmt.Printf("Validating %s\n", rule)
+		errs := kubectlnfd.Validate(rule)
+		if len(errs) > 0 {
+			fmt.Printf("%s is not valid\n", rule)
+			for _, e := range errs {
 				cmd.PrintErrln(e)
 			}
-			// Return non-zero exit code to indicate failure
 			os.Exit(1)
 		}
-		fmt.Printf("NodeFeatureRule %s is valid\n", nodefeaturerule)
+		fmt.Printf("%s is valid\n", rule)
 	},
 }
 
 func init() {
 	RootCmd.AddCommand(validateCmd)
 
-	validateCmd.Flags().StringVarP(&nodefeaturerule, "nodefeaturerule-file", "f", "", "Path to the NodeFeatureRule file to validate")
-	err := validateCmd.MarkFlagRequired("nodefeaturerule-file")
-	if err != nil {
+	validateCmd.Flags().StringVarP(&rule, "rule-file", "f", "", "Path to the NodeFeatureRule or NodeFeatureGroup file to validate")
+	if err := validateCmd.MarkFlagRequired("rule-file"); err != nil {
 		panic(err)
 	}
 }

--- a/docs/reference/plugin-commandline-reference.md
+++ b/docs/reference/plugin-commandline-reference.md
@@ -25,9 +25,9 @@ Print usage and exit.
 
 Validate a NodeFeatureRule file.
 
-### -f / --nodefeaturerule-file
+### -f / --rule-file
 
-The `--nodefeaturerule-file` flag specifies the path to the NodeFeatureRule file
+The `--rule-file` flag specifies the path to the NodeFeatureRule file
 to validate.
 
 ## Test
@@ -49,18 +49,18 @@ Default: `default`.
 The `--nodename` flag specifies the name of the node to test the
 NodeFeatureRule against.
 
-### -f, --nodefeaturerule-file
+### -f, --rule-file
 
-The `--nodefeaturerule-file` flag specifies the path to the NodeFeatureRule file
+The `--rule-file` flag specifies the path to the NodeFeatureRule file
 to test.
 
 ## DryRun
 
 Process a NodeFeatureRule file against a NodeFeature file.
 
-### -f, --nodefeaturerule-file
+### -f, --rule-file
 
-The `--nodefeaturerule-file` flag specifies the path to the NodeFeatureRule file
+The `--rule-file` flag specifies the path to the NodeFeatureRule file
 to test.
 
 ### -n, --nodefeature-file

--- a/docs/usage/kubectl-plugin.md
+++ b/docs/usage/kubectl-plugin.md
@@ -22,7 +22,8 @@ sort: 10
 ## Overview
 
 The `kubectl` plugin `kubectl nfd` can be used to validate/dryrun and test
-NodeFeatureRule objects. It can be installed with the following command:
+NodeFeatureRule and NodeFeatureGroup objects. It can be installed with the
+following command:
 
 ```bash
 git clone https://github.com/kubernetes-sigs/node-feature-discovery
@@ -34,37 +35,60 @@ mv ./bin/kubectl-nfd ${KUBECTL_PATH}
 
 ### Validate
 
-The plugin can be used to validate a NodeFeatureRule object:
+The plugin can be used to validate a NodeFeatureRule or NodeFeatureGroup object.
+The kind is detected automatically from the file content:
 
 ```bash
-kubectl nfd validate -f <nodefeaturerule.yaml>
+kubectl nfd validate -f <nodefeaturerule-or-nodefeaturegroup.yaml>
+```
+
+You can use the example files to try it out:
+
+```bash
+$ kubectl nfd validate -f examples/nodefeaturegroup.yaml
+Validating examples/nodefeaturegroup.yaml
+Validating rule:  kernel version
+Validating rule:  veth kernel module
+examples/nodefeaturegroup.yaml is valid
 ```
 
 ### Test
 
-The plugin can be used to test a NodeFeatureRule object against a node:
+The plugin can be used to test a NodeFeatureRule or NodeFeatureGroup object
+against a node. The kind is detected automatically from the file content:
 
 ```bash
-kubectl nfd test -f <nodefeaturerule.yaml> -n <node-name>
+kubectl nfd test -f <nodefeaturerule-or-nodefeaturegroup.yaml> -n <node-name>
 ```
 
 ### DryRun
 
-The plugin can be used to DryRun a NodeFeatureRule object against a NodeFeature
-file:
+The plugin can be used to dry run a NodeFeatureRule or NodeFeatureGroup object
+against a NodeFeature file. The kind is detected automatically from the file
+content:
 
 ```bash
 kubectl get -n node-feature-discovery nodefeature <nodename> -o yaml > <nodefeature.yaml>
-kubectl nfd dryrun -f <nodefeaturerule.yaml> -n <nodefeature.yaml>
+kubectl nfd dryrun -f <nodefeaturerule-or-nodefeaturegroup.yaml> -n <nodefeature.yaml>
 ```
 
-Or you can use the example NodeFeature file(it is a minimal NodeFeature file):
+For example, using the example files:
 
 ```bash
 $ kubectl nfd dryrun -f examples/nodefeaturerule.yaml -n examples/nodefeature.yaml
-Evaluating NodeFeatureRule "examples/nodefeaturerule.yaml" against NodeFeature "examples/nodefeature.yaml"
+Evaluating "examples/nodefeaturerule.yaml" against NodeFeature "examples/nodefeature.yaml"
 Processing rule:  my sample rule
 *** Labels ***
 vendor.io/my-sample-feature=true
-NodeFeatureRule "examples/nodefeaturerule.yaml" is valid for NodeFeature "examples/nodefeature.yaml"
+"examples/nodefeaturerule.yaml" is valid for NodeFeature "examples/nodefeature.yaml"
+```
+
+```bash
+$ kubectl nfd dryrun -f examples/nodefeaturegroup.yaml -n examples/nodefeature.yaml
+Evaluating "examples/nodefeaturegroup.yaml" against NodeFeature "examples/nodefeature.yaml"
+Processing rule:  kernel version
+Rule "kernel version" did not match
+Processing rule:  veth kernel module
+Rule "veth kernel module" did not match
+"examples/nodefeaturegroup.yaml" is valid for NodeFeature "examples/nodefeature.yaml"
 ```

--- a/docs/usage/kubectl-plugin.md
+++ b/docs/usage/kubectl-plugin.md
@@ -22,7 +22,8 @@ sort: 10
 ## Overview
 
 The `kubectl` plugin `kubectl nfd` can be used to validate/dryrun and test
-NodeFeatureRule objects. It can be installed with the following command:
+NodeFeatureRule and NodeFeatureGroup objects. It can be installed with the
+following command:
 
 ```bash
 git clone https://github.com/kubernetes-sigs/node-feature-discovery
@@ -34,37 +35,60 @@ mv ./bin/kubectl-nfd ${KUBECTL_PATH}
 
 ### Validate
 
-The plugin can be used to validate a NodeFeatureRule object:
+The plugin can be used to validate a NodeFeatureRule or NodeFeatureGroup object.
+The kind is detected automatically from the file content:
 
 ```bash
-kubectl nfd validate -f <nodefeaturerule.yaml>
+kubectl nfd validate -f <nodefeaturerule-or-nodefeaturegroup.yaml>
+```
+
+You can use the example files to try it out:
+
+```bash
+$ kubectl nfd validate -f examples/nodefeaturegroup.yaml
+Validating examples/nodefeaturegroup.yaml
+Validating rule:  kernel version
+Validating rule:  veth kernel module
+examples/nodefeaturegroup.yaml is valid
 ```
 
 ### Test
 
-The plugin can be used to test a NodeFeatureRule object against a node:
+The plugin can be used to test a NodeFeatureRule or NodeFeatureGroup object
+against a node. The kind is detected automatically from the file content:
 
 ```bash
-kubectl nfd test -f <nodefeaturerule.yaml> -n <node-name>
+kubectl nfd test -f <nodefeaturerule-or-nodefeaturegroup.yaml> -n <node-name>
 ```
 
 ### DryRun
 
-The plugin can be used to DryRun a NodeFeatureRule object against a NodeFeature
-file:
+The plugin can be used to dry run a NodeFeatureRule or NodeFeatureGroup object
+against a NodeFeature file. The kind is detected automatically from the file
+content:
 
 ```bash
 kubectl get -n node-feature-discovery nodefeature <nodename> -o yaml > <nodefeature.yaml>
-kubectl nfd dryrun -f <nodefeaturerule.yaml> -n <nodefeature.yaml>
+kubectl nfd dryrun -f <nodefeaturerule-or-nodefeaturegroup.yaml> -n <nodefeature.yaml>
 ```
 
-Or you can use the example NodeFeature file(it is a minimal NodeFeature file):
+For example, using the example files:
 
 ```bash
 $ kubectl nfd dryrun -f examples/nodefeaturerule.yaml -n examples/nodefeature.yaml
-Evaluating NodeFeatureRule "examples/nodefeaturerule.yaml" against NodeFeature "examples/nodefeature.yaml"
+Evaluating "examples/nodefeaturerule.yaml" against NodeFeature "examples/nodefeature.yaml"
 Processing rule:  my sample rule
 *** Labels ***
 vendor.io/my-sample-feature=true
-NodeFeatureRule "examples/nodefeaturerule.yaml" is valid for NodeFeature "examples/nodefeature.yaml"
+"examples/nodefeaturerule.yaml" is valid for NodeFeature "examples/nodefeature.yaml"
+```
+
+```bash
+$ kubectl nfd dryrun -f examples/nodefeaturegroup.yaml -n examples/nodefeature.yaml
+Evaluating "examples/nodefeaturegroup.yaml" against NodeFeature "examples/nodefeature.yaml"
+Processing rule:  kernel version
+Rule "kernel version" matched
+Processing rule:  veth kernel module
+Rule "veth kernel module" did not match
+"examples/nodefeaturegroup.yaml" is valid for NodeFeature "examples/nodefeature.yaml"
 ```

--- a/examples/nodefeaturegroup.yaml
+++ b/examples/nodefeaturegroup.yaml
@@ -9,3 +9,8 @@ spec:
         - feature: kernel.version
           matchExpressions:
             major: {op: In, value: ["6"]}
+    - name: "veth kernel module"
+      matchFeatures:
+        - feature: kernel.loadedmodule
+          matchExpressions:
+            veth: {op: Exists}

--- a/pkg/kubectl-nfd/common.go
+++ b/pkg/kubectl-nfd/common.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectlnfd
+
+import (
+	"fmt"
+	"os"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
+)
+
+func parseRuleFile(filepath string) (obj interface{}) {
+	file, err := os.ReadFile(filepath)
+	if err != nil {
+		return []error{fmt.Errorf("error reading file: %w", err)}
+	}
+	typeMeta := metav1.TypeMeta{}
+	if err = yaml.Unmarshal(file, &typeMeta); err != nil {
+		return []error{fmt.Errorf("error reading resource kind: %w", err)}
+	}
+	switch typeMeta.Kind {
+	case "NodeFeatureRule":
+		nfr := nfdv1alpha1.NodeFeatureRule{}
+		if err := yaml.Unmarshal(file, &nfr); err != nil {
+			return []error{fmt.Errorf("error reading NodeFeatureRule file: %w", err)}
+		}
+		return &nfr
+	case "NodeFeatureGroup":
+		nfg := nfdv1alpha1.NodeFeatureGroup{}
+		if err := yaml.Unmarshal(file, &nfg); err != nil {
+			return []error{fmt.Errorf("error reading NodeFeatureGroup file: %w", err)}
+		}
+		return &nfg
+	default:
+		return []error{fmt.Errorf("unsupported resource kind %q: must be NodeFeatureRule or NodeFeatureGroup", typeMeta.Kind)}
+	}
+}

--- a/pkg/kubectl-nfd/common_test.go
+++ b/pkg/kubectl-nfd/common_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectlnfd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
+)
+
+func TestParseRuleFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		missing  bool
+		expected interface{}
+	}{
+		{
+			name: "NodeFeatureRule",
+			content: `apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: test-rule
+spec:
+  rules:
+  - name: test rule
+    labels:
+      test-label: "true"
+`,
+			expected: &nfdv1alpha1.NodeFeatureRule{},
+		},
+		{
+			name: "NodeFeatureGroup",
+			content: `apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureGroup
+metadata:
+  name: test-group
+spec:
+  rules:
+  - name: test rule
+`,
+			expected: &nfdv1alpha1.NodeFeatureGroup{},
+		},
+		{
+			name: "unsupported kind",
+			content: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap
+`,
+			expected: []error{},
+		},
+		{
+			name:     "malformed YAML",
+			content:  "kind: [this is not valid yaml",
+			expected: []error{},
+		},
+		{
+			name:     "missing file",
+			missing:  true,
+			expected: []error{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var path string
+			if test.missing {
+				path = filepath.Join(t.TempDir(), "does-not-exist.yaml")
+			} else {
+				path = filepath.Join(t.TempDir(), "rule.yaml")
+				assert.NoError(t, os.WriteFile(path, []byte(test.content), 0644))
+			}
+
+			obj := parseRuleFile(path)
+
+			switch test.expected.(type) {
+			case *nfdv1alpha1.NodeFeatureRule:
+				assert.IsType(t, &nfdv1alpha1.NodeFeatureRule{}, obj)
+			case *nfdv1alpha1.NodeFeatureGroup:
+				assert.IsType(t, &nfdv1alpha1.NodeFeatureGroup{}, obj)
+			case []error:
+				assert.IsType(t, []error{}, obj)
+				errs, ok := obj.([]error)
+				assert.True(t, ok)
+				assert.NotEmpty(t, errs)
+			}
+		})
+	}
+}

--- a/pkg/kubectl-nfd/common_test.go
+++ b/pkg/kubectl-nfd/common_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectlnfd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
+)
+
+func TestParseRuleFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		missing  bool
+		expected interface{}
+	}{
+		{
+			name: "NodeFeatureRule",
+			content: `apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: test-rule
+spec:
+  rules:
+  - name: test rule
+    labels:
+      test-label: "true"
+`,
+			expected: &nfdv1alpha1.NodeFeatureRule{},
+		},
+		{
+			name: "NodeFeatureGroup",
+			content: `apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureGroup
+metadata:
+  name: test-group
+spec:
+  featureGroupRules:
+  - name: test rule
+`,
+			expected: &nfdv1alpha1.NodeFeatureGroup{},
+		},
+		{
+			name: "unsupported kind",
+			content: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap
+`,
+			expected: []error{},
+		},
+		{
+			name:     "malformed YAML",
+			content:  "kind: [this is not valid yaml",
+			expected: []error{},
+		},
+		{
+			name:     "missing file",
+			missing:  true,
+			expected: []error{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var path string
+			if test.missing {
+				path = filepath.Join(t.TempDir(), "does-not-exist.yaml")
+			} else {
+				path = filepath.Join(t.TempDir(), "rule.yaml")
+				assert.NoError(t, os.WriteFile(path, []byte(test.content), 0644))
+			}
+
+			obj := parseRuleFile(path)
+
+			switch test.expected.(type) {
+			case *nfdv1alpha1.NodeFeatureRule:
+				assert.IsType(t, &nfdv1alpha1.NodeFeatureRule{}, obj)
+				nfr, ok := obj.(*nfdv1alpha1.NodeFeatureRule)
+				assert.True(t, ok)
+				assert.Len(t, nfr.Spec.Rules, 1)
+			case *nfdv1alpha1.NodeFeatureGroup:
+				assert.IsType(t, &nfdv1alpha1.NodeFeatureGroup{}, obj)
+				nfg, ok := obj.(*nfdv1alpha1.NodeFeatureGroup)
+				assert.True(t, ok)
+				assert.Len(t, nfg.Spec.Rules, 1)
+			case []error:
+				assert.IsType(t, []error{}, obj)
+				errs, ok := obj.([]error)
+				assert.True(t, ok)
+				assert.Len(t, errs, 1)
+				switch test.name {
+				case "unsupported kind":
+					assert.ErrorContains(t, errs[0], "unsupported resource kind")
+				case "malformed YAML":
+					assert.ErrorContains(t, errs[0], "error reading resource kind")
+				case "missing file":
+					assert.ErrorContains(t, errs[0], "error reading file")
+				}
+			}
+		})
+	}
+}

--- a/pkg/kubectl-nfd/dryrun.go
+++ b/pkg/kubectl-nfd/dryrun.go
@@ -31,34 +31,53 @@ import (
 	"sigs.k8s.io/node-feature-discovery/pkg/apis/nfd/validate"
 )
 
-func DryRun(nodefeaturerulepath, nodefeaturepath string) []error {
+func processNodeFeatureGroup(nodeFeatureGroup nfdv1alpha1.NodeFeatureGroup, nodeFeature nfdv1alpha1.NodeFeatureSpec) []error {
 	var errs []error
-	nfr := nfdv1alpha1.NodeFeatureRule{}
-	nf := nfdv1alpha1.NodeFeature{}
 
-	nfrFile, err := os.ReadFile(nodefeaturerulepath)
-	if err != nil {
-		return []error{fmt.Errorf("error reading NodeFeatureRule file: %w", err)}
+	for _, rule := range nodeFeatureGroup.Spec.Rules {
+		fmt.Println("Processing rule: ", rule.Name)
+		ruleOut, err := nodefeaturerule.ExecuteGroupRule(&rule, &nodeFeature.Features, true)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to process rule %q: %w", rule.Name, err))
+			continue
+		}
+		if ruleOut.MatchStatus == nil || !ruleOut.MatchStatus.IsMatch {
+			fmt.Printf("Rule %q did not match\n", rule.Name)
+			continue
+		}
+		fmt.Printf("Rule %q matched\n", rule.Name)
+		if len(ruleOut.Vars) > 0 {
+			fmt.Println("***\tVars\t***")
+			for k, v := range ruleOut.Vars {
+				fmt.Printf("%s=%s\n", k, v)
+			}
+		}
 	}
-
-	err = yaml.Unmarshal(nfrFile, &nfr)
-	if err != nil {
-		return []error{fmt.Errorf("error parsing NodeFeatureRule: %w", err)}
-	}
-
-	nfFile, err := os.ReadFile(nodefeaturepath)
-	if err != nil {
-		return []error{fmt.Errorf("error reading NodeFeatureRule file: %w", err)}
-	}
-
-	err = yaml.Unmarshal(nfFile, &nf)
-	if err != nil {
-		return []error{fmt.Errorf("error parsing NodeFeatureRule: %w", err)}
-	}
-
-	errs = append(errs, processNodeFeatureRule(nfr, nf.Spec)...)
 
 	return errs
+}
+
+func DryRun(resourcepath, nodefeaturepath string) []error {
+	nfFile, err := os.ReadFile(nodefeaturepath)
+	if err != nil {
+		return []error{fmt.Errorf("error reading NodeFeature file: %w", err)}
+	}
+	nf := nfdv1alpha1.NodeFeature{}
+	if err = yaml.Unmarshal(nfFile, &nf); err != nil {
+		return []error{fmt.Errorf("error parsing NodeFeature: %w", err)}
+	}
+
+	t := parseRuleFile(resourcepath)
+	switch o := t.(type) {
+	case *nfdv1alpha1.NodeFeatureRule:
+		return processNodeFeatureRule(*o, nf.Spec)
+	case *nfdv1alpha1.NodeFeatureGroup:
+		return processNodeFeatureGroup(*o, nf.Spec)
+	case []error:
+		return o
+	default:
+		return []error{fmt.Errorf("unsupported resource %v: must be NodeFeatureRule or NodeFeatureGroup", t)}
+	}
 }
 
 func processNodeFeatureRule(nodeFeatureRule nfdv1alpha1.NodeFeatureRule, nodeFeature nfdv1alpha1.NodeFeatureSpec) []error {

--- a/pkg/kubectl-nfd/dryrun.go
+++ b/pkg/kubectl-nfd/dryrun.go
@@ -31,34 +31,55 @@ import (
 	"sigs.k8s.io/node-feature-discovery/pkg/apis/nfd/validate"
 )
 
-func DryRun(nodefeaturerulepath, nodefeaturepath string) []error {
+func processNodeFeatureGroup(nodeFeatureGroup nfdv1alpha1.NodeFeatureGroup, nodeFeature nfdv1alpha1.NodeFeatureSpec) []error {
 	var errs []error
-	nfr := nfdv1alpha1.NodeFeatureRule{}
-	nf := nfdv1alpha1.NodeFeature{}
 
-	nfrFile, err := os.ReadFile(nodefeaturerulepath)
-	if err != nil {
-		return []error{fmt.Errorf("error reading NodeFeatureRule file: %w", err)}
+	for _, rule := range nodeFeatureGroup.Spec.Rules {
+		fmt.Println("Processing rule: ", rule.Name)
+		ruleOut, err := nodefeaturerule.ExecuteGroupRule(&rule, &nodeFeature.Features, true)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to process rule %q: %w", rule.Name, err))
+			continue
+		}
+		if ruleOut.MatchStatus == nil || !ruleOut.MatchStatus.IsMatch {
+			fmt.Printf("Rule %q did not match\n", rule.Name)
+			nodeFeature.Features.InsertAttributeFeatures(nfdv1alpha1.RuleBackrefDomain, nfdv1alpha1.RuleBackrefFeature, ruleOut.Vars)
+			continue
+		}
+		fmt.Printf("Rule %q matched\n", rule.Name)
+		if len(ruleOut.Vars) > 0 {
+			fmt.Println("***\tVars\t***")
+			for k, v := range ruleOut.Vars {
+				fmt.Printf("%s=%s\n", k, v)
+			}
+		}
+		nodeFeature.Features.InsertAttributeFeatures(nfdv1alpha1.RuleBackrefDomain, nfdv1alpha1.RuleBackrefFeature, ruleOut.Vars)
 	}
-
-	err = yaml.Unmarshal(nfrFile, &nfr)
-	if err != nil {
-		return []error{fmt.Errorf("error parsing NodeFeatureRule: %w", err)}
-	}
-
-	nfFile, err := os.ReadFile(nodefeaturepath)
-	if err != nil {
-		return []error{fmt.Errorf("error reading NodeFeatureRule file: %w", err)}
-	}
-
-	err = yaml.Unmarshal(nfFile, &nf)
-	if err != nil {
-		return []error{fmt.Errorf("error parsing NodeFeatureRule: %w", err)}
-	}
-
-	errs = append(errs, processNodeFeatureRule(nfr, nf.Spec)...)
 
 	return errs
+}
+
+func DryRun(resourcepath, nodefeaturepath string) []error {
+	nfFile, err := os.ReadFile(nodefeaturepath)
+	if err != nil {
+		return []error{fmt.Errorf("error reading NodeFeature file: %w", err)}
+	}
+	nf := nfdv1alpha1.NodeFeature{}
+	if err = yaml.Unmarshal(nfFile, &nf); err != nil {
+		return []error{fmt.Errorf("error parsing NodeFeature: %w", err)}
+	}
+
+	t := parseRuleFile(resourcepath)
+	switch o := t.(type) {
+	case *nfdv1alpha1.NodeFeatureRule:
+		return processNodeFeatureRule(*o, nf.Spec)
+	case *nfdv1alpha1.NodeFeatureGroup:
+		return processNodeFeatureGroup(*o, nf.Spec)
+	case []error:
+		return o
+	default:
+		return []error{fmt.Errorf("unsupported resource %v: must be NodeFeatureRule or NodeFeatureGroup", t)}
+	}
 }
 
 func processNodeFeatureRule(nodeFeatureRule nfdv1alpha1.NodeFeatureRule, nodeFeature nfdv1alpha1.NodeFeatureSpec) []error {
@@ -108,6 +129,8 @@ func processNodeFeatureRule(nodeFeatureRule nfdv1alpha1.NodeFeatureRule, nodeFea
 		}
 		// annotations
 		maps.Copy(annotations, ruleOut.Annotations)
+
+		nodeFeature.Features.InsertAttributeFeatures(nfdv1alpha1.RuleBackrefDomain, nfdv1alpha1.RuleBackrefFeature, ruleOut.Vars)
 	}
 
 	if len(taints) > 0 {

--- a/pkg/kubectl-nfd/test.go
+++ b/pkg/kubectl-nfd/test.go
@@ -19,7 +19,6 @@ package kubectlnfd
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,21 +27,16 @@ import (
 
 	nfdclientset "sigs.k8s.io/node-feature-discovery/api/generated/clientset/versioned"
 	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
-
-	"sigs.k8s.io/yaml"
 )
 
-func Test(nodefeaturerulepath, nodeName, kubeconfig string) []error {
-	var errs []error
-	var err error
-
+func getNodeFeatures(nodeName, kubeconfig string) (*nfdv1alpha1.NodeFeatureSpec, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	if kubeconfig != "" {
 		loadingRules.ExplicitPath = kubeconfig
 	}
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{}).ClientConfig()
 	if err != nil {
-		return []error{fmt.Errorf("error building kubeconfig: %w", err)}
+		return nil, fmt.Errorf("error building kubeconfig: %w", err)
 	}
 
 	nfdClient := nfdclientset.NewForConfigOrDie(config)
@@ -50,7 +44,7 @@ func Test(nodefeaturerulepath, nodeName, kubeconfig string) []error {
 	sel := k8sLabels.SelectorFromSet(k8sLabels.Set{nfdv1alpha1.NodeFeatureObjNodeNameLabel: nodeName})
 	list, err := nfdClient.NfdV1alpha1().NodeFeatures(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{LabelSelector: sel.String()})
 	if err != nil {
-		return []error{fmt.Errorf("failed to get NodeFeature resources for node %q: %w", nodeName, err)}
+		return nil, fmt.Errorf("failed to get NodeFeature resources for node %q: %w", nodeName, err)
 	}
 	objs := list.Items
 	names := make([]string, len(objs))
@@ -67,19 +61,26 @@ func Test(nodefeaturerulepath, nodeName, kubeconfig string) []error {
 			s.MergeInto(features)
 		}
 	}
+	return features, nil
+}
 
-	nfrFile, err := os.ReadFile(nodefeaturerulepath)
+// Test reads a NodeFeatureRule or NodeFeatureGroup file and evaluates it against
+// the NodeFeature objects of the given node. The kind is detected automatically.
+func Test(resourcepath, nodeName, kubeconfig string) []error {
+	features, err := getNodeFeatures(nodeName, kubeconfig)
 	if err != nil {
-		return []error{fmt.Errorf("error reading NodeFeatureRule file: %w", err)}
+		return []error{err}
 	}
 
-	nfr := nfdv1alpha1.NodeFeatureRule{}
-	err = yaml.Unmarshal(nfrFile, &nfr)
-	if err != nil {
-		return []error{fmt.Errorf("error parsing NodeFeatureRule: %w", err)}
+	t := parseRuleFile(resourcepath)
+	switch o := t.(type) {
+	case *nfdv1alpha1.NodeFeatureRule:
+		return processNodeFeatureRule(*o, *features)
+	case *nfdv1alpha1.NodeFeatureGroup:
+		return processNodeFeatureGroup(*o, *features)
+	case []error:
+		return o
+	default:
+		return []error{fmt.Errorf("unsupported resource %v: must be NodeFeatureRule or NodeFeatureGroup", t)}
 	}
-
-	errs = append(errs, processNodeFeatureRule(nfr, *features)...)
-
-	return errs
 }

--- a/pkg/kubectl-nfd/validate.go
+++ b/pkg/kubectl-nfd/validate.go
@@ -18,31 +18,55 @@ package kubectlnfd
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/resource"
-	"sigs.k8s.io/yaml"
 
 	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
 	"sigs.k8s.io/node-feature-discovery/pkg/apis/nfd/validate"
 )
 
-// Given a file path, read the file and check if is a valid NodeFeatureRule file
-func ValidateNFR(filepath string) []error {
-	var err error
+// Validate reads a file and checks if it is a valid NodeFeatureRule or NodeFeatureGroup file.
+// The kind is detected automatically from the file content.
+func Validate(filepath string) []error {
+	t := parseRuleFile(filepath)
+	switch o := t.(type) {
+	case *nfdv1alpha1.NodeFeatureRule:
+		return validateNFR(*o)
+	case *nfdv1alpha1.NodeFeatureGroup:
+		return validateNFG(*o)
+	case []error:
+		return o
+	default:
+		return []error{fmt.Errorf("unsupported resource %v: must be NodeFeatureRule or NodeFeatureGroup", t)}
+	}
+}
+
+func validateNFG(nfg nfdv1alpha1.NodeFeatureGroup) []error {
 	var validationErr []error
 
-	file, err := os.ReadFile(filepath)
-	if err != nil {
-		return []error{fmt.Errorf("error reading NodeFeatureRule file: %w", err)}
+	for _, rule := range nfg.Spec.Rules {
+		fmt.Println("Validating rule: ", rule.Name)
+		// Validate Rule Name
+		if rule.Name == "" {
+			validationErr = append(validationErr, fmt.Errorf("rule name cannot be empty"))
+		}
+
+		// Validate VarsTemplate
+		validationErr = append(validationErr, validate.Template(rule.VarsTemplate)...)
+
+		// Validate matchFeatures
+		validationErr = append(validationErr, validate.MatchFeatures(rule.MatchFeatures)...)
+
+		// Validate matchAny
+		validationErr = append(validationErr, validate.MatchAny(rule.MatchAny)...)
 	}
 
-	nfr := nfdv1alpha1.NodeFeatureRule{}
-	err = yaml.Unmarshal(file, &nfr)
-	if err != nil {
-		return []error{fmt.Errorf("error reading NodeFeatureRule file: %w", err)}
-	}
+	return validationErr
+}
+
+func validateNFR(nfr nfdv1alpha1.NodeFeatureRule) []error {
+	var validationErr []error
 
 	for _, rule := range nfr.Spec.Rules {
 		fmt.Println("Validating rule: ", rule.Name)


### PR DESCRIPTION
Support NodeFeatureGroup for dryrun, validation and test.

--nodefeaturerule-file flag is renamed to --rule-file,
now supports both rules and groups.