### PR TITLE
topology-updater: serve per-pod lookups from a node-scoped Pod informer

### DIFF
--- a/deployment/base/rbac-topologyupdater/topologyupdater-clusterrole.yaml
+++ b/deployment/base/rbac-topologyupdater/topologyupdater-clusterrole.yaml
@@ -28,6 +28,8 @@ rules:
   - pods
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - topology.node.k8s.io
   resources:

--- a/deployment/helm/node-feature-discovery/templates/clusterrole.yaml
+++ b/deployment/helm/node-feature-discovery/templates/clusterrole.yaml
@@ -91,6 +91,8 @@ rules:
   - pods
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - topology.node.k8s.io
   resources:

--- a/pkg/nfd-topology-updater/nfd-topology-updater.go
+++ b/pkg/nfd-topology-updater/nfd-topology-updater.go
@@ -24,14 +24,18 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
 	k8sclient "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 
@@ -49,6 +53,11 @@ import (
 	"sigs.k8s.io/node-feature-discovery/pkg/version"
 	"sigs.k8s.io/yaml"
 )
+
+// nodeScopedPodInformerResync is zero because topology scans read pods
+// from the cached lister only. This value only makes sense when event
+// handlers are registered to the informer.
+const nodeScopedPodInformerResync = 0
 
 const (
 	// TopologyManagerPolicyAttributeName represents an attribute which defines
@@ -200,9 +209,50 @@ func (w *nfdTopologyUpdater) Run() error {
 		return fmt.Errorf("faild to configure Node Feature Discovery Topology Updater: %w", err)
 	}
 
+	syncCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// Build a node-scoped Pod informer so per-pod lookups in
+	// PodResourcesScanner.isWatchable() are served from a local cache
+	// avoiding cluster-wide pod traffic.
+	podInformerFactory := informers.NewSharedInformerFactoryWithOptions(
+		k8sClient,
+		nodeScopedPodInformerResync,
+		informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+			opts.FieldSelector = fields.OneTermEqualSelector("spec.nodeName", w.nodeName).String()
+		}),
+	)
+	podInformer := podInformerFactory.Core().V1().Pods()
+	podLister := podInformer.Lister()
+
+	podInformerStop := make(chan struct{})
+	var stopPodInformerOnce sync.Once
+	stopPodInformer := func() {
+		stopPodInformerOnce.Do(func() {
+			close(podInformerStop)
+		})
+	}
+	defer stopPodInformer()
+
+	go func() {
+		select {
+		case <-w.stop:
+			cancel()
+			stopPodInformer()
+		case <-podInformerStop:
+		}
+	}()
+
+	podInformerFactory.Start(podInformerStop)
+	klog.InfoS("waiting for node-scoped Pod informer cache sync", "nodeName", w.nodeName)
+	if !cache.WaitForCacheSync(syncCtx.Done(), podInformer.Informer().HasSynced) {
+		return fmt.Errorf("timed out waiting for node-scoped Pod informer cache sync for node %q", w.nodeName)
+	}
+	klog.InfoS("node-scoped Pod informer cache synced", "nodeName", w.nodeName)
+
 	var resScan resourcemonitor.ResourcesScanner
 
-	resScan, err = resourcemonitor.NewPodResourcesScanner(w.resourcemonitorArgs.Namespace, podResClient, k8sClient, w.resourcemonitorArgs.PodSetFingerprint)
+	resScan, err = resourcemonitor.NewPodResourcesScanner(w.resourcemonitorArgs.Namespace, podResClient, podLister, k8sClient, w.resourcemonitorArgs.PodSetFingerprint)
 	if err != nil {
 		return fmt.Errorf("failed to initialize ResourceMonitor instance: %w", err)
 	}

--- a/pkg/resourcemonitor/podresourcesscanner.go
+++ b/pkg/resourcemonitor/podresourcesscanner.go
@@ -22,8 +22,10 @@ import (
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	client "k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 	"k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
@@ -35,15 +37,25 @@ import (
 type PodResourcesScanner struct {
 	namespace         string
 	podResourceClient podresourcesapi.PodResourcesListerClient
+	podLister         corev1listers.PodLister
 	k8sClient         client.Interface
 	podFingerprint    bool
 }
 
 // NewPodResourcesScanner creates a new ResourcesScanner instance
-func NewPodResourcesScanner(namespace string, podResourceClient podresourcesapi.PodResourcesListerClient, k8sClient client.Interface, podFingerprint bool) (ResourcesScanner, error) {
+func NewPodResourcesScanner(namespace string, podResourceClient podresourcesapi.PodResourcesListerClient, podLister corev1listers.PodLister, k8sClient client.Interface, podFingerprint bool) (ResourcesScanner, error) {
+	if k8sClient == nil {
+		return nil, fmt.Errorf("kubernetes client is required")
+	}
+
+	if podLister == nil {
+		return nil, fmt.Errorf("pod lister is required")
+	}
+
 	resourcemonitorInstance := &PodResourcesScanner{
 		namespace:         namespace,
 		podResourceClient: podResourceClient,
+		podLister:         podLister,
 		k8sClient:         k8sClient,
 		podFingerprint:    podFingerprint,
 	}
@@ -59,14 +71,26 @@ func NewPodResourcesScanner(namespace string, podResourceClient podresourcesapi.
 // isWatchable tells if the the given namespace should be watched.
 // In Scan(), if watchable is false, this pods scan will skip
 // so we can return directly if pod's namespace is not watchable
-func (resMon *PodResourcesScanner) isWatchable(podResource *podresourcesapi.PodResources) (bool, bool, error) {
+func (resMon *PodResourcesScanner) isWatchable(ctx context.Context, podResource *podresourcesapi.PodResources) (bool, bool, error) {
 	if resMon.namespace != "*" && resMon.namespace != podResource.GetNamespace() {
 		return false, false, nil
 	}
 
-	pod, err := resMon.k8sClient.CoreV1().Pods(podResource.GetNamespace()).Get(context.TODO(), podResource.Name, metav1.GetOptions{})
+	ns := podResource.GetNamespace()
+	name := podResource.GetName()
+
+	pod, err := resMon.podLister.Pods(ns).Get(name)
 	if err != nil {
-		return false, false, err
+		if !apierrors.IsNotFound(err) {
+			return false, false, err
+		}
+		// The informer cache can lag behind the kubelet PodResources API. Use a
+		// live GET to preserve topology correctness.
+		klog.InfoS("pod not in informer cache, falling back to GET", "namespace", ns, "podName", name)
+		pod, err = resMon.k8sClient.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, false, err
+		}
 	}
 
 	isPodGuaranteed := qos.GetPodQOS(pod) == corev1.PodQOSGuaranteed
@@ -137,7 +161,7 @@ func (resMon *PodResourcesScanner) Scan() (ScanResponse, error) {
 
 	for _, podResource := range respPodResources {
 		klog.V(1).InfoS("scanning pod", "podName", podResource.GetName())
-		isWatchable, isExclusiveCPUs, err := resMon.isWatchable(podResource)
+		isWatchable, isExclusiveCPUs, err := resMon.isWatchable(ctx, podResource)
 		if err != nil {
 			return ScanResponse{}, fmt.Errorf("checking if pod in a namespace is watchable, namespace:%v, pod name %v: %w", podResource.GetNamespace(), podResource.GetName(), err)
 		}

--- a/pkg/resourcemonitor/podresourcesscanner_test.go
+++ b/pkg/resourcemonitor/podresourcesscanner_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resourcemonitor
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -26,13 +28,150 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	v1 "k8s.io/kubelet/pkg/apis/podresources/v1"
 
 	mockpodres "sigs.k8s.io/node-feature-discovery/pkg/podres/mocks"
 )
+
+// newFakePodLister returns a PodLister backed by an in-memory indexer
+// pre-populated with the given pods. It avoids spinning up a fake
+// clientset / informer / sync loop in unit tests; PodLister only needs
+// an Indexer, and tests for PodResourcesScanner exercise lookups not
+// reflector behavior.
+func newFakePodLister(pods ...*corev1.Pod) corev1listers.PodLister {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, pod := range pods {
+		_ = indexer.Add(pod)
+	}
+	return corev1listers.NewPodLister(indexer)
+}
+
+type errorPodLister struct {
+	err error
+}
+
+func (l errorPodLister) List(selector labels.Selector) ([]*corev1.Pod, error) {
+	return nil, l.err
+}
+
+func (l errorPodLister) Pods(namespace string) corev1listers.PodNamespaceLister {
+	return errorPodNamespaceLister(l)
+}
+
+type errorPodNamespaceLister struct {
+	err error
+}
+
+func (l errorPodNamespaceLister) List(selector labels.Selector) ([]*corev1.Pod, error) {
+	return nil, l.err
+}
+
+func (l errorPodNamespaceLister) Get(name string) (*corev1.Pod, error) {
+	return nil, l.err
+}
+
+func TestNewPodResourcesScannerRequiresKubernetesClient(t *testing.T) {
+	Convey("When I create a pod resources scanner without a Kubernetes client", t, func() {
+		resScan, err := NewPodResourcesScanner("*", nil, newFakePodLister(), nil, false)
+
+		Convey("Error is present", func() {
+			So(err, ShouldNotBeNil)
+		})
+		Convey("Return ResourcesScanner should be nil", func() {
+			So(resScan, ShouldBeNil)
+		})
+	})
+}
+
+func TestIsWatchable(t *testing.T) {
+	Convey("When pod is missing from the lister and live GET succeeds", t, func() {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "test-container",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+								corev1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+								corev1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
+							},
+						},
+					},
+				},
+			},
+		}
+		resScan := &PodResourcesScanner{
+			namespace: "*",
+			podLister: newFakePodLister(),
+			k8sClient: fakeclient.NewClientset(pod),
+		}
+
+		isWatchable, isExclusiveCPUs, err := resScan.isWatchable(context.Background(), &v1.PodResources{
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		})
+
+		Convey("Error is nil", func() {
+			So(err, ShouldBeNil)
+		})
+		Convey("Pod is watchable", func() {
+			So(isWatchable, ShouldBeTrue)
+		})
+		Convey("Pod has exclusive CPUs", func() {
+			So(isExclusiveCPUs, ShouldBeTrue)
+		})
+	})
+
+	Convey("When pod is missing from the lister and live GET fails", t, func() {
+		resScan := &PodResourcesScanner{
+			namespace: "*",
+			podLister: newFakePodLister(),
+			k8sClient: fakeclient.NewClientset(),
+		}
+
+		_, _, err := resScan.isWatchable(context.Background(), &v1.PodResources{
+			Name:      "missing-pod",
+			Namespace: "default",
+		})
+
+		Convey("NotFound error is returned", func() {
+			So(apierrors.IsNotFound(err), ShouldBeTrue)
+		})
+	})
+
+	Convey("When pod lister returns a non-NotFound error", t, func() {
+		listerErr := errors.New("lister failure")
+		resScan := &PodResourcesScanner{
+			namespace: "*",
+			podLister: errorPodLister{err: listerErr},
+			k8sClient: fakeclient.NewClientset(),
+		}
+
+		_, _, err := resScan.isWatchable(context.Background(), &v1.PodResources{
+			Name:      "test-pod",
+			Namespace: "default",
+		})
+
+		Convey("Lister error is returned", func() {
+			So(errors.Is(err, listerErr), ShouldBeTrue)
+		})
+	})
+}
 
 func TestPodScanner(t *testing.T) {
 	// PodFingerprint only depends on Name/Namespace of the pods running on a Node
@@ -50,9 +189,8 @@ func TestPodScanner(t *testing.T) {
 	Convey("When I scan for pod resources using fake client and no namespace", t, func() {
 		mockPodResClient := new(mockpodres.PodResourcesListerClient)
 
-		fakeCli := fakeclient.NewClientset()
 		computePodFingerprint := true
-		resScan, err := NewPodResourcesScanner("*", mockPodResClient, fakeCli, computePodFingerprint)
+		resScan, err := NewPodResourcesScanner("*", mockPodResClient, newFakePodLister(), fakeclient.NewClientset(), computePodFingerprint)
 
 		Convey("Creating a Resources Scanner using a mock client", func() {
 			So(err, ShouldBeNil)
@@ -170,8 +308,7 @@ func TestPodScanner(t *testing.T) {
 				},
 			}
 
-			fakeCli := fakeclient.NewClientset(pod)
-			resScan.(*PodResourcesScanner).k8sClient = fakeCli
+			resScan.(*PodResourcesScanner).podLister = newFakePodLister(pod)
 			res, err := resScan.Scan()
 
 			Convey("Error is nil", func() {
@@ -288,8 +425,7 @@ func TestPodScanner(t *testing.T) {
 				},
 			}
 
-			fakeCli = fakeclient.NewClientset(pod)
-			resScan.(*PodResourcesScanner).k8sClient = fakeCli
+			resScan.(*PodResourcesScanner).podLister = newFakePodLister(pod)
 			res, err := resScan.Scan()
 
 			Convey("Error is nil", func() {
@@ -378,8 +514,7 @@ func TestPodScanner(t *testing.T) {
 					QOSClass: corev1.PodQOSGuaranteed,
 				},
 			}
-			fakeCli = fakeclient.NewClientset(pod)
-			resScan.(*PodResourcesScanner).k8sClient = fakeCli
+			resScan.(*PodResourcesScanner).podLister = newFakePodLister(pod)
 			res, err := resScan.Scan()
 
 			Convey("Error is nil", func() {
@@ -471,8 +606,7 @@ func TestPodScanner(t *testing.T) {
 					QOSClass: corev1.PodQOSGuaranteed,
 				},
 			}
-			fakeCli = fakeclient.NewClientset(pod)
-			resScan.(*PodResourcesScanner).k8sClient = fakeCli
+			resScan.(*PodResourcesScanner).podLister = newFakePodLister(pod)
 			res, err := resScan.Scan()
 
 			Convey("Error is nil", func() {
@@ -549,8 +683,7 @@ func TestPodScanner(t *testing.T) {
 					},
 				},
 			}
-			fakeCli = fakeclient.NewClientset(pod)
-			resScan.(*PodResourcesScanner).k8sClient = fakeCli
+			resScan.(*PodResourcesScanner).podLister = newFakePodLister(pod)
 			res, err := resScan.Scan()
 
 			Convey("Error is nil", func() {
@@ -644,8 +777,7 @@ func TestPodScanner(t *testing.T) {
 					QOSClass: corev1.PodQOSGuaranteed,
 				},
 			}
-			fakeCli = fakeclient.NewClientset(pod)
-			resScan.(*PodResourcesScanner).k8sClient = fakeCli
+			resScan.(*PodResourcesScanner).podLister = newFakePodLister(pod)
 			res, err := resScan.Scan()
 
 			Convey("Error is nil", func() {
@@ -688,9 +820,8 @@ func TestPodScanner(t *testing.T) {
 
 	Convey("When I scan for pod resources using fake client and given namespace", t, func() {
 		mockPodResClient := new(mockpodres.PodResourcesListerClient)
-		fakeCli := fakeclient.NewClientset()
 		computePodFingerprint := false
-		resScan, err := NewPodResourcesScanner("pod-res-test", mockPodResClient, fakeCli, computePodFingerprint)
+		resScan, err := NewPodResourcesScanner("pod-res-test", mockPodResClient, newFakePodLister(), fakeclient.NewClientset(), computePodFingerprint)
 
 		Convey("Creating a Resources Scanner using a mock client", func() {
 			So(err, ShouldBeNil)
@@ -776,8 +907,7 @@ func TestPodScanner(t *testing.T) {
 					},
 				},
 			}
-			fakeCli = fakeclient.NewClientset(pod)
-			resScan.(*PodResourcesScanner).k8sClient = fakeCli
+			resScan.(*PodResourcesScanner).podLister = newFakePodLister(pod)
 			res, err := resScan.Scan()
 
 			Convey("Error is nil", func() {
@@ -844,8 +974,7 @@ func TestPodScanner(t *testing.T) {
 					QOSClass: corev1.PodQOSGuaranteed,
 				},
 			}
-			fakeCli = fakeclient.NewClientset(pod)
-			resScan.(*PodResourcesScanner).k8sClient = fakeCli
+			resScan.(*PodResourcesScanner).podLister = newFakePodLister(pod)
 			res, err := resScan.Scan()
 
 			Convey("Error is nil", func() {
@@ -924,8 +1053,7 @@ func TestPodScanner(t *testing.T) {
 					},
 				},
 			}
-			fakeCli = fakeclient.NewClientset(pod)
-			resScan.(*PodResourcesScanner).k8sClient = fakeCli
+			resScan.(*PodResourcesScanner).podLister = newFakePodLister(pod)
 			res, err := resScan.Scan()
 
 			Convey("Error is nil", func() {
@@ -990,8 +1118,7 @@ func TestPodScanner(t *testing.T) {
 					},
 				},
 			}
-			fakeCli = fakeclient.NewClientset(pod)
-			resScan.(*PodResourcesScanner).k8sClient = fakeCli
+			resScan.(*PodResourcesScanner).podLister = newFakePodLister(pod)
 			res, err := resScan.Scan()
 
 			Convey("Error is nil", func() {
@@ -1051,8 +1178,7 @@ func TestPodScanner(t *testing.T) {
 					QOSClass: corev1.PodQOSGuaranteed,
 				},
 			}
-			fakeCli = fakeclient.NewClientset(pod)
-			resScan.(*PodResourcesScanner).k8sClient = fakeCli
+			resScan.(*PodResourcesScanner).podLister = newFakePodLister(pod)
 			res, err := resScan.Scan()
 
 			Convey("Error is nil", func() {
@@ -1138,8 +1264,7 @@ func TestPodScanner(t *testing.T) {
 					QOSClass: corev1.PodQOSGuaranteed,
 				},
 			}
-			fakeCli = fakeclient.NewClientset(pod)
-			resScan.(*PodResourcesScanner).k8sClient = fakeCli
+			resScan.(*PodResourcesScanner).podLister = newFakePodLister(pod)
 			res, err := resScan.Scan()
 
 			Convey("Error is nil", func() {
@@ -1249,8 +1374,7 @@ func TestPodScanner(t *testing.T) {
 					QOSClass: corev1.PodQOSGuaranteed,
 				},
 			}
-			fakeCli = fakeclient.NewClientset(pod)
-			resScan.(*PodResourcesScanner).k8sClient = fakeCli
+			resScan.(*PodResourcesScanner).podLister = newFakePodLister(pod)
 			res, err := resScan.Scan()
 
 			Convey("Error is nil", func() {


### PR DESCRIPTION
PodResourcesScanner.isWatchable() previously issued a live GET pods to the API server for every pod returned by the kubelet podresources API, on every scan. In a production cluster with 700 nodes, and 25k pods, this resulted in sustained ~900 GET pods/s anti-pattern against the apiservers.

Replace the direct client GET with a lister backed by a SharedInformer that is scoped to this node via fieldSelector=spec.nodeName, so both the initial LIST and the ongoing WATCH only see this node's pods. Steady-state apiserver traffic from nfd-topology-updater drops to one LIST + one WATCH per process, with WATCH events only for pods that actually change on this node.

The kubelet podresources API can return a pod a moment before the apiserver WATCH stream delivers it to the informer, so NotFound from the lister falls back to a live GET to keep noderesourcetopology accurate. Other lister errors are propagated unchanged (Scan() still treats them as fatal for the scan). RBAC for the topology-updater ClusterRole is widened from get to get,list,watch on pods.

### Release Notes:
```
The nfd-topology-updater ClusterRole gains list,watch on pods. Helm users get it on upgrade, plain-kustomize users will need to re-apply the manifest or topology-updater will hang on cache sync.
```




Assisted-by: Cursor <cursor@cursor.com>