### PR TITLE
feat(nfd-worker): add core.noPublishFeatures to slim NodeFeature objects

### DIFF
--- a/cmd/nfd-worker/main.go
+++ b/cmd/nfd-worker/main.go
@@ -91,6 +91,8 @@ func parseArgs(flags *flag.FlagSet, osArgs ...string) *worker.Args {
 			args.Overrides.FeatureSources = overrides.FeatureSources
 		case "label-sources":
 			args.Overrides.LabelSources = overrides.LabelSources
+		case "no-publish-features":
+			args.Overrides.NoPublishFeatures = overrides.NoPublishFeatures
 		case "no-owner-refs":
 			args.Overrides.NoOwnerRefs = overrides.NoOwnerRefs
 		}
@@ -118,8 +120,9 @@ func initFlags(flagset *flag.FlagSet) (*worker.Args, *worker.ConfigOverrideArgs)
 
 	// Flags overlapping with config file options
 	overrides := &worker.ConfigOverrideArgs{
-		FeatureSources: &utils.StringSliceVal{},
-		LabelSources:   &utils.StringSliceVal{},
+		FeatureSources:    &utils.StringSliceVal{},
+		LabelSources:      &utils.StringSliceVal{},
+		NoPublishFeatures: &utils.StringSliceVal{},
 	}
 	overrides.NoPublish = flagset.Bool("no-publish", false,
 		"Do not publish discovered features, disable connection to nfd-master and don't create NodeFeature object.")
@@ -131,6 +134,11 @@ func initFlags(flagset *flag.FlagSet) (*worker.Args, *worker.ConfigOverrideArgs)
 	flagset.Var(overrides.LabelSources, "label-sources",
 		"Comma separated list of label sources. Special value 'all' enables all sources. "+
 			"Prefix the source name with '-' to disable it.")
+	flagset.Var(overrides.NoPublishFeatures, "no-publish-features",
+		"Comma separated list of feature keys to discover but omit from the published "+
+			"NodeFeature object (e.g. 'pci.device'). Suffix a key with '*' for a prefix "+
+			"match (e.g. 'pci.*'). Reduces object size; only use for features that no "+
+			"NodeFeatureRule or NodeFeatureGroup consumes.")
 
 	return args, overrides
 }

--- a/deployment/components/worker-config/nfd-worker.conf.example
+++ b/deployment/components/worker-config/nfd-worker.conf.example
@@ -5,6 +5,10 @@
 #  sleepInterval: 60s
 #  featureSources: [all]
 #  labelSources: [all]
+#  # Discover these features but omit them from the published NodeFeature object
+#  # to reduce its size. Exact key or '*' prefix (e.g. pci.device, pci.*).
+#  # Only for features no NodeFeatureRule/NodeFeatureGroup consumes.
+#  noPublishFeatures: []
 #  klog:
 #    addDirHeader: false
 #    alsologtostderr: false

--- a/deployment/helm/node-feature-discovery/values.yaml
+++ b/deployment/helm/node-feature-discovery/values.yaml
@@ -402,6 +402,10 @@ worker:
     #  sleepInterval: 60s
     #  featureSources: [all]
     #  labelSources: [all]
+    #  # Discover these features but omit them from the published NodeFeature object
+    #  # to reduce its size. Exact key or '*' prefix (e.g. pci.device, pci.*).
+    #  # Only for features no NodeFeatureRule/NodeFeatureGroup consumes.
+    #  noPublishFeatures: []
     #  klog:
     #    addDirHeader: false
     #    alsologtostderr: false

--- a/docs/reference/worker-commandline-reference.md
+++ b/docs/reference/worker-commandline-reference.md
@@ -126,6 +126,28 @@ Example:
 nfd-worker -label-sources=kernel,system,local
 ```
 
+### -no-publish-features
+
+The `-no-publish-features` flag specifies a comma-separated list of feature keys
+that are discovered but omitted from the published `NodeFeature` object, to
+reduce its size. Each entry matches the `<source>.<feature>` key exactly, or as
+a prefix when it ends with `*`. Discovery is not affected, so the features stay
+available to label sources and inline custom rules. Consider using the
+`core.noPublishFeatures` config file option, instead, allowing dynamic
+configurability.
+
+> **NOTE:** This flag takes precedence over the `core.noPublishFeatures`
+> configuration file option. Only use it for features that no cluster-side
+> `NodeFeatureRule` or `NodeFeatureGroup` consumes.
+
+Default: *empty*
+
+Example:
+
+```bash
+nfd-worker -no-publish-features=pci.device,usb.*
+```
+
 ### -port
 
 The `-port` flag specifies the port on which metrics and healthz endpoints are

--- a/docs/reference/worker-configuration-reference.md
+++ b/docs/reference/worker-configuration-reference.md
@@ -110,6 +110,37 @@ core:
 > **NOTE:** `core.sources` takes precedence over the `core.labelSources`
 > configuration file option.
 
+### core.noPublishFeatures
+
+`core.noPublishFeatures` specifies a list of feature keys that are discovered but
+omitted from the published `NodeFeature` object. Discovery itself is not
+affected, so the features remain available locally for label sources and inline
+custom/`NodeFeatureRule` rules in `sources.custom`; they are only stripped from
+the published object to reduce its size (and thus the load on the Kubernetes API
+server, etcd and the nfd-master informer cache).
+
+Each entry is matched against the `<source>.<feature>` key either exactly, or as
+a prefix when it ends with `*`.
+
+> **NOTE:** Overridden by the `-no-publish-features` command line flag (if
+> specified). Only use this for features that no cluster-side `NodeFeatureRule`
+> or `NodeFeatureGroup` consumes - those are evaluated by nfd-master against the
+> published `Spec.Features`, so removing a feature they rely on changes the
+> resulting labels, taints and extended resources.
+
+Default: `empty`
+
+Example:
+
+```yaml
+core:
+  # Discover PCI and USB devices (so local rules can still use them) but do not
+  # publish the potentially large per-device lists in the NodeFeature object.
+  noPublishFeatures:
+    - "pci.device"
+    - "usb.*"
+```
+
 ### core.labelWhiteList
 
 `core.labelWhiteList` specifies a regular expression for filtering feature

--- a/pkg/nfd-worker/nfd-worker-internal_test.go
+++ b/pkg/nfd-worker/nfd-worker-internal_test.go
@@ -273,3 +273,67 @@ func TestCreateFeatureLabels(t *testing.T) {
 		})
 	})
 }
+
+func TestRemoveNoPublishFeatures(t *testing.T) {
+	Convey("When stripping features that should not be published", t, func() {
+		newFeatures := func() *nfdv1alpha1.Features {
+			f := nfdv1alpha1.NewFeatures()
+			f.Flags["cpu.cpuid"] = nfdv1alpha1.NewFlagFeatures("AVX", "SSE")
+			f.Attributes["cpu.model"] = nfdv1alpha1.NewAttributeFeatures(map[string]string{"family": "23"})
+			f.Attributes["system.osrelease"] = nfdv1alpha1.NewAttributeFeatures(map[string]string{"ID": "rocky"})
+			f.Instances["pci.device"] = nfdv1alpha1.NewInstanceFeatures(
+				nfdv1alpha1.InstanceFeature{Attributes: map[string]string{"vendor": "10de"}})
+			return f
+		}
+
+		Convey("a nil/empty pattern list leaves the features untouched", func() {
+			f := newFeatures()
+			So(removeNoPublishFeatures(f, nil), ShouldBeEmpty)
+			So(len(f.Flags), ShouldEqual, 1)
+			So(len(f.Attributes), ShouldEqual, 2)
+			So(len(f.Instances), ShouldEqual, 1)
+		})
+
+		Convey("an exact key match removes only that feature", func() {
+			f := newFeatures()
+			So(removeNoPublishFeatures(f, []string{"pci.device"}), ShouldBeEmpty)
+			So(f.Instances, ShouldNotContainKey, "pci.device")
+			So(len(f.Flags), ShouldEqual, 1)
+			So(len(f.Attributes), ShouldEqual, 2)
+		})
+
+		Convey("a '*' suffix removes all features of a source by prefix", func() {
+			f := newFeatures()
+			So(removeNoPublishFeatures(f, []string{"cpu.*"}), ShouldBeEmpty)
+			So(len(f.Flags), ShouldEqual, 0)
+			So(f.Attributes, ShouldNotContainKey, "cpu.model")
+			So(f.Attributes, ShouldContainKey, "system.osrelease")
+			So(len(f.Instances), ShouldEqual, 1)
+		})
+
+		Convey("multiple patterns are all applied", func() {
+			f := newFeatures()
+			So(removeNoPublishFeatures(f, []string{"pci.device", "cpu.cpuid"}), ShouldBeEmpty)
+			So(len(f.Flags), ShouldEqual, 0)
+			So(len(f.Instances), ShouldEqual, 0)
+			So(len(f.Attributes), ShouldEqual, 2)
+		})
+
+		Convey("a non-matching pattern removes nothing and is reported", func() {
+			f := newFeatures()
+			unmatched := removeNoPublishFeatures(f, []string{"usb.device", "memory.*"})
+			So(unmatched, ShouldResemble, []string{"usb.device", "memory.*"})
+			So(len(f.Flags), ShouldEqual, 1)
+			So(len(f.Attributes), ShouldEqual, 2)
+			So(len(f.Instances), ShouldEqual, 1)
+		})
+
+		Convey("only the non-matching patterns are reported, in config order", func() {
+			f := newFeatures()
+			unmatched := removeNoPublishFeatures(f, []string{"pci.device", "usb.*", "cpu.cpuid"})
+			So(unmatched, ShouldResemble, []string{"usb.*"})
+			So(f.Instances, ShouldNotContainKey, "pci.device")
+			So(f.Flags, ShouldNotContainKey, "cpu.cpuid")
+		})
+	})
+}

--- a/pkg/nfd-worker/nfd-worker.go
+++ b/pkg/nfd-worker/nfd-worker.go
@@ -35,6 +35,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	k8sclient "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -84,7 +85,13 @@ type coreConfig struct {
 	FeatureSources []string
 	Sources        *[]string
 	LabelSources   []string
-	SleepInterval  utils.DurationVal
+	// NoPublishFeatures lists feature keys that are discovered (so they remain
+	// available to label sources and inline custom rules) but are omitted from
+	// the published NodeFeature object to reduce its size. Each entry is matched
+	// against the "<source>.<feature>" key, exactly or, when it ends with "*",
+	// as a prefix (e.g. "pci.device" or "pci.*").
+	NoPublishFeatures []string
+	SleepInterval     utils.DurationVal
 }
 
 type sourcesConfig map[string]source.Config
@@ -107,10 +114,11 @@ type Args struct {
 
 // ConfigOverrideArgs are args that override config file options
 type ConfigOverrideArgs struct {
-	NoPublish      *bool
-	NoOwnerRefs    *bool
-	FeatureSources *utils.StringSliceVal
-	LabelSources   *utils.StringSliceVal
+	NoPublish         *bool
+	NoOwnerRefs       *bool
+	FeatureSources    *utils.StringSliceVal
+	LabelSources      *utils.StringSliceVal
+	NoPublishFeatures *utils.StringSliceVal
 }
 
 type nfdWorker struct {
@@ -125,6 +133,11 @@ type nfdWorker struct {
 	featureSources      []source.FeatureSource
 	labelSources        []source.LabelSource
 	ownerReference      []metav1.OwnerReference
+
+	// noPublishNoMatchWarned records core.noPublishFeatures patterns already
+	// warned about for matching no feature, so a persistent no-match (typically
+	// a typo) is logged once rather than on every discovery cycle.
+	noPublishNoMatchWarned sets.Set[string]
 }
 
 // This ticker can represent infinite and normal intervals.
@@ -165,10 +178,11 @@ func (f *nfdWorkerOpt) apply(n *nfdWorker) {
 // NewNfdWorker creates new NfdWorker instance.
 func NewNfdWorker(opts ...NfdWorkerOption) (NfdWorker, error) {
 	nfd := &nfdWorker{
-		config:              &NFDConfig{},
-		kubernetesNamespace: utils.GetKubernetesNamespace(),
-		stop:                make(chan struct{}),
-		sourceEvent:         make(chan *source.FeatureSource),
+		config:                 &NFDConfig{},
+		kubernetesNamespace:    utils.GetKubernetesNamespace(),
+		stop:                   make(chan struct{}),
+		sourceEvent:            make(chan *source.FeatureSource),
+		noPublishNoMatchWarned: sets.New[string](),
 	}
 
 	for _, o := range opts {
@@ -540,6 +554,9 @@ func (w *nfdWorker) configure(ctx context.Context, filepath string, overrides st
 	if w.args.Overrides.LabelSources != nil {
 		c.Core.LabelSources = *w.args.Overrides.LabelSources
 	}
+	if w.args.Overrides.NoPublishFeatures != nil {
+		c.Core.NoPublishFeatures = *w.args.Overrides.NoPublishFeatures
+	}
 
 	c.Core.sanitize()
 
@@ -646,6 +663,61 @@ func (w *nfdWorker) advertiseFeatures(labels Labels) error {
 	return nil
 }
 
+// removeNoPublishFeatures deletes the feature keys matched by patterns from the
+// Features that will be published in the NodeFeature object. Discovery is not
+// affected, so the features remain available to label sources and inline custom
+// rules; they are only omitted from the published object. Each pattern matches
+// the "<source>.<feature>" key exactly, or as a prefix when it ends with "*"
+// (e.g. "pci.device" or "pci.*").
+//
+// It returns the patterns that matched no feature key. That usually means a
+// typo, but it can be legitimate on a heterogeneous cluster where the same
+// config reaches nodes lacking the targeted hardware, so the caller logs it
+// informationally rather than treating it as an error.
+func removeNoPublishFeatures(features *nfdv1alpha1.Features, patterns []string) []string {
+	if features == nil || len(patterns) == 0 {
+		return nil
+	}
+	matched := make([]bool, len(patterns))
+	matches := func(key string) bool {
+		hit := false
+		for i, p := range patterns {
+			if prefix, ok := strings.CutSuffix(p, "*"); ok {
+				if strings.HasPrefix(key, prefix) {
+					matched[i] = true
+					hit = true
+				}
+			} else if key == p {
+				matched[i] = true
+				hit = true
+			}
+		}
+		return hit
+	}
+	for k := range features.Flags {
+		if matches(k) {
+			delete(features.Flags, k)
+		}
+	}
+	for k := range features.Attributes {
+		if matches(k) {
+			delete(features.Attributes, k)
+		}
+	}
+	for k := range features.Instances {
+		if matches(k) {
+			delete(features.Instances, k)
+		}
+	}
+	var unmatched []string
+	for i, p := range patterns {
+		if !matched[i] {
+			unmatched = append(unmatched, p)
+		}
+	}
+	return unmatched
+}
+
 // updateNodeFeatureObject creates/updates the node-specific NodeFeature custom resource.
 func (m *nfdWorker) updateNodeFeatureObject(labels Labels) error {
 	cli, err := m.getNfdClient()
@@ -656,6 +728,17 @@ func (m *nfdWorker) updateNodeFeatureObject(labels Labels) error {
 	namespace := m.kubernetesNamespace
 
 	features := source.GetAllFeatures()
+
+	// Strip features that are configured not to be published. Discovery has
+	// already run (and feature labels have already been computed from the full
+	// set), so this only shrinks the published object, reducing load on the
+	// apiserver, etcd and nfd-master's informer cache.
+	for _, p := range removeNoPublishFeatures(features, m.config.Core.NoPublishFeatures) {
+		if !m.noPublishNoMatchWarned.Has(p) {
+			m.noPublishNoMatchWarned.Insert(p)
+			klog.InfoS("core.noPublishFeatures pattern matched no feature; possible typo, or the targeted hardware is absent on this node", "pattern", p)
+		}
+	}
 
 	// TODO: we could implement some simple caching of the object, only get it
 	// every 10 minutes or so because nobody else should really be modifying it


### PR DESCRIPTION
NodeFeature objects can be dominated by large feature sets - e.g. pci.device on nodes with many SR-IOV virtual functions - that few or no labels are actually derived from. Because nfd-master caches every NodeFeature in its informer (one object per node), this bloat scales with cluster size and inflates nfd-master's memory, etcd storage and apiserver/watch traffic.

Add a new core.noPublishFeatures config option (and matching -no-publish-features flag) listing feature keys to omit from the published NodeFeature object. Feature discovery is unaffected and runs before label computation, so the omitted features remain available to label sources and inline sources.custom rules; only the published Spec.Features is trimmed.

Each entry matches the "<source>.<feature>" key exactly, or as a prefix when it ends with "*" (e.g. "pci.device" or "pci.*").

The option is opt-in and defaults to empty, so behaviour is unchanged unless configured. Note that it must only be used for features that no cluster-side NodeFeatureRule or NodeFeatureGroup consumes, since those are evaluated by nfd-master against the published Spec.Features.