### PR TITLE
perf(nodefeaturerule): cache compiled MatchInRegexp patterns

### DIFF
--- a/pkg/apis/nfd/nodefeaturerule/expression.go
+++ b/pkg/apis/nfd/nodefeaturerule/expression.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	strings "strings"
+	"sync"
 
 	"maps"
 
@@ -54,6 +55,43 @@ var matchOps = map[nfdv1alpha1.MatchOp]struct{}{
 	nfdv1alpha1.MatchGeLe:         {},
 	nfdv1alpha1.MatchIsTrue:       {},
 	nfdv1alpha1.MatchIsFalse:      {},
+}
+
+// compiledRegexps memoizes compiled regular expressions by their pattern string.
+// evaluateMatchExpression runs for every feature element of every rule on every
+// node on every reconcile, so compiling MatchInRegexp patterns from scratch each
+// time was a dominant source of nfd-master allocation churn.
+//
+// The cache key is the pattern string, which comes from NodeFeatureRule /
+// NodeFeatureGroup specs (MatchExpression.Value) -- never from NodeFeature
+// objects or the feature values being matched. So the high-cardinality, churning
+// data never enters the cache; only the small, slowly-changing set of
+// operator-authored patterns does. A plain unbounded sync.Map therefore stays
+// bounded in practice (a handful of KB), and sync.Map is safe for the concurrent
+// node updater pool.
+//
+// Entries are never evicted -- including when a rule is modified or deleted, so a
+// retired pattern lingers until the process restarts. This is intentional: tying
+// eviction to rule lifecycle would need reference counting (a pattern may be
+// shared across rules) for negligible benefit. The only way this grows unbounded
+// is a workload that produces many *unique* patterns over time (e.g. rules with
+// node names or UUIDs baked into the regex). If that ever becomes a concern,
+// replace the sync.Map with a size-capped LRU (e.g. hashicorp/golang-lru) behind
+// the same compileRegexp signature.
+var compiledRegexps sync.Map // map[string]*regexp.Regexp
+
+// compileRegexp returns a compiled regexp for pattern, reusing a previously
+// compiled instance when one exists.
+func compileRegexp(pattern string) (*regexp.Regexp, error) {
+	if re, ok := compiledRegexps.Load(pattern); ok {
+		return re.(*regexp.Regexp), nil
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+	actual, _ := compiledRegexps.LoadOrStore(pattern, re)
+	return actual.(*regexp.Regexp), nil
 }
 
 // evaluateMatchExpression evaluates the MatchExpression against a single input value.
@@ -108,7 +146,7 @@ func evaluateMatchExpression(m *nfdv1alpha1.MatchExpression, valid bool, value i
 			}
 			valueRe := make([]*regexp.Regexp, len(m.Value))
 			for i, v := range m.Value {
-				re, err := regexp.Compile(v)
+				re, err := compileRegexp(v)
 				if err != nil {
 					return false, fmt.Errorf("invalid expressiom, 'value' field must only contain valid regexps for Op %q (have %v)", m.Op, m.Value)
 				}

--- a/pkg/apis/nfd/nodefeaturerule/expression_test.go
+++ b/pkg/apis/nfd/nodefeaturerule/expression_test.go
@@ -28,6 +28,28 @@ type BoolAssertionFunc func(assert.TestingT, bool, ...interface{}) bool
 
 type ValueAssertionFunc func(assert.TestingT, interface{}, ...interface{}) bool
 
+func TestCompileRegexp(t *testing.T) {
+	// The same pattern must return the same cached instance (no recompile).
+	re1, err := compileRegexp("^foo-[0-9]+$")
+	assert.NoError(t, err)
+	re2, err := compileRegexp("^foo-[0-9]+$")
+	assert.NoError(t, err)
+	assert.Same(t, re1, re2, "expected the same cached *regexp.Regexp instance for an identical pattern")
+
+	// The cached regexp must still match correctly.
+	assert.True(t, re1.MatchString("foo-42"))
+	assert.False(t, re1.MatchString("bar"))
+
+	// A different pattern yields a different instance.
+	re3, err := compileRegexp("^bar$")
+	assert.NoError(t, err)
+	assert.NotSame(t, re1, re3)
+
+	// Invalid patterns return an error.
+	_, err = compileRegexp("[invalid(")
+	assert.Error(t, err)
+}
+
 func TestEvaluateMatchExpression(t *testing.T) {
 	type V = nfdv1alpha1.MatchValue
 	type TC struct {


### PR DESCRIPTION
evaluateMatchExpression recompiled every MatchInRegexp pattern with regexp.Compile on each call -- and it is invoked per feature element, per rule, per node, on every reconcile. Compiled regexps are heavy objects, so repeatedly recompiling the same rule patterns is an avoidable source of heap allocation and CPU work under nfd-master's reconcile churn.

Memoize compiled patterns in a package-level sync.Map keyed by pattern string. Matching behavior is unchanged: a term's patterns are still all compiled before matching, so an invalid pattern errors exactly as before. sync.Map is safe for the concurrent node updater pool.

A size-capped LRU cache was considered but rejected. The cache key is the pattern string, which comes only from NodeFeatureRule / NodeFeatureGroup specs -- operator-authored objects that change infrequently -- never from NodeFeature objects or the feature values being matched. The set of distinct patterns is therefore small and slowly-changing, so a plain unbounded map stays bounded in practice and avoids the extra dependency and eviction bookkeeping. An LRU can be swapped in behind the same compileRegexp signature if some workload ever starts producing many unique patterns (e.g. node names or UUIDs baked into a regex).