### PR TITLE
template + custom/api: minor input-validation tweaks

### DIFF
--- a/pkg/apis/nfd/template/template.go
+++ b/pkg/apis/nfd/template/template.go
@@ -18,6 +18,7 @@ package template
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 	"text/template"
@@ -29,8 +30,36 @@ type Helper struct {
 	template *template.Template
 }
 
+// funcMap returns sprig's text-template FuncMap with the host-environment
+// functions removed. env / expandenv / getHostByName are the only sprig
+// builtins that read process state or outbound DNS — leaving the rest
+// (date, random, string, list, etc.) available for legitimate use in
+// label expansion.
+func funcMap() template.FuncMap {
+	m := sprig.TxtFuncMap()
+	for _, name := range []string{"env", "expandenv", "getHostByName"} {
+		delete(m, name)
+	}
+	return m
+}
+
+// MaxTemplateSize bounds the input to text/template.Parse to prevent stack-
+// overflow aborts from recursive descent in text/template/parse. Per-action
+// parser stack cost is ~1.7 KiB and minimum action width is ~5 bytes, so a
+// 64 KiB cap bounds total stack growth at ~22 MiB — well below Go's 1 GiB
+// goroutine stack ceiling.
+const MaxTemplateSize = 64 * 1024
+
+// ErrTemplateTooLarge is returned by NewHelper when the input template
+// exceeds MaxTemplateSize. Exported so callers can distinguish this
+// from generic parse errors via errors.Is.
+var ErrTemplateTooLarge = errors.New("template exceeds maximum allowed size")
+
 func NewHelper(name string) (*Helper, error) {
-	tmpl := template.New("").Funcs(sprig.FuncMap()).Option("missingkey=error")
+	if len(name) > MaxTemplateSize {
+		return nil, fmt.Errorf("%w: %d bytes > %d limit", ErrTemplateTooLarge, len(name), MaxTemplateSize)
+	}
+	tmpl := template.New("").Funcs(funcMap()).Option("missingkey=error")
 	tmpl, err := tmpl.Parse(name)
 	if err != nil {
 		return nil, fmt.Errorf("invalid template: %w", err)

--- a/pkg/apis/nfd/template/template_test.go
+++ b/pkg/apis/nfd/template/template_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	stdtemplate "text/template"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMain handles a subprocess re-exec used by TestParse_LargeInputExitsQuickly.
+// When NFD_TEMPLATE_LARGE_INPUT is set, this binary runs text/template.Parse
+// directly on a pathologically large input, bypassing NewHelper's size cap.
+// Otherwise, runs the normal test suite.
+func TestMain(m *testing.M) {
+	if os.Getenv("NFD_TEMPLATE_LARGE_INPUT") == "1" {
+		_, _ = stdtemplate.New("").Parse(strings.Repeat("{{if 1}}", 600_000))
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func TestNewHelper_RejectsOverBoundary(t *testing.T) {
+	_, err := NewHelper(strings.Repeat("a", MaxTemplateSize+1))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrTemplateTooLarge),
+		"expected ErrTemplateTooLarge, got %v", err)
+}
+
+func TestNewHelper_AcceptsBoundary(t *testing.T) {
+	// Exactly at the cap must be accepted. Input is plain text (no template
+	// actions) so the parser does no recursion regardless of length.
+	_, err := NewHelper(strings.Repeat("a", MaxTemplateSize))
+	require.NoError(t, err)
+}
+
+func TestNewHelper_RejectsLargeInput(t *testing.T) {
+	// A 600_000-action input is well over the cap. NewHelper should reject
+	// it via the size guard rather than letting it through to the recursive
+	// parser.
+	_, err := NewHelper(strings.Repeat("{{if 1}}", 600_000))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrTemplateTooLarge),
+		"expected ErrTemplateTooLarge, got %v", err)
+}
+
+func TestParse_LargeInputExitsQuickly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess re-exec is slow under -short")
+	}
+	// Subprocess re-exec: the child runs text/template.Parse directly on a
+	// 600_000-action input (bypassing NewHelper's size cap). text/template
+	// does not internally bound input compute, so the application-layer cap
+	// is what keeps parse latency predictable. The child is expected to NOT
+	// complete the parse cleanly and to exit quickly rather than hang. If a
+	// future Go release changes that behavior, this test will flip and the
+	// application-layer cap may become tunable rather than load-bearing.
+	cmd := exec.Command(os.Args[0], "-test.run=^$")
+	cmd.Env = append(os.Environ(), "NFD_TEMPLATE_LARGE_INPUT=1")
+	start := time.Now()
+	_, err := cmd.CombinedOutput()
+	elapsed := time.Since(start)
+	require.Error(t, err, "child should not complete the parse cleanly")
+	require.Less(t, elapsed.Seconds(), 30.0, "child should exit quickly, not hang")
+}
+
+func TestNewHelper_DropsHostEnvFuncs(t *testing.T) {
+	// env / expandenv / getHostByName read process env and outbound DNS;
+	// not useful for NodeFeatureRule label expansion.
+	for _, tmpl := range []string{
+		`{{env "PATH"}}`,
+		`{{expandenv "$PATH"}}`,
+		`{{getHostByName "localhost"}}`,
+	} {
+		_, err := NewHelper(tmpl)
+		require.Error(t, err, "expected %q to fail", tmpl)
+	}
+}
+
+func TestNewHelper_KeepsUsefulSprigFuncs(t *testing.T) {
+	// Sanity: sprig's general-purpose functions remain available. Picks one
+	// from each major category; not exhaustive.
+	for _, tmpl := range []string{
+		`{{upper "x"}}`,
+		`{{add 1 2}}`,
+		`{{trim " x "}}`,
+	} {
+		_, err := NewHelper(tmpl)
+		require.NoError(t, err, "expected %q to succeed", tmpl)
+	}
+}

--- a/source/custom/api/expression.go
+++ b/source/custom/api/expression.go
@@ -17,12 +17,60 @@ limitations under the License.
 package api
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 )
+
+// MaxJSONDepth bounds JSON nesting depth in MatchExpression(.Set) decoding.
+// Go's encoding/json already imposes its own (~10k) cap; this tighter
+// application-layer limit rejects pathological inputs earlier with a
+// clearer error and stays effective on toolchains that lack the
+// internal cap.
+const MaxJSONDepth = 100
+
+// ErrJSONTooDeep is returned when a MatchExpression(.Set) input exceeds
+// MaxJSONDepth.
+var ErrJSONTooDeep = errors.New("JSON nesting exceeds maximum depth")
+
+// boundedJSONDepth scans data with json.Decoder.Token and returns an
+// error if nesting exceeds maxDepth. Token consumes ~constant memory
+// per level, so this is safe to call before json.Unmarshal.
+//
+// Any tokenizer error (io.EOF or malformed JSON) returns nil — the
+// caller's subsequent json.Unmarshal surfaces the canonical parse
+// error. boundedJSONDepth only enforces the depth invariant.
+//
+// Only MatchExpression and MatchExpressionSet need this pre-check.
+// MatchOp and MatchValue UnmarshalJSON receive scalar / flat-array
+// input and do not recurse into nested containers.
+func boundedJSONDepth(data []byte, maxDepth int) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	depth := 0
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil
+		}
+		delim, ok := tok.(json.Delim)
+		if !ok {
+			continue
+		}
+		switch delim {
+		case '{', '[':
+			depth++
+			if depth > maxDepth {
+				return fmt.Errorf("%w: %d > %d", ErrJSONTooDeep, depth, maxDepth)
+			}
+		case '}', ']':
+			depth--
+		}
+	}
+}
 
 var matchOps = map[MatchOp]struct{}{
 	MatchAny:          {},
@@ -100,6 +148,10 @@ type matchExpression MatchExpression
 
 // UnmarshalJSON implements the Unmarshaler interface of "encoding/json"
 func (m *MatchExpression) UnmarshalJSON(data []byte) error {
+	if err := boundedJSONDepth(data, MaxJSONDepth); err != nil {
+		return err
+	}
+
 	raw := new(interface{})
 
 	err := json.Unmarshal(data, raw)
@@ -139,6 +191,10 @@ func (m *MatchExpression) UnmarshalJSON(data []byte) error {
 
 // UnmarshalJSON implements the Unmarshaler interface of "encoding/json".
 func (m *MatchExpressionSet) UnmarshalJSON(data []byte) error {
+	if err := boundedJSONDepth(data, MaxJSONDepth); err != nil {
+		return err
+	}
+
 	*m = MatchExpressionSet{}
 
 	names := make([]string, 0)

--- a/source/custom/api/expression_test.go
+++ b/source/custom/api/expression_test.go
@@ -17,10 +17,43 @@ limitations under the License.
 package api
 
 import (
+	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMatchExpression_RejectsDeepNesting(t *testing.T) {
+	deep := strings.Repeat("[", MaxJSONDepth+1) + strings.Repeat("]", MaxJSONDepth+1)
+	var m MatchExpression
+	err := json.Unmarshal([]byte(deep), &m)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrJSONTooDeep),
+		"expected ErrJSONTooDeep, got %v", err)
+}
+
+func TestMatchExpressionSet_RejectsDeepNesting(t *testing.T) {
+	deep := strings.Repeat("[", MaxJSONDepth+1) + strings.Repeat("]", MaxJSONDepth+1)
+	var s MatchExpressionSet
+	err := json.Unmarshal([]byte(deep), &s)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrJSONTooDeep),
+		"expected ErrJSONTooDeep, got %v", err)
+}
+
+func TestMatchExpression_AcceptsDepthAtCap(t *testing.T) {
+	// Boundary check: exactly MaxJSONDepth levels must NOT trigger
+	// ErrJSONTooDeep. The content is otherwise invalid for a
+	// MatchExpression, so json.Unmarshal will fail with a different
+	// (downstream) error — we only assert the depth check did not fire.
+	atCap := strings.Repeat("[", MaxJSONDepth) + strings.Repeat("]", MaxJSONDepth)
+	var m MatchExpression
+	err := json.Unmarshal([]byte(atCap), &m)
+	assert.False(t, errors.Is(err, ErrJSONTooDeep),
+		"depth at cap should not trigger ErrJSONTooDeep; got %v", err)
+}
 
 type BoolAssertionFunc func(assert.TestingT, bool, ...interface{}) bool
 


### PR DESCRIPTION
A few small input-validation tweaks I noticed while reading around the
template and custom-source decoding code.

**`pkg/apis/nfd/template`:**

1. Cap `labelsTemplate` / `varsTemplate` at 64 KiB in `NewHelper` before
   calling `text/template.Parse`. `text/template` parses recursively and
   very large inputs do a lot of recursive work before any rule even
   matches. Adds a typed `ErrTemplateTooLarge` so callers can tell this
   apart from generic parse errors. Real templates in our examples are
   tens to hundreds of bytes; 64 KiB is well above realistic use.

2. Drop `env` / `expandenv` / `getHostByName` from sprig's FuncMap.
   These three are the only sprig builtins that read process
   environment or outbound DNS, and aren't useful for `NodeFeatureRule`
   label expansion. The rest of sprig (date, random, string, list,
   etc.) stays available. Templates calling `{{env ...}}` /
   `{{expandenv ...}}` / `{{getHostByName ...}}` will now fail to parse
   with function-not-defined — worth a release note.

**`source/custom/api`:**

3. Cap JSON nesting depth in `MatchExpression` / `MatchExpressionSet`
   `UnmarshalJSON`. Go 1.26's json decoder caps depth internally (~10k)
   so the immediate risk is gone on current toolchains, but we fail
   earlier with a clearer error tied to the NFD type and stay covered
   against older Go toolchains. Gated at 100 levels (real custom-source
   configs are 2-3 levels deep at most). Adds typed `ErrJSONTooDeep`.

Tests in `pkg/apis/nfd/template/template_test.go` and
`source/custom/api/expression_test.go`. `make test` clean.