### PR TITLE
fix(ci): bump gcb-docker-gcloud builder to v20260205-38cfa9523f

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 timeout: 5000s
 steps:
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
     entrypoint: scripts/test-infra/push-image.sh
     env:
     - IMAGE_REGISTRY=gcr.io/$PROJECT_ID


### PR DESCRIPTION
## Problem

`post-node-feature-discovery-push-images` has failed on every run since
2026-07-08: build step 0 cannot pull the pinned builder image
`gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079`
("manifest unknown" — the tag has been garbage-collected from the staging
registry). This blocks all -devel staging images and, critically, the
v0.19.0 release staging build (release tracker: #2420).

Example failing run:
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-node-feature-discovery-push-images/2075532779931570176

## Approach

Bump the builder pin to the current tag `v20260205-38cfa9523f` (verified
present via the registry tags API; latest available).

## Testing done

- Registry check: pinned tag absent, replacement tag present
  (gcr.io/v2/k8s-staging-test-infra/gcb-docker-gcloud/tags/list).
- One-line change; cloudbuild semantics unchanged.
