### PR TITLE
Add graceful signal handling to all NFD daemon entrypoints

### DIFF
--- a/cmd/nfd-gc/main.go
+++ b/cmd/nfd-gc/main.go
@@ -17,9 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -56,6 +59,14 @@ func main() {
 		klog.ErrorS(err, "failed to initialize nfd garbage collector instance")
 		os.Exit(1)
 	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+
+	go func() {
+		<-ctx.Done()
+		gc.Stop()
+	}()
 
 	if err = gc.Run(); err != nil {
 		klog.ErrorS(err, "error while running")

--- a/cmd/nfd-master/main.go
+++ b/cmd/nfd-master/main.go
@@ -17,9 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -66,6 +69,14 @@ func main() {
 		klog.ErrorS(err, "failed to initialize NfdMaster instance")
 		os.Exit(1)
 	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+
+	go func() {
+		<-ctx.Done()
+		instance.Stop()
+	}()
 
 	if err = instance.Run(); err != nil {
 		klog.ErrorS(err, "error while running")

--- a/cmd/nfd-topology-updater/main.go
+++ b/cmd/nfd-topology-updater/main.go
@@ -17,12 +17,15 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net"
 	"os"
+	"os/signal"
 	"path"
 	"strings"
+	"syscall"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -57,6 +60,14 @@ func main() {
 		klog.ErrorS(err, "failed to initialize topology updater instance")
 		os.Exit(1)
 	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+
+	go func() {
+		<-ctx.Done()
+		instance.Stop()
+	}()
 
 	if err = instance.Run(); err != nil {
 		klog.ErrorS(err, "error while running")

--- a/cmd/nfd-worker/main.go
+++ b/cmd/nfd-worker/main.go
@@ -17,9 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"k8s.io/klog/v2"
 
@@ -65,6 +68,14 @@ func main() {
 		klog.ErrorS(err, "failed to initialize NfdWorker instance")
 		os.Exit(1)
 	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+
+	go func() {
+		<-ctx.Done()
+		instance.Stop()
+	}()
 
 	if err = instance.Run(); err != nil {
 		klog.ErrorS(err, "error while running")


### PR DESCRIPTION
Resolves #2546

All NFD daemon binaries (`nfd-worker`, `nfd-master`, `nfd-gc`, `nfd-topology-updater`) exit with non-zero codes (1 or 2) when receiving SIGTERM during pod termination. This is because none of the `main()` entrypoints register OS signal handlers, even though each binary already has a `Stop()` method that cleanly shuts down the `Run()` loop via a channel.

This causes spurious alerts in environments that monitor non-zero exit codes from DaemonSet pods during rolling updates.

This PR registers `signal.NotifyContext` for SIGTERM/SIGINT in each entrypoint. On signal, call the instance's `Stop()` method, which triggers the existing `<-w.stop` select case in `Run()` to  return nil (exit 0).

## Testing
Run locally:
 - `make build` passes
 - `make test` (unit tests)

