### PR TITLE
feat(cpu): add x86-64 level CPUID flags

### DIFF
--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -119,6 +119,7 @@ configuration options for details.
 | VAES               | AVX-512 vector AES instructions |
 | VPCLMULQDQ         | Carry-less multiplication quadword |
 | WRMSRNS            | Non-Serializing Write to Model Specific Register |
+| X86_64_V1, X86_64_V2, X86_64_V3, X86_64_V4 | x86-64 microarchitecture level (v1-v4) per the x86-64 psABI spec (cumulative; a v4 CPU gets all four flags) |
 
 By default, the following CPUID flags have been blacklisted: AVX10 (use
 AVX10_VERSION instead), BMI1, BMI2, CLMUL, CMOV, CX16, ERMS, F16C, HTT, LZCNT,

--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -119,7 +119,7 @@ configuration options for details.
 | VAES               | AVX-512 vector AES instructions |
 | VPCLMULQDQ         | Carry-less multiplication quadword |
 | WRMSRNS            | Non-Serializing Write to Model Specific Register |
-| X86_64_V1, X86_64_V2, X86_64_V3, X86_64_V4 | x86-64 microarchitecture level (v1-v4) per the x86-64 psABI spec (cumulative; a v4 CPU gets all four flags) |
+| X86_64_V1, X86_64_V2, X86_64_V3, X86_64_V4 | x86-64 microarchitecture level (v1-v4) per the x86-64 psABI spec (cumulative; a v4 CPU gets all four flags). X86_64_V1 is the x86-64 baseline that essentially every amd64 node satisfies; it is kept mainly as a "level detection succeeded" marker, adding little scheduling signal beyond kubernetes.io/arch=amd64. |
 
 By default, the following CPUID flags have been blacklisted: AVX10 (use
 AVX10_VERSION instead), BMI1, BMI2, CLMUL, CMOV, CX16, ERMS, F16C, HTT, LZCNT,

--- a/source/cpu/cpu.go
+++ b/source/cpu/cpu.go
@@ -461,6 +461,18 @@ func (f keyFilter) unmask(k string) bool {
 	return false
 }
 
+// microarchLevelFlags maps an x86-64 psABI microarchitecture level to its
+// cumulative feature names (X86_64_V1..X86_64_V<level>); a level <= 0 yields
+// none. It is kept in this arch-neutral file, rather than cpuid_amd64.go, so
+// the mapping can be unit tested on any GOARCH.
+func microarchLevelFlags(level int) []string {
+	var flags []string
+	for i := 1; i <= level; i++ {
+		flags = append(flags, fmt.Sprintf("X86_64_V%d", i))
+	}
+	return flags
+}
+
 func init() {
 	source.Register(&src)
 }

--- a/source/cpu/cpu_test.go
+++ b/source/cpu/cpu_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cpu
 
 import (
+	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,5 +33,31 @@ func TestCpuSource(t *testing.T) {
 
 	assert.Nil(t, err, err)
 	assert.Empty(t, l)
+}
 
+func TestGetCpuidFlags_X86_64Levels(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("x86-64 microarchitecture levels only apply on amd64")
+	}
+
+	flags := getCpuidFlags()
+	flagSet := make(map[string]bool, len(flags))
+	for _, f := range flags {
+		flagSet[f] = true
+	}
+
+	// Every x86-64 CPU is at least level 1
+	assert.True(t, flagSet["X86_64_V1"], "expected X86_64_V1 flag on amd64")
+
+	// Levels must be cumulative: if V(n) is present, all V(1)..V(n-1) must be too
+	for level := 4; level >= 2; level-- {
+		flag := fmt.Sprintf("X86_64_V%d", level)
+		if !flagSet[flag] {
+			continue
+		}
+		for i := 1; i < level; i++ {
+			lower := fmt.Sprintf("X86_64_V%d", i)
+			assert.True(t, flagSet[lower], "X86_64_V%d present but %s missing", level, lower)
+		}
+	}
 }

--- a/source/cpu/cpu_test.go
+++ b/source/cpu/cpu_test.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/klauspost/cpuid/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,18 +47,32 @@ func TestGetCpuidFlags_X86_64Levels(t *testing.T) {
 		flagSet[f] = true
 	}
 
-	// Every x86-64 CPU is at least level 1
-	assert.True(t, flagSet["X86_64_V1"], "expected X86_64_V1 flag on amd64")
+	// V(i) must be present iff i <= the detected level. Asserting equality against
+	// X64Level pins both presence and absence; a cumulative-only check would hold by
+	// construction and miss an over-claimed level above what X64Level reports.
+	level := cpuid.CPU.X64Level()
+	for i := 1; i <= 4; i++ {
+		flag := fmt.Sprintf("X86_64_V%d", i)
+		assert.Equal(t, i <= level, flagSet[flag], "flag %s vs detected level %d", flag, level)
+	}
+}
 
-	// Levels must be cumulative: if V(n) is present, all V(1)..V(n-1) must be too
-	for level := 4; level >= 2; level-- {
-		flag := fmt.Sprintf("X86_64_V%d", level)
-		if !flagSet[flag] {
-			continue
-		}
-		for i := 1; i < level; i++ {
-			lower := fmt.Sprintf("X86_64_V%d", i)
-			assert.True(t, flagSet[lower], "X86_64_V%d present but %s missing", level, lower)
-		}
+func TestX86_64LevelFlags(t *testing.T) {
+	// Deterministic, host-independent check of the level-to-flags mapping. Unlike
+	// the test above, this catches an over-claimed level (e.g. a hardcoded 1..4
+	// loop) on any machine, since the expected flags don't depend on the host CPU.
+	cases := []struct {
+		level int
+		want  []string
+	}{
+		{level: -1, want: nil},
+		{level: 0, want: nil},
+		{level: 1, want: []string{"X86_64_V1"}},
+		{level: 2, want: []string{"X86_64_V1", "X86_64_V2"}},
+		{level: 3, want: []string{"X86_64_V1", "X86_64_V2", "X86_64_V3"}},
+		{level: 4, want: []string{"X86_64_V1", "X86_64_V2", "X86_64_V3", "X86_64_V4"}},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, microarchLevelFlags(tc.level), "level %d", tc.level)
 	}
 }

--- a/source/cpu/cpuid_amd64.go
+++ b/source/cpu/cpuid_amd64.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cpu
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/klauspost/cpuid/v2"
@@ -24,7 +25,15 @@ import (
 
 // getCpuidFlags returns feature names for all the supported CPU features.
 func getCpuidFlags() []string {
-	return cpuid.CPU.FeatureSet()
+	flags := cpuid.CPU.FeatureSet()
+
+	if level := cpuid.CPU.X64Level(); level > 0 {
+		for i := 1; i <= level; i++ {
+			flags = append(flags, fmt.Sprintf("X86_64_V%d", i))
+		}
+	}
+
+	return flags
 }
 
 func getCpuidAttributes() map[string]string {

--- a/source/cpu/cpuid_amd64.go
+++ b/source/cpu/cpuid_amd64.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cpu
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/klauspost/cpuid/v2"
@@ -26,12 +25,7 @@ import (
 // getCpuidFlags returns feature names for all the supported CPU features.
 func getCpuidFlags() []string {
 	flags := cpuid.CPU.FeatureSet()
-
-	if level := cpuid.CPU.X64Level(); level > 0 {
-		for i := 1; i <= level; i++ {
-			flags = append(flags, fmt.Sprintf("X86_64_V%d", i))
-		}
-	}
+	flags = append(flags, microarchLevelFlags(cpuid.CPU.X64Level())...)
 
 	return flags
 }


### PR DESCRIPTION
## Summary

Adds x86-64 microarchitecture level (v1-v4) as cumulative CPUID flags using the `klauspost/cpuid/v2` `X64Level()` API that is already vendored at v2.3.0.
A v4-capable node produces:

```
feature.node.kubernetes.io/cpu-cpuid.X86_64_V1=true
feature.node.kubernetes.io/cpu-cpuid.X86_64_V2=true
feature.node.kubernetes.io/cpu-cpuid.X86_64_V3=true
feature.node.kubernetes.io/cpu-cpuid.X86_64_V4=true
```

This enables scheduling workloads that require a minimum microarchitecture level
without numeric comparisons:

```yaml
nodeSelector:
  feature.node.kubernetes.io/cpu-cpuid.X86_64_V3: "true"
```

The flags are also available for NodeFeatureRule matching via cpu.cpuid.

## Why

Addresses #2046. Individual CPUID feature flags create clutter and don't map cleanly to the x86-64 psABI-defined microarchitecture levels that users actually care about for scheduling. The cumulative flag approach was discussed and agreed upon in the issue thread.

