### PR TITLE
chore: point master README and netlify redirect to v0.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ features and system configuration!
 #### Helm
 
 ```bash
-helm install -n node-feature-discovery --create-namespace nfd oci://registry.k8s.io/nfd/charts/node-feature-discovery --version 0.18.3
+helm install -n node-feature-discovery --create-namespace nfd oci://registry.k8s.io/nfd/charts/node-feature-discovery --version 0.19.0
 ```
 
 #### Kustomize
@@ -22,7 +22,7 @@ helm install -n node-feature-discovery --create-namespace nfd oci://registry.k8s
 Alternatively, you can deploy using kubectl and kustomize:
 
 ```bash
-kubectl apply -k "https://github.com/kubernetes-sigs/node-feature-discovery/deployment/overlays/default?ref=v0.19.0
+kubectl apply -k "https://github.com/kubernetes-sigs/node-feature-discovery/deployment/overlays/default?ref=v0.19.0"
 ```
 
 #### Verify the deployment

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ helm install -n node-feature-discovery --create-namespace nfd oci://registry.k8s
 Alternatively, you can deploy using kubectl and kustomize:
 
 ```bash
-kubectl apply -k "https://github.com/kubernetes-sigs/node-feature-discovery/deployment/overlays/default?ref=v0.18.3"
+kubectl apply -k "https://github.com/kubernetes-sigs/node-feature-discovery/deployment/overlays/default?ref=v0.19.0
 ```
 
 #### Verify the deployment
@@ -44,4 +44,4 @@ $ kubectl get no -o json | jq ".items[].metadata.labels"
 ...
 ```
 
-[documentation]: https://kubernetes-sigs.github.io/node-feature-discovery
+[documentation]: https://kubernetes-sigs.github.io/node-feature-discovery/v0.19

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,6 @@
 
 [[redirects]]
     from = "https://nfd.sigs.k8s.io/*"
-    to = "https://release-0-18--kubernetes-sigs-nfd.netlify.app/:splat"
+    to = "https://release-0-19--kubernetes-sigs-nfd.netlify.app/:splat"
     status = 301
     force = true


### PR DESCRIPTION
Post-release follow-up for v0.19.0
(https://github.com/kubernetes-sigs/node-feature-discovery/releases/tag/v0.19.0):

- README: deployment references master -> v0.19.0 (the README-only slice of
  the hack/prepare-release.sh refs diff, per the release checklist)
- netlify.toml: nfd.sigs.k8s.io redirect release-0-18 -> release-0-19

Related: #2420
