### PR TITLE
custom/api: cap JSON nesting depth in MatchExpression(.Set) Unmarshal

### DIFF
--- a/source/custom/api/expression.go
+++ b/source/custom/api/expression.go
@@ -17,12 +17,58 @@ limitations under the License.
 package api
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"regexp"
 	"strconv"
 	"strings"
 )
+
+// MaxJSONDepth bounds JSON nesting depth in MatchExpression(.Set) decoding.
+// Go's encoding/json already imposes its own (~10k) cap; this tighter
+// application-layer limit rejects pathological inputs earlier with a
+// clearer error and stays effective on toolchains that lack the
+// internal cap.
+const MaxJSONDepth = 100
+
+// ErrJSONTooDeep is returned when a MatchExpression(.Set) input exceeds
+// MaxJSONDepth.
+var ErrJSONTooDeep = errors.New("JSON nesting exceeds maximum depth")
+
+// boundedJSONDepth scans data with json.Decoder.Token and returns an
+// error if nesting exceeds maxDepth. Token consumes ~constant memory
+// per level, so this is safe to call before json.Unmarshal. Returns
+// nil on malformed JSON — the caller's subsequent decode produces the
+// canonical parse error.
+func boundedJSONDepth(data []byte, maxDepth int) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	depth := 0
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return nil
+		}
+		delim, ok := tok.(json.Delim)
+		if !ok {
+			continue
+		}
+		switch delim {
+		case '{', '[':
+			depth++
+			if depth > maxDepth {
+				return fmt.Errorf("%w: %d > %d", ErrJSONTooDeep, depth, maxDepth)
+			}
+		case '}', ']':
+			depth--
+		}
+	}
+}
 
 var matchOps = map[MatchOp]struct{}{
 	MatchAny:          {},
@@ -100,6 +146,10 @@ type matchExpression MatchExpression
 
 // UnmarshalJSON implements the Unmarshaler interface of "encoding/json"
 func (m *MatchExpression) UnmarshalJSON(data []byte) error {
+	if err := boundedJSONDepth(data, MaxJSONDepth); err != nil {
+		return err
+	}
+
 	raw := new(interface{})
 
 	err := json.Unmarshal(data, raw)
@@ -139,6 +189,10 @@ func (m *MatchExpression) UnmarshalJSON(data []byte) error {
 
 // UnmarshalJSON implements the Unmarshaler interface of "encoding/json".
 func (m *MatchExpressionSet) UnmarshalJSON(data []byte) error {
+	if err := boundedJSONDepth(data, MaxJSONDepth); err != nil {
+		return err
+	}
+
 	*m = MatchExpressionSet{}
 
 	names := make([]string, 0)

--- a/source/custom/api/expression_test.go
+++ b/source/custom/api/expression_test.go
@@ -17,10 +17,31 @@ limitations under the License.
 package api
 
 import (
+	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMatchExpression_RejectsDeepNesting(t *testing.T) {
+	deep := strings.Repeat("[", MaxJSONDepth+1) + strings.Repeat("]", MaxJSONDepth+1)
+	var m MatchExpression
+	err := json.Unmarshal([]byte(deep), &m)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrJSONTooDeep),
+		"expected ErrJSONTooDeep, got %v", err)
+}
+
+func TestMatchExpressionSet_RejectsDeepNesting(t *testing.T) {
+	deep := strings.Repeat("[", MaxJSONDepth+1) + strings.Repeat("]", MaxJSONDepth+1)
+	var s MatchExpressionSet
+	err := json.Unmarshal([]byte(deep), &s)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrJSONTooDeep),
+		"expected ErrJSONTooDeep, got %v", err)
+}
 
 type BoolAssertionFunc func(assert.TestingT, bool, ...interface{}) bool
 


### PR DESCRIPTION
While reading `expression.go` I noticed `MatchExpression` and
`MatchExpressionSet` `UnmarshalJSON` hand the raw bytes straight to
`encoding/json` with an `interface{}` target.

Go 1.26's json decoder has its own internal depth cap (~10k), so the
immediate risk is gone on current toolchains, but we can fail earlier
with a clearer error tied to the NFD type, and stay covered if anyone
builds against an older Go toolchain.

Adds a small depth-counting `Token` pre-pass before `json.Unmarshal`,
gated at 100 levels (real custom-source configs are 2-3 levels deep at
most). Returns a typed `ErrJSONTooDeep` so callers can distinguish it
from a generic parse error.

Tests in `source/custom/api/expression_test.go`.