### PR TITLE
Add optional aggregate role for CRD resources

### DIFF
--- a/deployment/helm/node-feature-discovery/README.md
+++ b/deployment/helm/node-feature-discovery/README.md
@@ -196,6 +196,7 @@ NFD.
 | master.serviceAccount.name | string | `nil` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | master.revisionHistoryLimit | int | `nil` | Specifies the number of old ReplicaSets for the Deployment to retain. [revisionHistoryLimit](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit) |
 | master.rbac.create | bool | `true` | Create [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) configuration for nfd-master. |
+| master.rbac.createAggregateRoles | bool | `false` | Create aggregate roles that grant view and edit access to NFD CRD resources. |
 | master.resources.limits | object | `{"memory":"4Gi"}` | Resource [limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) for the nfd-master container. |
 | master.resources.requests | object | `{"cpu":"100m","memory":"128Mi"}` | Resource [requests](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) for the nfd-master container. |
 | master.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the nfd-master pods. |

--- a/deployment/helm/node-feature-discovery/templates/clusterrole-aggregate.yaml
+++ b/deployment/helm/node-feature-discovery/templates/clusterrole-aggregate.yaml
@@ -1,0 +1,44 @@
+{{- if and .Values.master.enable .Values.master.rbac.create .Values.master.rbac.createAggregateRoles }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "node-feature-discovery.fullname" . }}-view
+  labels:
+    {{- include "node-feature-discovery.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeatures
+  - nodefeaturerules
+  - nodefeaturegroups
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "node-feature-discovery.fullname" . }}-edit
+  labels:
+    {{- include "node-feature-discovery.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeatures
+  - nodefeaturerules
+  - nodefeaturegroups
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+{{- end }}

--- a/deployment/helm/node-feature-discovery/values.schema.json
+++ b/deployment/helm/node-feature-discovery/values.schema.json
@@ -496,6 +496,10 @@
                         "create": {
                             "description": "Create [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) configuration for nfd-master.",
                             "type": "boolean"
+                        },
+                        "createAggregateRoles": {
+                            "description": "Create aggregate roles that grant view and edit access to NFD CRD resources.",
+                            "type": "boolean"
                         }
                     }
                 },

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -203,6 +203,9 @@ master:
     # -- Create [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) configuration for nfd-master.
     # @section -- NFD-Master
     create: true
+    # -- Create aggregate roles that grant view and edit access to NFD CRD resources.
+    # @section -- NFD-Master
+    createAggregateRoles: false
   # @schema $ref: $k8s/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements
   resources:
     # @schema hidden

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -214,6 +214,7 @@ NFD.
 | master.serviceAccount.name | string | `nil` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | master.revisionHistoryLimit | int | `nil` | Specifies the number of old ReplicaSets for the Deployment to retain. [revisionHistoryLimit](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit) |
 | master.rbac.create | bool | `true` | Create [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) configuration for nfd-master. |
+| master.rbac.createAggregateRoles | bool | `false` | Create aggregate roles that grant view and edit access to NFD CRD resources. |
 | master.resources.limits | object | `{"memory":"4Gi"}` | Resource [limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) for the nfd-master container. |
 | master.resources.requests | object | `{"cpu":"100m","memory":"128Mi"}` | Resource [requests](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) for the nfd-master container. |
 | master.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the nfd-master pods. |


### PR DESCRIPTION
On my test cluster it is helpful to have an aggregate role for viewing CRD resources.