### PR TITLE
feat(network): add aggregated SR-IOV VF count labels

### DIFF
--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -197,6 +197,8 @@ configuration options for details.
 | ------------------------------| ----- | --------------------------------------------------------------- |
 | **`network-sriov.capable`**   | true  | [Single Root Input/Output Virtualization][sriov] (SR-IOV) enabled Network Interface Card(s) present |
 | **`network-sriov.configured`**| true  | SR-IOV virtual functions have been configured                   |
+| **`network-sriov.total_vfs`** | 254   | Total SR-IOV VF capacity aggregated across all physical NICs    |
+| **`network-sriov.num_vfs`**   | 128   | Number of configured SR-IOV VFs aggregated across all physical NICs |
 
 ### PCI
 

--- a/source/network/network.go
+++ b/source/network/network.go
@@ -76,24 +76,54 @@ func (s *networkSource) Priority() int { return 0 }
 func (s *networkSource) GetLabels() (source.FeatureLabels, error) {
 	labels := source.FeatureLabels{}
 	features := s.GetFeatures()
+	totalVFsAll := 0
+	numVFsAll := 0
+	sriovCapable := false
 
 	for _, dev := range features.Instances[DeviceFeature].Elements {
 		attrs := dev.Attributes
-		for attr, feature := range map[string]string{
-			"sriov_totalvfs": "sriov.capable",
-			"sriov_numvfs":   "sriov.configured"} {
 
-			if v, ok := attrs[attr]; ok {
-				t, err := strconv.Atoi(v)
-				if err != nil {
-					klog.ErrorS(err, "failed to parse sriov attribute", "attributeName", attr, "deviceName", attrs["name"])
-					continue
-				}
-				if t > 0 {
-					labels[feature] = true
-				}
+		totalVFs := 0
+		numVFs := 0
+
+		// Parse total VFs
+		if v, ok := attrs["sriov_totalvfs"]; ok {
+			t, err := strconv.Atoi(v)
+			if err != nil {
+				klog.ErrorS(err, "failed to parse sriov_totalvfs", "deviceName", attrs["name"], "value", v)
+			} else {
+				totalVFs = t
 			}
 		}
+
+		// Parse configured VFs
+		if v, ok := attrs["sriov_numvfs"]; ok {
+			t, err := strconv.Atoi(v)
+			if err != nil {
+				klog.ErrorS(err, "failed to parse sriov_numvfs", "deviceName", attrs["name"], "value", v)
+			} else {
+				numVFs = t
+			}
+		}
+
+		if totalVFs > 0 {
+			sriovCapable = true
+			totalVFsAll += totalVFs
+		}
+
+		if numVFs > 0 {
+			numVFsAll += numVFs
+		}
+	}
+
+	if sriovCapable {
+		labels["sriov.capable"] = true
+		labels["sriov.total_vfs"] = totalVFsAll
+	}
+
+	if numVFsAll > 0 {
+		labels["sriov.configured"] = true
+		labels["sriov.num_vfs"] = numVFsAll
 	}
 	return labels, nil
 }

--- a/source/network/network_test.go
+++ b/source/network/network_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
 )
 
 func TestNetworkSource(t *testing.T) {
@@ -32,4 +33,168 @@ func TestNetworkSource(t *testing.T) {
 	assert.Nil(t, err, err)
 	assert.Empty(t, l)
 
+}
+
+func TestGetLabelsSriovAggregation(t *testing.T) {
+	tests := []struct {
+		name     string
+		devices  []map[string]string
+		expected map[string]interface{}
+	}{
+		{
+			name: "single NIC",
+			devices: []map[string]string{
+				{
+					"name":           "eth0",
+					"sriov_totalvfs": "8",
+					"sriov_numvfs":   "2",
+				},
+			},
+			expected: map[string]interface{}{
+				"sriov.capable":    true,
+				"sriov.configured": true,
+				"sriov.total_vfs":  8,
+				"sriov.num_vfs":    2,
+			},
+		},
+		{
+			name: "multi NIC aggregation",
+			devices: []map[string]string{
+				{
+					"name":           "eth0",
+					"sriov_totalvfs": "8",
+					"sriov_numvfs":   "2",
+				},
+				{
+					"name":           "eth1",
+					"sriov_totalvfs": "16",
+					"sriov_numvfs":   "4",
+				},
+			},
+			expected: map[string]interface{}{
+				"sriov.capable":    true,
+				"sriov.configured": true,
+				"sriov.total_vfs":  24,
+				"sriov.num_vfs":    6,
+			},
+		},
+		{
+			name: "exclude zero totalvfs (still counts num_vfs)",
+			devices: []map[string]string{
+				{
+					"name":           "eth0",
+					"sriov_totalvfs": "0",
+					"sriov_numvfs":   "4",
+				},
+			},
+			expected: map[string]interface{}{
+				"sriov.configured": true,
+				"sriov.num_vfs":    4,
+			},
+		},
+		{
+			name: "malformed totalvfs",
+			devices: []map[string]string{
+				{
+					"name":           "eth0",
+					"sriov_totalvfs": "invalid",
+					"sriov_numvfs":   "2",
+				},
+			},
+			expected: map[string]interface{}{
+				"sriov.configured": true,
+				"sriov.num_vfs":    2,
+			},
+		},
+		{
+			name: "malformed numvfs",
+			devices: []map[string]string{
+				{
+					"name":           "eth0",
+					"sriov_totalvfs": "8",
+					"sriov_numvfs":   "garbage",
+				},
+			},
+			expected: map[string]interface{}{
+				"sriov.capable":   true,
+				"sriov.total_vfs": 8,
+			},
+		},
+		{
+			name: "mixed valid and invalid devices",
+			devices: []map[string]string{
+				{
+					"name":           "eth0",
+					"sriov_totalvfs": "8",
+					"sriov_numvfs":   "2",
+				},
+				{
+					"name":           "eth1",
+					"sriov_totalvfs": "invalid",
+					"sriov_numvfs":   "4",
+				},
+				{
+					"name":           "eth2",
+					"sriov_totalvfs": "0",
+					"sriov_numvfs":   "1",
+				},
+			},
+			expected: map[string]interface{}{
+				"sriov.capable":    true,
+				"sriov.configured": true,
+				"sriov.total_vfs":  8,
+				"sriov.num_vfs":    7, // 2 + 4 + 1
+			},
+		},
+		{
+			name: "no sriov anywhere",
+			devices: []map[string]string{
+				{
+					"name": "eth0",
+				},
+			},
+			expected: map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &networkSource{
+				features: nfdv1alpha1.NewFeatures(),
+			}
+
+			var elems []nfdv1alpha1.InstanceFeature
+			for _, dev := range tt.devices {
+				elems = append(elems, *nfdv1alpha1.NewInstanceFeature(dev))
+			}
+
+			s.features.Instances[DeviceFeature] = nfdv1alpha1.InstanceFeatureSet{
+				Elements: elems,
+			}
+
+			labels, err := s.GetLabels()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Validate expected labels
+			for k, v := range tt.expected {
+				got, ok := labels[k]
+				if !ok {
+					t.Errorf("expected label %q not found", k)
+					continue
+				}
+				if got != v {
+					t.Errorf("label %q: expected %v, got %v", k, v, got)
+				}
+			}
+
+			// Ensure no unexpected labels
+			for k := range labels {
+				if _, ok := tt.expected[k]; !ok {
+					t.Errorf("unexpected label %q present", k)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
Expose total SR-IOV VF capacity and configured VF count across all network devices on the node.


Current SR-IOV labels(https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/docs/usage/features.md?plain=1#L194-L200)
 (sriov.capable, sriov.configured) are boolean and don't expose the actual VF counts.

**New Labels**

- **network-sriov.total_vfs**: Total SR-IOV VF capacity across all NICs
- **network-sriov.num_vfs**: Total configured (active) VFs across all NICs

**Behavior Changes**

Before this PR Only boolean labels were exposed:

- feature.node.kubernetes.io/network-sriov.capable: "true"
- feature.node.kubernetes.io/network-sriov.configured: "true"

**After this PR**

- feature.node.kubernetes.io/network-sriov.capable=true
- feature.node.kubernetes.io/network-sriov.configured=true
- feature.node.kubernetes.io/network-sriov.total_vfs=254
- feature.node.kubernetes.io/network-sriov.num_vfs=4

**Key Points**

- **total_vfs** is capacity (sum of all NICs)
- **num_vfs** is runtime configured VFs
- num_vfs is aggregated independently of total_vfs
- Labels are only set when meaningful:
        - capable → if any NIC supports SR-IOV
        - configured → if any VF is configured

**Tests**

Added table-driven tests covering:

- Single NIC
- Multi-NIC aggregation
- Devices with sriov_totalvfs=0
- Malformed sysfs values
- Mixed valid/invalid devices
- No SR-IOV present

**Docs**

Updated docs/usage/features.md to include:
network-sriov.total_vfs
network-sriov.num_vfs

with a note that values are aggregated across all physical NICs.

**Notes**
Backward compatible: existing labels unchanged
New labels are additive