### PR TITLE
api: register List types in scheme

### DIFF
--- a/api/nfd/v1alpha1/register.go
+++ b/api/nfd/v1alpha1/register.go
@@ -41,8 +41,11 @@ func Resource(resource string) schema.GroupResource {
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&NodeFeature{},
+		&NodeFeatureList{},
 		&NodeFeatureRule{},
+		&NodeFeatureRuleList{},
 		&NodeFeatureGroup{},
+		&NodeFeatureGroupList{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil


### PR DESCRIPTION
## Summary

Register NodeFeatureList, NodeFeatureRuleList, and NodeFeatureGroupList in the API scheme via addKnownTypes in `api/nfd/v1alpha1/register.go` This follows the standard Kubernetes convention of registering both singular and List types. The List types already exist in types.go with proper kubebuilder markers and generated `DeepCopyObject()`, but were not added to the scheme, preventing their use in kubebuilder controllers.

Fixes #2476

## Test plan

- make build passes
- make test passes (all unit tests, including `api/nfd/v1alpha1`)