### PR TITLE
fix(nfd-worker): trim whitespace in noPublishFeatures patterns

### DIFF
--- a/pkg/utils/flags.go
+++ b/pkg/utils/flags.go
@@ -81,9 +81,16 @@ func (a *StringSetVal) UnmarshalJSON(data []byte) error {
 // StringSliceVal is a Value encapsulating a slice of comma-separated strings
 type StringSliceVal []string
 
-// Set implements the regexp.Value interface
+// Set implements the regexp.Value interface. Surrounding whitespace is trimmed
+// from each comma-separated entry and blank entries are dropped, so a value like
+// "cpu, pci" parses to ["cpu", "pci"] and "" parses to an empty slice.
 func (a *StringSliceVal) Set(val string) error {
-	*a = strings.Split(val, ",")
+	*a = nil
+	for s := range strings.SplitSeq(val, ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			*a = append(*a, s)
+		}
+	}
 	return nil
 }
 

--- a/pkg/utils/flags_test.go
+++ b/pkg/utils/flags_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringSliceValSet(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+		want StringSliceVal
+	}{
+		{name: "simple", val: "cpu,pci", want: StringSliceVal{"cpu", "pci"}},
+		{name: "surrounding whitespace is trimmed", val: "cpu, pci", want: StringSliceVal{"cpu", "pci"}},
+		{name: "whitespace around every entry is trimmed", val: " pci.device , usb.* ", want: StringSliceVal{"pci.device", "usb.*"}},
+		{name: "blank entries are dropped", val: "pci.device,,usb.*", want: StringSliceVal{"pci.device", "usb.*"}},
+		{name: "single entry", val: "cpu", want: StringSliceVal{"cpu"}},
+		{name: "empty string yields an empty slice", val: "", want: nil},
+		{name: "whitespace-only yields an empty slice", val: "  ", want: nil},
+		{name: "only blanks and whitespace yields an empty slice", val: ", ,\t,", want: nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got StringSliceVal
+			assert.NoError(t, got.Set(tc.val))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
StringSliceVal keeps the spaces around comma-separated entries, so a configured value like "pci.device, usb.*" yielded a " usb.*" pattern that never matched any feature key and was wrongly reported as unmatched. Trim each pattern once up front and ignore blank entries, both when matching and when collecting the unmatched patterns. Add tests covering padded and blank patterns.

Also drop the per-call []*regexp.Regexp slice in the MatchInRegexp branch of evaluateMatchExpression: now that compiled patterns are cached, compile and match in a single pass. Every pattern is still compiled, so an invalid regexp is reported even after a match, while the last per-call allocation on that hot path is removed.