### PR TITLE
source/crypto: add IBM CEX card feature discovery for s390x

### DIFF
--- a/docs/get-started/introduction.md
+++ b/docs/get-started/introduction.md
@@ -63,6 +63,7 @@ One instance of nfd-gc is supposed to be running in the cluster.
 Feature discovery is divided into domain-specific feature sources:
 
 - CPU
+- Crypto
 - Kernel
 - Memory
 - Network
@@ -84,6 +85,7 @@ An overview of the default feature labels:
 ```json
 {
   "feature.node.kubernetes.io/cpu-<feature-name>": "true",
+  "feature.node.kubernetes.io/crypto-<feature-name>": "true",
   "feature.node.kubernetes.io/custom-<feature-name>": "true",
   "feature.node.kubernetes.io/kernel-<feature name>": "<feature value>",
   "feature.node.kubernetes.io/memory-<feature-name>": "true",

--- a/docs/usage/crypto-source.md
+++ b/docs/usage/crypto-source.md
@@ -1,0 +1,271 @@
+---
+title: "Crypto Source"
+layout: default
+sort: 8
+---
+
+# Crypto Source
+
+---
+
+## Overview
+
+The crypto source detects IBM Crypto Express (CEX) cryptographic
+cards on s390x systems. These hardware security modules (HSMs)
+provide cryptographic acceleration and secure key management
+capabilities for IBM Z and LinuxONE platforms.
+
+CEX cards are specialized cryptographic coprocessors that offload
+cryptographic operations from the main CPU, providing:
+
+- Hardware-accelerated encryption and decryption
+- Secure key storage and management
+- Cryptographic operations in FIPS-compliant environments
+- Support for various cryptographic algorithms (RSA, AES, SHA, etc.)
+
+## Platform Support
+
+**Architecture:** s390x only
+
+The crypto source is specifically designed for IBM Z and LinuxONE
+systems and will not detect any features on other architectures.
+
+## Supported Card Types
+
+The crypto source detects the following IBM Crypto Express card generations:
+
+- **CEX4** - Fourth generation
+- **CEX5** - Fifth generation
+- **CEX6** - Sixth generation
+- **CEX7** - Seventh generation
+- **CEX8** - Eighth generation (latest)
+
+Each generation may be available in different configurations:
+
+- **CEX-A (Accelerator)** - Provides cryptographic acceleration
+  for clear key operations
+- **CEX-C (CCA Coprocessor)** - Supports IBM Common Cryptographic
+  Architecture (CCA) for secure key operations
+- **CEX-P (EP11 Coprocessor)** - Supports Enterprise PKCS#11
+  (EP11) for secure key operations
+
+## Hardware Requirements
+
+### Bare Metal Systems
+
+On bare metal IBM Z or LinuxONE systems, CEX cards are
+automatically detected if:
+
+- The system has CEX cards installed
+- The AP (Adjunct Processor) bus is enabled in the system
+  configuration
+- The Linux kernel has AP bus support enabled
+- The cards are online and accessible
+
+### Virtual Machines
+
+For virtual machines (z/VM, KVM, etc.), CEX card detection requires:
+
+- **Hardware passthrough** - The CEX card must be passed through
+  to the VM
+- **AP bus configuration** - The VM must have access to the AP bus
+- **Proper virtualization setup** - The hypervisor must support
+  cryptographic passthrough
+
+**Important:** CEX cards are **not** detected in VMs without
+hardware passthrough. The cards must be explicitly assigned to
+the VM at the virtualization layer.
+
+## Detection Mechanism
+
+The crypto source scans the sysfs AP bus directory
+(`/sys/bus/ap/devices/`) to discover CEX cards. For each detected
+card, it reads:
+
+- Card type and generation (e.g., CEX8C)
+- Operational mode (Accelerator, CCA, EP11) — derived from the type suffix
+- Online/offline status
+- Configuration status (whether the card is configured at HMC level)
+- Hardware type identifier
+- Queue depth
+- Installed AP function facilities (ap_functions)
+- Associated cryptographic queues
+
+## Labels Generated
+
+The crypto source generates the following node labels:
+
+### `crypto-cex.present`
+
+**Type:** Boolean (true)
+
+Indicates that at least one CEX card is present and detected on the node.
+
+```yaml
+feature.node.kubernetes.io/crypto-cex.present: "true"
+```
+
+### `crypto-cex.count`
+
+**Type:** String (numeric)
+
+The total number of CEX cards detected on the node.
+
+```yaml
+feature.node.kubernetes.io/crypto-cex.count: "2"
+```
+
+### `crypto-cex.type-<TYPE>`
+
+**Type:** Boolean (true)
+
+A label is created for each unique card type detected. The
+`<TYPE>` placeholder is replaced with the actual card type
+(e.g., `CEX8C`, `CEX7P`, `CEX6A`).
+
+```yaml
+feature.node.kubernetes.io/crypto-cex.type-CEX8C: "true"
+feature.node.kubernetes.io/crypto-cex.type-CEX7P: "true"
+```
+
+### `crypto-cex.mode-<MODE>`
+
+**Type:** Boolean (true)
+
+A label is created for each unique operational mode present. Possible values:
+
+- `accelerator` — Clear key acceleration (CEX*A cards)
+- `cca` — IBM Common Cryptographic Architecture coprocessor (CEX*C cards)
+- `ep11` — Enterprise PKCS#11 coprocessor (CEX*P cards)
+
+```yaml
+feature.node.kubernetes.io/crypto-cex.mode-cca: "true"
+feature.node.kubernetes.io/crypto-cex.mode-ep11: "true"
+```
+
+## Instance Features
+
+In addition to labels, the crypto source exposes detailed
+information about each card through instance features under the
+`crypto.cex-card` feature set.
+
+### Available Attributes
+
+| Attribute      | Description                                           | Example Value    |
+|----------------|-------------------------------------------------------|------------------|
+| `name`         | Card device name                                      | `card00`         |
+| `type`         | Card type and generation                              | `CEX8C`          |
+| `mode`         | Operational mode (accelerator, cca, ep11)             | `cca`            |
+| `online`       | Online status (1=online, 0=offline)                   | `1`              |
+| `config`       | HMC configuration status (1=configured, 0=deconfig)  | `1`              |
+| `hwtype`       | Hardware type identifier                              | `14`             |
+| `depth`        | Queue depth                                           | `8`              |
+| `ap_functions` | Installed AP function facilities (hex bitmask)        | `0x93800000`     |
+| `queue_count`  | Number of queues associated with the card             | `2`              |
+| `queues`       | Comma-separated list of queue identifiers             | `00.0014,00.0015`|
+
+### Example Instance Features
+
+```yaml
+crypto:
+  cex-card:
+    - name: "card00"
+      type: "CEX8C"
+      mode: "cca"
+      online: "1"
+      config: "1"
+      hwtype: "14"
+      depth: "8"
+      ap_functions: "0x93800000"
+      queue_count: "2"
+      queues: "00.0014,00.0015"
+    - name: "card01"
+      type: "CEX8A"
+      mode: "accelerator"
+      online: "1"
+      config: "1"
+      hwtype: "14"
+      depth: "8"
+      ap_functions: "0x93800000"
+      queue_count: "2"
+      queues: "01.0016,01.0017"
+```
+
+## Usage with NodeFeatureRule
+
+You can use NodeFeatureRule to create custom labels and extended
+resources based on detected CEX cards.
+
+### Example: Label Nodes with Specific Card Types
+
+```yaml
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: cex-card-types
+spec:
+  rules:
+    - name: "cex8-coprocessor"
+      labels:
+        "crypto/cex8-coprocessor": "true"
+      matchFeatures:
+        - feature: crypto.cex-card
+          matchExpressions:
+            type:
+              op: In
+              value:
+                - "CEX8C"
+                - "CEX8P"
+```
+
+## Verification
+
+### Check if CEX Cards are Detected
+
+On an s390x system with CEX cards, verify detection:
+
+```bash
+# Check node labels
+kubectl get nodes -o json | jq '.items[].metadata.labels' | grep crypto
+
+# Expected output:
+# "feature.node.kubernetes.io/crypto-cex.count": "2",
+# "feature.node.kubernetes.io/crypto-cex.present": "true",
+# "feature.node.kubernetes.io/crypto-cex.type-CEX8C": "true"
+```
+
+### Check Instance Features
+
+```bash
+# Get NodeFeature object
+kubectl get nodefeature -n node-feature-discovery <node-name> -o yaml
+
+# Look for crypto.cex-card section
+```
+
+### Verify AP Bus on the Host
+
+```bash
+# Check if AP bus exists
+ls -la /sys/bus/ap/devices/
+
+# Expected output shows card* entries:
+# card00
+# card01
+# 00.0014
+# 00.0015
+# ...
+
+# Check card details
+cat /sys/bus/ap/devices/card00/type
+# Expected output: CEX8C
+
+cat /sys/bus/ap/devices/card00/online
+# Expected output: 1
+```
+
+## References
+[ibm-cex-concepts]: https://www.ibm.com/docs/en/linux-on-systems?topic=linuxone-concepts-crypto-hw
+[ibm-z-crypto]: https://www.ibm.com/docs/en/systems-hardware/zsystems/9175-ME1?topic=more-crypto-adapters
+[ibm-zcrypt]: https://www.ibm.com/docs/en/linux-on-systems?topic=tasks-loading-zcrypt-device-driver
+[kernel-ap]: https://docs.kernel.org/arch/s390/vfio-ap.html

--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -231,6 +231,57 @@ instructions.
 | --------------------------------| ----- | ----------------------------------------------------------- |
 | **`storage-nonrotationaldisk`** | true  | Non-rotational disk, like SSD, is present in the node        |
 
+### Crypto
+
+| Feature                      | Value  | Description                                                 |
+| ---------------------------- | ------ | ----------------------------------------------------------- |
+| **`crypto-cex.present`**     | true   | IBM CEX cryptographic card(s) detected (s390x only)         |
+| **`crypto-cex.count`**       | string | Number of CEX cards present                                 |
+| **`crypto-cex.type-<TYPE>`** | true   | CEX card of specific type detected (e.g., `crypto-cex.type-CEX8C`) |
+
+The crypto source detects IBM Crypto Express (CEX) cards on s390x systems. These
+hardware security modules provide cryptographic acceleration and secure key
+management capabilities. Supported card types include CEX4, CEX5, CEX6, CEX7,
+and CEX8 in various configurations (A, C, P).
+
+**Platform Support:** s390x only
+
+**Requirements:**
+
+- s390x architecture with AP (Adjunct Processor) bus support
+- Physical hardware or VM with CEX card passthrough
+- Kernel support for AP bus (`/sys/bus/ap/devices/`)
+
+**Instance Features:**
+
+The crypto source also exposes detailed information about each detected card
+through instance features under the `crypto.cex-card` feature set:
+
+- `name`: Card device name (e.g., `card00`)
+- `type`: Card type (e.g., `CEX8C`, `CEX7P`)
+- `online`: Online status (`1` for online, `0` for offline)
+- `hwtype`: Hardware type identifier
+- `depth`: Queue depth
+- `queue_count`: Number of queues associated with the card
+- `queues`: Comma-separated list of queue identifiers
+
+**Example output:**
+
+```yaml
+crypto:
+  cex-card:
+    - name: "card00"
+      type: "CEX8C"
+      online: "1"
+      hwtype: "14"
+      depth: "8"
+      queue_count: "2"
+      queues: "00.0014,00.0015"
+```
+
+For detailed information about using the crypto source, see the
+[crypto source documentation](crypto-source.md).
+
 ### System
 
 | Feature                                 | Value  | Description                                                 |

--- a/pkg/nfd-worker/nfd-worker.go
+++ b/pkg/nfd-worker/nfd-worker.go
@@ -52,6 +52,7 @@ import (
 
 	// Register all source packages
 	_ "sigs.k8s.io/node-feature-discovery/source/cpu"
+	_ "sigs.k8s.io/node-feature-discovery/source/crypto"
 	_ "sigs.k8s.io/node-feature-discovery/source/custom"
 	_ "sigs.k8s.io/node-feature-discovery/source/fake"
 	_ "sigs.k8s.io/node-feature-discovery/source/kernel"

--- a/source/crypto/crypto.go
+++ b/source/crypto/crypto.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crypto
+
+import (
+	"fmt"
+	"strconv"
+
+	"k8s.io/klog/v2"
+
+	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils"
+	"sigs.k8s.io/node-feature-discovery/source"
+)
+
+// Name of this feature source
+const Name = "crypto"
+
+// CexCardFeature is the name of the feature set that holds all discovered CEX cards.
+const CexCardFeature = "cex-card"
+
+// cryptoSource implements the FeatureSource and LabelSource interfaces.
+type cryptoSource struct {
+	features *nfdv1alpha1.Features
+}
+
+// Singleton source instance
+var (
+	src                      = cryptoSource{}
+	_   source.FeatureSource = &src
+	_   source.LabelSource   = &src
+)
+
+// Name returns the name of the feature source
+func (s *cryptoSource) Name() string { return Name }
+
+// Priority method of the LabelSource interface
+func (s *cryptoSource) Priority() int { return 0 }
+
+// GetLabels method of the LabelSource interface
+func (s *cryptoSource) GetLabels() (source.FeatureLabels, error) {
+	labels := source.FeatureLabels{}
+	features := s.GetFeatures()
+
+	instances, ok := features.Instances[CexCardFeature]
+	if !ok || len(instances.Elements) == 0 {
+		return labels, nil
+	}
+
+	labels["cex.present"] = true
+	labels["cex.count"] = strconv.Itoa(len(instances.Elements))
+
+	cardTypes := make(map[string]bool)
+	cardModes := make(map[string]bool)
+	for _, card := range instances.Elements {
+		if cardType, ok := card.Attributes["type"]; ok {
+			cardTypes[cardType] = true
+		}
+		if mode, ok := card.Attributes["mode"]; ok {
+			cardModes[mode] = true
+		}
+	}
+
+	for cardType := range cardTypes {
+		labels["cex.type-"+cardType] = true
+	}
+	for mode := range cardModes {
+		labels["cex.mode-"+mode] = true
+	}
+
+	return labels, nil
+}
+
+// Discover method of the FeatureSource interface
+func (s *cryptoSource) Discover() error {
+	s.features = nfdv1alpha1.NewFeatures()
+
+	cards, err := detectCexCards()
+	if err != nil {
+		return fmt.Errorf("failed to detect CEX cards: %w", err)
+	}
+
+	if len(cards) > 0 {
+		s.features.Instances[CexCardFeature] = nfdv1alpha1.InstanceFeatureSet{Elements: cards}
+	}
+
+	klog.V(3).InfoS("discovered features", "featureSource", s.Name(), "features", utils.DelayedDumper(s.features))
+
+	return nil
+}
+
+// GetFeatures method of the FeatureSource interface
+func (s *cryptoSource) GetFeatures() *nfdv1alpha1.Features {
+	if s.features == nil {
+		s.features = nfdv1alpha1.NewFeatures()
+	}
+	return s.features
+}
+
+func init() {
+	source.Register(&src)
+}

--- a/source/crypto/crypto_linux_s390x.go
+++ b/source/crypto/crypto_linux_s390x.go
@@ -1,0 +1,147 @@
+//go:build linux && s390x
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crypto
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/klog/v2"
+
+	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
+	"sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath"
+)
+
+// cardAttrs is the list of sysfs attributes read from each card directory.
+// https://github.com/torvalds/linux/blob/master/drivers/s390/crypto/ap_card.c
+var cardAttrs = []string{"type", "online", "hwtype", "depth", "ap_functions", "config"}
+
+// modeFromType extracts the operational mode from a CEX type string.
+// CEX type strings end with a mode suffix: A=Accelerator, C=CCA, P=EP11.
+func modeFromType(cexType string) string {
+	if len(cexType) == 0 {
+		return ""
+	}
+	switch cexType[len(cexType)-1] {
+	case 'A':
+		return "accelerator"
+	case 'C':
+		return "cca"
+	case 'P':
+		return "ep11"
+	default:
+		return ""
+	}
+}
+
+// detectCexCards detects IBM CEX cryptographic cards on s390x systems.
+// It scans /sys/bus/ap/devices/ for card entries and reads their attributes.
+func detectCexCards() ([]nfdv1alpha1.InstanceFeature, error) {
+	sysfsBasePath := hostpath.SysfsDir.Path("bus/ap/devices")
+
+	if _, err := os.Stat(sysfsBasePath); os.IsNotExist(err) {
+		klog.V(3).InfoS("AP bus not found, no CEX cards detected", "path", sysfsBasePath)
+		return nil, nil
+	}
+
+	devices, err := os.ReadDir(sysfsBasePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list AP devices: %w", err)
+	}
+
+	cards := make([]nfdv1alpha1.InstanceFeature, 0)
+	for _, device := range devices {
+		deviceName := device.Name()
+
+		if !strings.HasPrefix(deviceName, "card") {
+			continue
+		}
+
+		cardPath := filepath.Join(sysfsBasePath, deviceName)
+		cardInfo := readCexCardInfo(cardPath, deviceName)
+
+		if len(cardInfo.Attributes) > 1 {
+			cards = append(cards, *cardInfo)
+		}
+	}
+
+	klog.V(3).InfoS("detected CEX cards", "count", len(cards))
+	return cards, nil
+}
+
+// readCexCardInfo reads attributes for a single CEX card from its sysfs directory.
+func readCexCardInfo(cardPath, cardName string) *nfdv1alpha1.InstanceFeature {
+	attrs := map[string]string{"name": cardName}
+
+	for _, attrName := range cardAttrs {
+		attrPath := filepath.Join(cardPath, attrName)
+		data, err := os.ReadFile(attrPath)
+		if err != nil {
+			klog.V(4).InfoS("failed to read card attribute", "card", cardName, "attribute", attrName, "error", err)
+			continue
+		}
+		attrs[attrName] = strings.TrimSpace(string(data))
+	}
+
+	// Derive the operational mode from the type string
+	if cardType, ok := attrs["type"]; ok {
+		if mode := modeFromType(cardType); mode != "" {
+			attrs["mode"] = mode
+		}
+	}
+
+	queues, err := enumerateCardQueues(cardPath, cardName)
+	if err != nil {
+		klog.V(4).InfoS("failed to enumerate queues", "card", cardName, "error", err)
+	} else if len(queues) > 0 {
+		attrs["queue_count"] = fmt.Sprintf("%d", len(queues))
+		attrs["queues"] = strings.Join(queues, ",")
+	}
+
+	return nfdv1alpha1.NewInstanceFeature(attrs)
+}
+
+// enumerateCardQueues finds AP queues (APQNs) associated with a card.
+// Queue entries in sysfs have the format "<cardnum>.<domain>" (e.g., "00.0014").
+func enumerateCardQueues(cardPath, cardName string) ([]string, error) {
+	cardNum := strings.TrimPrefix(cardName, "card")
+
+	parentPath := filepath.Dir(cardPath)
+	devices, err := os.ReadDir(parentPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read devices directory: %w", err)
+	}
+
+	queues := make([]string, 0)
+	queuePrefix := cardNum + "."
+
+	for _, device := range devices {
+		deviceName := device.Name()
+		if strings.HasPrefix(deviceName, queuePrefix) {
+			queuePath := filepath.Join(parentPath, deviceName)
+			if _, err := os.Stat(filepath.Join(queuePath, "online")); err == nil {
+				queues = append(queues, deviceName)
+			}
+		}
+	}
+
+	return queues, nil
+}

--- a/source/crypto/crypto_stub.go
+++ b/source/crypto/crypto_stub.go
@@ -1,0 +1,29 @@
+//go:build !(linux && s390x)
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crypto
+
+import (
+	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
+)
+
+// detectCexCards is a stub for non-s390x platforms.
+// CEX cards are only available on s390x architecture.
+func detectCexCards() ([]nfdv1alpha1.InstanceFeature, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Add a new 'crypto' feature source that detects IBM Crypto Express (CEX) cards on s390x systems by scanning the AP bus sysfs interface.

Detected instance attributes per card:
- type, mode (accelerator/cca/ep11), online, config
- hwtype, depth, ap_functions
- queue_count, queues

Generated labels:
- crypto-cex.present, crypto-cex.count
- crypto-cex.type-<TYPE>, crypto-cex.mode-<MODE>