### PR TITLE
fix(helm): render prune job resources at container level

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/post-delete-job.yaml
+++ b/deployment/helm/node-feature-discovery/templates/post-delete-job.yaml
@@ -82,6 +82,10 @@ spec:
             {{- if .Values.master.instance | empty | not }}
             - "-instance={{ .Values.master.instance }}"
             {{- end }}
+          {{- with .Values.master.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       restartPolicy: Never
       {{- with .Values.master.nodeSelector }}
       nodeSelector:
@@ -95,9 +99,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.master.resources }}
-      resources:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
 {{- end }}
-


### PR DESCRIPTION
## Summary

I believe the Helm `post-delete` prune Job currently renders `.Values.master.resources` at the PodSpec level instead of the `nfd-master` container level.

The regular `nfd-master` Deployment applies `master.resources` to the container, but the `post-delete` cleanup Job appears to place the same values under:

```yaml
spec:
  template:
    spec:
      resources:
```

instead of:

```yaml
spec:
  template:
    spec:
      containers:
        - name: nfd-master
          resources:
```

This PR moves the resources block into the prune Job's `nfd-master` container.

## Why I believe this is wrong

In `deployment/helm/node-feature-discovery/templates/post-delete-job.yaml`, the resources block is rendered after `restartPolicy`, `nodeSelector`, `affinity`, and `tolerations`:

```yaml
      restartPolicy: Never
      {{- with .Values.master.resources }}
      resources:
        {{- toYaml . | nindent 8 }}
      {{- end }}
```

That indentation places `resources` under `spec.template.spec`, not under the container.

When rendering the chart with non-empty `master.resources`, the prune Job ends up with pod-level resources and no container-level resources:

```bash
helm template nfd ./deployment/helm/node-feature-discovery \
  --namespace kube-system \
  --set master.resources.requests.cpu=10m \
  --set master.resources.requests.memory=64Mi \
  --set master.resources.limits.memory=128Mi \
  | yq 'select(.kind == "Job" and .metadata.name == "nfd-node-feature-discovery-prune") | {
      pod_resources: .spec.template.spec.resources,
      container_resources: .spec.template.spec.containers[0].resources
    }'
```

```json
{
  "pod_resources": {
    "limits": {
      "memory": "128Mi"
    },
    "requests": {
      "cpu": "10m",
      "memory": "64Mi"
    }
  },
  "container_resources": null
}
```

The `nfd-master` container in the prune Job therefore does not receive the configured CPU/memory requests and limits.

One reason this can be easy to miss is that Kubernetes 1.32 introduced `PodSpec.resources` as an alpha `PodLevelResources` field. On clusters whose API exposes that field, the manifest may pass validation even though the chart is applying `master.resources` to a different API field than the regular master container resources.

## How to reproduce

Render the chart with non-empty `master.resources` and inspect the prune Job:

```bash
helm template nfd ./deployment/helm/node-feature-discovery \
  --namespace kube-system \
  | yq 'select(.kind == "Job" and .metadata.name == "nfd-node-feature-discovery-prune") | {
      pod_resources: .spec.template.spec.resources,
      container_resources: .spec.template.spec.containers[0].resources
    }'
```

Before this change, the output shows resources at the pod level and no resources on the container:

```json
{
  "pod_resources": {
    "limits": {
      "memory": "4Gi"
    },
    "requests": {
      "cpu": "100m",
      "memory": "128Mi"
    }
  },
  "container_resources": null
}
```

After this change, the resources are rendered under the `nfd-master` container:

```json
{
  "pod_resources": null,
  "container_resources": {
    "limits": {
      "memory": "4Gi"
    },
    "requests": {
      "cpu": "100m",
      "memory": "128Mi"
    }
  }
}
```

## Testing

Rendered the Helm chart and verified that the prune Job now places `.Values.master.resources` under:

```yaml
spec.template.spec.containers[0].resources
```

instead of:

```yaml
spec.template.spec.resources
```

Also ran:

```bash
make helm-lint

helm template nfd deployment/helm/node-feature-discovery --namespace kube-system \
  | yq 'select(.kind == "Job" and .metadata.name == "nfd-node-feature-discovery-prune")' \
  | kubectl create --dry-run=server --validate=strict -f - -o json \
  | jq '{kind, name: .metadata.name, pod_resources: .spec.template.spec.resources, container_resources: .spec.template.spec.containers[0].resources}'
```
