### PR TITLE
fix(nfd-master): prevent stop() panic and informer leak on init failure

### DIFF
--- a/pkg/nfd-master/nfd-api-controller.go
+++ b/pkg/nfd-master/nfd-api-controller.go
@@ -268,6 +268,9 @@ func newNfdController(config *restclient.Config, nfdApiControllerOptions nfdApiC
 	ret := informerFactory.WaitForCacheSync(c.stopChan)
 	for res, ok := range ret {
 		if !ok {
+			// Stop the informers started above so their goroutines
+			// don't leak when construction fails.
+			c.stop()
 			return nil, fmt.Errorf("informer cache failed to sync resource %s", res)
 		}
 	}
@@ -279,7 +282,11 @@ func newNfdController(config *restclient.Config, nfdApiControllerOptions nfdApiC
 
 func (c *nfdController) stop() {
 	close(c.stopChan)
-	c.namespaceLister.stop()
+	// namespaceLister is only created when a NodeFeature namespace selector is
+	// configured, so it may be nil (the default).
+	if c.namespaceLister != nil {
+		c.namespaceLister.stop()
+	}
 }
 
 func getNodeNameForObj(obj metav1.Object) (string, error) {

--- a/pkg/nfd-master/nfd-api-controller_test.go
+++ b/pkg/nfd-master/nfd-api-controller_test.go
@@ -47,6 +47,13 @@ func TestGetNodeNameForObj(t *testing.T) {
 	assert.Equal(t, n, "node-1")
 }
 
+func TestControllerStop(t *testing.T) {
+	// stop() must not panic when no NodeFeature namespace selector was
+	// configured and namespaceLister is therefore nil (the default).
+	c := &nfdController{stopChan: make(chan struct{})}
+	assert.NotPanics(t, c.stop)
+}
+
 func newTestNamespace(name string) *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
nfdController.stop() dereferenced c.namespaceLister unconditionally, but that lister is only created when a NodeFeature namespace selector is configured. In the default configuration the field is nil, so stopping the master panicked with a nil-pointer dereference. Guard the call.

newNfdController() starts the shared informers and then returns an error if WaitForCacheSync fails, previously without stopping them and leaking those goroutines. Call stop() before returning so a failed construction cleans up after itself.