### PR TITLE
build(image): cross-compile from $BUILDPLATFORM via tonistiigi/xx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,47 +1,111 @@
+# BUILDER_IMAGE MUST be Debian-family (xx-apt-get requires apt-get).
+# Project's Makefile pins it to golang:1.26-trixie (matches go.mod
+# minimum Go version) which satisfies this. Override with a non-Debian
+# image only if you also swap xx-apt-get for the matching package manager.
+#
+# tonistiigi/xx is pinned by sha256 digest below. Minimum acceptable
+# version is 1.5.0 (arm/v7 + $TARGETVARIANT handling). To update:
+#   docker pull tonistiigi/xx:1.x.y
+#   docker inspect --format='{{index .RepoDigests 0}}' tonistiigi/xx:1.x.y
+# Track in Renovate / Dependabot alongside the runtime base-image pins.
 ARG BUILDER_IMAGE
 ARG BASE_IMAGE_FULL
 ARG BASE_IMAGE_MINIMAL
+ARG XX_IMAGE=tonistiigi/xx@sha256:010d4b66aed389848b0694f91c7aaee9df59a6f20be7f5d12e53663a37bd14e2
 
-# Build node feature discovery
-FROM ${BUILDER_IMAGE:-golang} AS builder
+# Cross-build helper (host arch; never shipped)
+FROM --platform=$BUILDPLATFORM ${XX_IMAGE} AS xx
 
-# Get (cache) deps in a separate layer
+# Build node-feature-discovery on the build host, cross-compile to TARGET.
+# Running here on $BUILDPLATFORM avoids the QEMU translation-cache instability
+# that crashed go mod download under emulation (see PR commit body for the
+# crash signatures).
+FROM --platform=$BUILDPLATFORM ${BUILDER_IMAGE:-golang} AS builder
+COPY --from=xx / /
+
+ARG TARGETPLATFORM
+ARG TARGETARCH
+# Cross-toolchain packages (gcc, libc6-dev) are intentionally unpinned —
+# Debian point releases shift these frequently and the build-stage is
+# discarded; pinning would create frequent CI churn for no security gain.
+# hadolint ignore=DL3008
+RUN xx-apt-get update && \
+    xx-apt-get install -y --no-install-recommends gcc libc6-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# Module cache fetched on $BUILDPLATFORM. Modules are arch-independent;
+# no QEMU involvement here.
 COPY go.mod go.sum /go/node-feature-discovery/
 COPY api/nfd/go.mod api/nfd/go.sum /go/node-feature-discovery/api/nfd/
-
 WORKDIR /go/node-feature-discovery
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     go mod download
 
-# Do actual build
+# Force CGO on. xx-go --wrap defaults CGO_ENABLED=0 for cross-compile
+# targets, which would build-tag-filter out source/cpu/cpuid_linux_*.go
+# (which use #include <sys/auxv.h>) and silently fall back to the
+# cpuid_stub.go no-op variant.
+ENV CGO_ENABLED=1
+
+# Cross-compile via xx-go --wrap. After --wrap, /usr/local/go/bin/go is a
+# shim that sets CC, GOOS, GOARCH, GOARM from $TARGETPLATFORM for every
+# subsequent invocation in this stage. Use explicit per-binary go build
+# -o to bypass go install's $GOPATH/bin/$GOOS_$GOARCH/<name> redirect for
+# cross-targets (Go refuses GOBIN override on cross-compile).
 ARG VERSION
 ARG HOSTMOUNT_PREFIX
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=src=.,target=. \
-    make install VERSION=$VERSION HOSTMOUNT_PREFIX=$HOSTMOUNT_PREFIX
+    xx-go --wrap && \
+    # Silent-CGO-disable guard: source/cpu/cpuid_linux_{arm,arm64,ppc64le,s390x}.go
+    # each `import "C"` and wrap glibc's getauxval() via a small inline C
+    # function called gethwcap(). If xx-apt-get install silently failed
+    # or xx-go --wrap unset CGO_ENABLED, those files get build-tag-filtered
+    # out and the binary would ship with empty CPU feature labels at
+    # runtime with no build error.
+    #
+    # We probe by building an UNSTRIPPED nfd-worker (the production build
+    # below uses -s -w which destroys the symbol table) and grepping for
+    # the CGO-emitted wrapper symbol that can only exist if the linux
+    # cpuid file was compiled+linked. The Go package object is then
+    # cached, so the production -s -w link is cheap.
+    #
+    # amd64 is excluded: source/cpu/cpuid_amd64.go uses pure-Go cpuid via
+    # github.com/klauspost/cpuid/v2 — no CGO required on that arch.
+    case "$TARGETARCH" in \
+      arm64|arm|ppc64le|s390x) \
+        go build -v -tags osusergo,netgo -o /tmp/nfd-worker-guard ./cmd/nfd-worker && \
+        go tool nm /tmp/nfd-worker-guard | grep -q 'source/cpu\._Cfunc_gethwcap' \
+          || { echo "FAIL: source/cpu._Cfunc_gethwcap missing from nfd-worker — CGO likely disabled for $TARGETPLATFORM"; exit 1; } && \
+        rm -f /tmp/nfd-worker-guard \
+        ;; \
+    esac && \
+    for bin in nfd-master nfd-worker nfd-topology-updater nfd-gc kubectl-nfd nfd; do \
+      go build -v -tags osusergo,netgo \
+        -ldflags "-s -w -extldflags=-static -X sigs.k8s.io/node-feature-discovery/pkg/version.version=${VERSION} -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=${HOSTMOUNT_PREFIX}" \
+        -o /go/bin/$bin ./cmd/$bin || exit 1; \
+    done && \
+    xx-verify /go/bin/nfd-master
 
-# Create full variant of the production image
+# Runtime stages run at $TARGETPLATFORM (implicit). They only COPY, set USER,
+# and set ENV — trivial work under QEMU.
+
 FROM ${BASE_IMAGE_FULL:-debian:stable-slim} AS full
 
-# Run as unprivileged user
 USER 65534:65534
-
-# Use more verbose logging of gRPC
 ENV GRPC_GO_LOG_SEVERITY_LEVEL="INFO"
 
 COPY deployment/components/worker-config/nfd-worker.conf.example /etc/kubernetes/node-feature-discovery/nfd-worker.conf
-COPY --from=builder /go/bin/* /usr/bin/
+# Enumerate explicitly — matches Makefile BUILD_BINARIES. Defensive against
+# any future shim-leakage from xx-go.
+COPY --from=builder /go/bin/nfd-master /go/bin/nfd-worker /go/bin/nfd-topology-updater /go/bin/nfd-gc /go/bin/kubectl-nfd /go/bin/nfd /usr/bin/
 
-# Create minimal variant of the production image
 FROM ${BASE_IMAGE_MINIMAL:-scratch} AS minimal
 
-# Run as unprivileged user
 USER 65534:65534
-
-# Use more verbose logging of gRPC
 ENV GRPC_GO_LOG_SEVERITY_LEVEL="INFO"
 
 COPY deployment/components/worker-config/nfd-worker.conf.example /etc/kubernetes/node-feature-discovery/nfd-worker.conf
-COPY --from=builder /go/bin/* /usr/bin/
+COPY --from=builder /go/bin/nfd-master /go/bin/nfd-worker /go/bin/nfd-topology-updater /go/bin/nfd-gc /go/bin/kubectl-nfd /go/bin/nfd /usr/bin/

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,28 @@ image-all: ensure-buildx yamls
 	$(IMAGE_BUILDX_CMD) $(IMAGE_BUILD_ARGS) $(IMAGE_BUILD_ARGS_FULL)
 	$(IMAGE_BUILDX_CMD) $(IMAGE_BUILD_ARGS) $(IMAGE_BUILD_ARGS_MINIMAL)
 
+# Local cross-build smoke test for the full release matrix. Does NOT push;
+# does NOT --load. Exits non-zero on the first platform that fails to build.
+# Use to reproduce CI cross-build issues locally; leaves images named
+# nfd-cross-test:<plat> in the local cache for inspection (run
+# `docker image prune` or `docker rmi nfd-cross-test:*` to clean up).
+#
+# This recipe re-spells the docker buildx flags from IMAGE_BUILDX_CMD
+# rather than reusing the variable because IMAGE_BUILDX_CMD bakes in
+# --platform=$(IMAGE_ALL_PLATFORMS) (multi-arch in one invocation), and
+# we need a per-platform single-arch loop here. Keep the flags in sync
+# with IMAGE_BUILDX_CMD (line 78) if either changes. --pull is preserved
+# to match CI behaviour (fresh base images per smoke run).
+image-cross-test: ensure-buildx yamls
+	@for plat in $$(echo $(IMAGE_ALL_PLATFORMS) | tr , ' '); do \
+	  echo "===> $$plat"; \
+	  DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build \
+	    --builder=nfd-builder --platform=$$plat --progress=auto --pull \
+	    $(IMAGE_BUILD_ARGS) --target minimal \
+	    -t nfd-cross-test:$$(echo $$plat | tr / -) . \
+	    || { echo "FAIL $$plat"; exit 1; }; \
+	done
+
 # clean NFD labels on all nodes
 # devel only
 deploy-prune:


### PR DESCRIPTION
## Problem

The presubmit `pull-node-feature-discovery-build-image-cross-generic` crashes inside the QEMU-emulated `linux/arm64` builder stage during `go mod download` with Go-runtime memory-corruption signatures:

- `runtime: pointer 0x... to unallocated span`
- `fatal error: SIGSEGV at PC=0`
- `runtime: marked free object in span`

kubernetes/test-infra#37041 (merged 2026-05-15) bumped the failing job's memory from 8Gi to 16Gi; the next run with the same workload still hit the same signature. Memory headroom is not the fix.

## Root cause

The Dockerfile's `builder` stage had no `--platform=$BUILDPLATFORM` declaration, so the entire builder — including `go mod download` and `go build` / `make install` — ran under QEMU user-mode emulation for every non-host target architecture. QEMU's translation cache and Go's runtime allocator interact pathologically under emulation.

## Approach

Move the builder stage to `$BUILDPLATFORM` and cross-compile per `$TARGETPLATFORM` via `tonistiigi/xx` (pinned by sha256 digest). Only runtime stages (`COPY` / `USER` / `ENV`) still run under emulation — trivial work QEMU handles reliably.

CGO is retained because `source/cpu/cpuid_linux_{arm,arm64,ppc64le,s390x}.go` use `getauxval`. A build-time silent-CGO-disable guard (`go tool nm | grep source/cpu._Cfunc_gethwcap`) catches the regression class where the cross-libc install silently fails and `CGO_ENABLED=0` falls back, producing binaries with empty CPU feature labels. amd64 is excluded from the guard because it uses pure-Go cpuid via `github.com/klauspost/cpuid/v2`.

`go install` redirects cross-compile output to `/go/bin/$GOOS_$GOARCH/<name>/` and refuses `GOBIN` override, so the production stage uses explicit per-binary `go build -o /go/bin/$bin ./cmd/$bin`. Runtime `COPY` enumerates `BUILD_BINARIES` explicitly (defensive against any future xx-tool leakage).

A new `make image-cross-test` target gives reviewers and future debuggers a one-command local reproducer for the full 5-platform release matrix.

## CI scope vs release scope

| Surface | Script | Platforms |
|---|---|---|
| Prow presubmit | `scripts/test-infra/build-image-cross.sh` | `linux/amd64,linux/arm64` |
| Release push / local `make image-all` | Makefile default | `linux/amd64,linux/arm64,linux/arm/v7,linux/s390x,linux/ppc64le` |

## Testing done

Local verification on `linux/arm64` host (Docker Desktop, Apple Silicon, buildkit v0.29.0):

- `make image-cross-test` green for all 5 platforms.
- `make image-all` green for `full` + `minimal` targets × 5 platforms (single buildx invocation each).
- Per-arch ELF assertions on the resulting `nfd-worker`:
  - `file` reports statically linked + correct arch for each.
  - `readelf -d` shows no NEEDED entries (no dynamic deps).
  - `readelf -A` shows `Tag_CPU_arch=v7` on `linux/arm/v7`.
  - `go version -m` confirms `CGO_ENABLED=1` and correct `GOARCH`/`GOARM` on all five.
- The build-time CGO guard (unstripped probe + `go tool nm` symbol grep) fired and passed for arm64, arm/v7, s390x, ppc64le during the cross-build.

## Tracking issue

Post-merge gate: #2511

## Rollback

`git revert` is **NOT** a safe rollback — it reintroduces the QEMU memory-corruption crash class. If a regression appears post-merge:

1. Narrow release scope: set `IMAGE_ALL_PLATFORMS=linux/amd64,linux/arm64` in `scripts/test-infra/push-image.sh`.
2. Per-arch fallback: override `--platform=$TARGETPLATFORM` on the builder stage for the broken arch only.

Detail in the design spec on the agents-workbench branch (`.agents/plans/2026-05-15-multiarch-buildx-cross-compile-design.md`).

## References

- Test-infra: kubernetes/test-infra#37041
- tonistiigi/xx digest: `sha256:010d4b66aed389848b0694f91c7aaee9df59a6f20be7f5d12e53663a37bd14e2`

/sig node
/area node-feature-discovery
/cc @marquiz
