### PR TITLE
docs: document template functions removed from rule templates

### DIFF
--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -1134,10 +1134,16 @@ union of all the individual expansions.
 
 Rule templates use the Golang [text/template](https://pkg.go.dev/text/template)
 package along with [Sprig functions](https://masterminds.github.io/sprig/)
-and all their functionality (e.g. pipelines and functions) can
-be used. An example template taking use of the built-in `len` function,
-advertising the number of PCI network controllers from a specific vendor,
-and using Sprig's `first`, `trim` and `substr` to advertise the first one's class:
+and most of their functionality (e.g. pipelines and functions) can
+be used. The `env`, `expandenv` and `getHostByName` functions are removed
+from the available Sprig functions, as these are the only Sprig builtins
+that read host process environment state or perform outbound DNS lookups
+and are not needed for label expansion. A template referencing any of
+these three functions fails to parse (e.g. `function "env" not defined`);
+the affected rule is skipped and the error is logged by nfd-master. An
+example template taking use of the built-in `len` function, advertising
+the number of PCI network controllers from a specific vendor, and using
+Sprig's `first`, `trim` and `substr` to advertise the first one's class:
 <!-- {% raw %} -->
 
 ```yaml


### PR DESCRIPTION
## Problem

`docs/usage/customization-guide.md` (~line 1136) claims that
NodeFeatureRule label/vars templates get "all" Sprig functionality.
That stopped being true when `pkg/apis/nfd/template/template.go`
(commit 0c99ca0fb, merged via #2507) removed `env`, `expandenv` and
`getHostByName` from the template `FuncMap` as part of input-validation
hardening. A template that references any of these three functions now
fails to parse (`function "env" not defined`), and the affected rule is
silently skipped with only an nfd-master log entry — the docs give users
no indication why.

## Approach

Amend the paragraph introducing Sprig template functions to:
- Say "most" instead of "all" of Sprig's functionality is available.
- Name the three removed functions and why they were removed (they read
  host process environment state or perform outbound DNS lookups, and
  aren't needed for label expansion).
- State the observable failure mode: parse failure, rule skipped,
  error logged by nfd-master.

Scope kept to this one paragraph; a full-tree grep confirmed no other
docs/ location makes the same "all Sprig functions" claim.

## Testing done

- `grep -rniE 'sprig|expandenv|getHostByName' docs/` before and after
  the edit — confirmed the customization guide was the only stale
  reference and that no other doc claims full Sprig availability.
- `grep -n "env" docs/usage/customization-guide.md` — confirmed the
  edited paragraph is the only place `env`/`expandenv` now appear.
- Cross-checked the doc claim against `pkg/apis/nfd/template/template.go`
  (the `funcMap` deletion and its comment) and
  `pkg/nfd-master/nfd-master.go` (rule processing: parse/exec errors are
  logged via `klog.ErrorS` and the rule is skipped with `continue`).
- Did not run `make site-build`: the target requires a container
  runtime plus `bundle install` network access to fetch Jekyll gems,
  which isn't available in this environment; docs CI covers Jekyll
  render-sanity for this PR.

Related to #2507. This is a pre-cut, low-risk doc-only item split out
ahead of the larger #2420 v0.19 release-prep tracking issue.
