### PR TITLE
fix(ci): make Codecov coverage upload non-fatal in verify.sh

### DIFF
--- a/scripts/test-infra/verify.sh
+++ b/scripts/test-infra/verify.sh
@@ -18,10 +18,6 @@ kubectl="$gobinpath/kubectl"
 curl -L https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl -o "$kubectl"
 chmod 755 "$kubectl"
 
-curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
-curl -Os https://uploader.codecov.io/latest/linux/codecov
-chmod +x codecov
-
 # TODO: update logcheck version when there is a new release (newer than v0.9.0)
 go install sigs.k8s.io/logtools/logcheck@v0.9.1-0.20251007102500-d35c84c015fe
 
@@ -41,14 +37,27 @@ logcheck -config "${this_dir}/logcheck.conf" ./cmd/... ./pkg/...  ./source/...
 echo "Running unit tests"
 make test
 
-# Upload coverage report
-./codecov -t "${CODECOV_TOKEN}" \
-          -C "${PULL_PULL_SHA}" \
-          -r "${REPO_OWNER}/${REPO_NAME}" \
-          -P "${PULL_NUMBER}" \
-          -b "${BUILD_ID}" \
-          -B "${PULL_BASE_REF}" \
-          -N "${PULL_BASE_SHA}"
+# Upload coverage report (best-effort; coverage reporting must never gate CI).
+# The legacy Codecov uploader is deprecated and its download/key endpoints have
+# proven unreliable (e.g. the Keybase PGP key URL now returns a stub), so any
+# failure here is logged and treated as non-fatal. Migrating to the supported
+# Codecov CLI is tracked separately.
+upload_coverage() {
+    curl -Os https://uploader.codecov.io/latest/linux/codecov
+    chmod +x codecov
+    ./codecov -t "${CODECOV_TOKEN}" \
+              -C "${PULL_PULL_SHA}" \
+              -r "${REPO_OWNER}/${REPO_NAME}" \
+              -P "${PULL_NUMBER}" \
+              -b "${BUILD_ID}" \
+              -B "${PULL_BASE_REF}" \
+              -N "${PULL_BASE_SHA}"
+}
+
+echo "Uploading coverage report (best-effort, non-gating)"
+if ! upload_coverage; then
+    echo "WARNING: Codecov coverage upload failed; continuing because coverage reporting does not gate CI."
+fi
 
 # Check that repo is clean
 if ! git diff --quiet; then


### PR DESCRIPTION
## Problem

`pull-node-feature-discovery-verify-master` is failing on **every** PR, blocking all merges (including open Dependabot PRs #2510, #2520, #2521, #2522).

## Root cause

`scripts/test-infra/verify.sh` runs under `bash -e`. It imports the Codecov uploader's PGP key from `https://keybase.io/codecovsecurity/pgp_keys.asc`, which now returns a 32-byte `SELF-SIGNED PUBLIC KEY NOT FOUND` stub following the Keybase shutdown. `gpg --import` then exits non-zero and **aborts the whole script before any verification runs** — the job log dies at the gpg step (the `build`/`e2e`/`cross` jobs are unaffected, which is why only `verify-master` fails).

That imported key was never actually used to verify anything (there is no `gpgv` step), so it provided no real integrity guarantee.

## Fix

Coverage reporting is informational and must never gate merges. This consolidates the Codecov steps into a single best-effort `upload_coverage` function invoked via `if ! ...`, so any failure logs a **loud warning** and is non-fatal. The real verification steps (gofmt, golangci-lint, helm-lint, logcheck, unit tests, and the template/schema/README sync checks) remain **fatal and unchanged**.

## Testing

- `bash -n` and `shellcheck` (no new findings; my change adds no shellcheck warnings).
- Verified the guarded construct is non-fatal under `bash -e`: a failing `upload_coverage` logs the warning and execution continues (exit 0), whereas the original un-guarded form aborts. 
- This PR's own `verify-master` run is the end-to-end proof.

## Follow-up

The legacy Codecov uploader is itself deprecated; migrating to the supported Codecov CLI is tracked in #2526.

## Breaking changes

None. Coverage reporting behavior is unchanged when the uploader works; when it fails, the job now warns and continues instead of failing the gate.