### PR TITLE
fix(nfd-master): scope NodeFeatureGroup updates to their own namespace

### DIFF
--- a/pkg/nfd-master/nfd-api-controller.go
+++ b/pkg/nfd-master/nfd-api-controller.go
@@ -320,7 +320,7 @@ func (c *nfdController) addNodeFeatureGroupInformer(informerFactory nfdinformers
 func (c *nfdController) onNodeFeatureGroupAdd(obj interface{}) {
 	nfg := obj.(*nfdv1alpha1.NodeFeatureGroup)
 	klog.V(2).InfoS("NodeFeatureGroup added", "nodeFeatureGroup", klog.KObj(nfg))
-	c.updateNodeFeatureGroup(nfg.Name)
+	c.enqueueNodeFeatureGroup(nfg)
 }
 
 func (c *nfdController) onNodeFeatureGroupUpdate(oldObj, newObj interface{}) {
@@ -329,7 +329,7 @@ func (c *nfdController) onNodeFeatureGroupUpdate(oldObj, newObj interface{}) {
 	}
 	nfg := newObj.(*nfdv1alpha1.NodeFeatureGroup)
 	klog.V(2).InfoS("NodeFeatureGroup updated", "nodeFeatureGroup", klog.KObj(nfg))
-	c.updateNodeFeatureGroup(nfg.Name)
+	c.enqueueNodeFeatureGroup(nfg)
 }
 
 func (c *nfdController) onNodeFeatureGroupDelete(obj interface{}) {
@@ -346,7 +346,19 @@ func (c *nfdController) onNodeFeatureGroupDelete(obj interface{}) {
 	}
 
 	klog.V(2).InfoS("NodeFeatureGroup deleted", "nodeFeatureGroup", klog.KObj(nfg))
-	c.updateNodeFeatureGroup(nfg.Name)
+	c.enqueueNodeFeatureGroup(nfg)
+}
+
+// enqueueNodeFeatureGroup enqueues a NodeFeatureGroup by its namespace/name
+// key so that same-name objects in different namespaces do not collide and the
+// consumer can resolve the object in its own namespace.
+func (c *nfdController) enqueueNodeFeatureGroup(nfg *nfdv1alpha1.NodeFeatureGroup) {
+	key, err := cache.MetaNamespaceKeyFunc(nfg)
+	if err != nil {
+		klog.ErrorS(err, "failed to create key for NodeFeatureGroup", "nodeFeatureGroup", klog.KObj(nfg))
+		return
+	}
+	c.updateNodeFeatureGroup(key)
 }
 
 func (c *nfdController) stop() {
@@ -410,9 +422,9 @@ func (c *nfdController) updateAllNodes() {
 	}
 }
 
-func (c *nfdController) updateNodeFeatureGroup(nodeFeatureGroup string) {
+func (c *nfdController) updateNodeFeatureGroup(key string) {
 	select {
-	case c.updateNodeFeatureGroupChan <- nodeFeatureGroup:
+	case c.updateNodeFeatureGroupChan <- key:
 	case <-c.stopChan:
 	}
 }

--- a/pkg/nfd-master/nfd-master-internal_test.go
+++ b/pkg/nfd-master/nfd-master-internal_test.go
@@ -93,8 +93,25 @@ func newFakeNfdAPIController(client *fakenfdclient.Clientset) *nfdController {
 	}
 	c.ruleLister = ruleInformer.Lister()
 
-	// Start informers
+	// Add informer for NodeFeatureGroup objects
+	nodeFeatureGroupInformer := informerFactory.Nfd().V1alpha1().NodeFeatureGroups()
+	if _, err := nodeFeatureGroupInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(object interface{}) {},
+		UpdateFunc: func(oldObject, newObject interface{}) {},
+		DeleteFunc: func(object interface{}) {},
+	}); err != nil {
+		return nil
+	}
+	c.featureGroupLister = nodeFeatureGroupInformer.Lister()
+
+	// Start informers and wait for their caches to fill, so that listers are
+	// usable immediately when the helper returns.
 	informerFactory.Start(c.stopChan)
+	cache.WaitForCacheSync(c.stopChan,
+		featureInformer.Informer().HasSynced,
+		ruleInformer.Informer().HasSynced,
+		nodeFeatureGroupInformer.Informer().HasSynced,
+	)
 
 	utilruntime.Must(nfdv1alpha1.AddToScheme(nfdscheme.Scheme))
 

--- a/pkg/nfd-master/nfd-master-nfg-namespace_test.go
+++ b/pkg/nfd-master/nfd-master-nfg-namespace_test.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nfdmaster
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	fakeclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	fakenfdclient "sigs.k8s.io/node-feature-discovery/api/generated/clientset/versioned/fake"
+	nfdscheme "sigs.k8s.io/node-feature-discovery/api/generated/clientset/versioned/scheme"
+	nfdinformers "sigs.k8s.io/node-feature-discovery/api/generated/informers/externalversions"
+	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
+)
+
+const (
+	nfgTestMasterNamespace = "node-feature-discovery"
+	nfgTestOtherNamespace  = "other-namespace"
+	nfgTestName            = "test-nfg"
+)
+
+// newFakeNfdAPIControllerWithNFG builds a controller whose NodeFeature and
+// NodeFeatureGroup listers are backed by (and synced from) the given fake
+// client. Unlike newFakeNfdAPIController it also wires the NodeFeatureGroup
+// lister, which nfdAPIUpdateAllNodeFeatureGroups needs.
+func newFakeNfdAPIControllerWithNFG(client *fakenfdclient.Clientset) *nfdController {
+	c := &nfdController{
+		stopChan:           make(chan struct{}),
+		updateAllNodesChan: make(chan struct{}, 1),
+		updateOneNodeChan:  make(chan string),
+	}
+
+	informerFactory := nfdinformers.NewSharedInformerFactory(client, 1*time.Hour)
+
+	featureInformer := informerFactory.Nfd().V1alpha1().NodeFeatures()
+	c.featureLister = featureInformer.Lister()
+
+	nodeFeatureGroupInformer := informerFactory.Nfd().V1alpha1().NodeFeatureGroups()
+	c.featureGroupLister = nodeFeatureGroupInformer.Lister()
+
+	informerFactory.Start(c.stopChan)
+	cache.WaitForCacheSync(c.stopChan,
+		featureInformer.Informer().HasSynced,
+		nodeFeatureGroupInformer.Informer().HasSynced,
+	)
+
+	utilruntime.Must(nfdv1alpha1.AddToScheme(nfdscheme.Scheme))
+
+	return c
+}
+
+// newNfgTestNodeFeature returns a NodeFeature for testNodeName carrying the
+// system.name/nodename attribute that nfdAPIUpdateNodeFeatureGroup reads when
+// building the matched-node set.
+func newNfgTestNodeFeature() *nfdv1alpha1.NodeFeature {
+	return &nfdv1alpha1.NodeFeature{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testNodeName + "-features",
+			Namespace: nfgTestMasterNamespace,
+			Labels: map[string]string{
+				nfdv1alpha1.NodeFeatureObjNodeNameLabel: testNodeName,
+			},
+		},
+		Spec: nfdv1alpha1.NodeFeatureSpec{
+			Features: nfdv1alpha1.Features{
+				Attributes: map[string]nfdv1alpha1.AttributeFeatureSet{
+					"system.name": {
+						Elements: map[string]string{"nodename": testNodeName},
+					},
+				},
+			},
+		},
+	}
+}
+
+// newNfgMatchAll returns a NodeFeatureGroup in the given namespace with a
+// single rule that has no matchers, which matches every node (see
+// ExecuteGroupRule: IsMatch is true when both MatchAny and MatchFeatures are
+// empty).
+func newNfgMatchAll(namespace string) *nfdv1alpha1.NodeFeatureGroup {
+	return &nfdv1alpha1.NodeFeatureGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nfgTestName,
+			Namespace: namespace,
+		},
+		Spec: nfdv1alpha1.NodeFeatureGroupSpec{
+			Rules: []nfdv1alpha1.GroupRule{
+				{Name: "match-all"},
+			},
+		},
+	}
+}
+
+// drainNfgQueue processes every item currently in the NodeFeatureGroup queue.
+// The updater pool is started with parallelism 0 so no consumer goroutines
+// run; this drains the queue synchronously and deterministically.
+func drainNfgQueue(t *testing.T, u *updaterPool, cli *fakenfdclient.Clientset) {
+	t.Helper()
+	for i := 0; i < 100 && u.nfgQueue.Len() > 0; i++ {
+		u.processNodeFeatureGroupUpdateRequest(cli)
+	}
+	require.Zero(t, u.nfgQueue.Len(), "NodeFeatureGroup queue was not drained")
+}
+
+// TestNodeFeatureGroupNamespaceScoping exercises the full enqueue -> dequeue ->
+// status-write path for NodeFeatureGroups that live in different namespaces.
+//
+// Regression for #2558. On master this fails because:
+//   - the enqueue site keys the queue by bare Name, so two same-name NFGs in
+//     different namespaces collide into a single queue entry, and
+//   - the consumer resolves the NFG only in nfd-master's own namespace, so an
+//     NFG in any other namespace is NotFound and silently skipped, and
+//   - the status write is pinned to nfd-master's namespace.
+//
+// The net effect is that the NFG in nfgTestOtherNamespace never gets its status
+// populated. After the fix both NFGs are processed independently in their own
+// namespaces.
+func TestNodeFeatureGroupNamespaceScoping(t *testing.T) {
+	node := newTestNode()
+	k8sCli := fakeclient.NewClientset(node)
+
+	nodeFeature := newNfgTestNodeFeature()
+	nfgInMaster := newNfgMatchAll(nfgTestMasterNamespace)
+	nfgInOther := newNfgMatchAll(nfgTestOtherNamespace)
+
+	//nolint:staticcheck
+	nfdCli := fakenfdclient.NewSimpleClientset(nodeFeature, nfgInMaster, nfgInOther)
+
+	fakeMaster := newFakeMaster(WithKubernetesClient(k8sCli), withNFDClient(nfdCli))
+	fakeMaster.namespace = nfgTestMasterNamespace
+	fakeMaster.nfdController = newFakeNfdAPIControllerWithNFG(nfdCli)
+
+	updaterPool := newUpdaterPool(fakeMaster)
+	fakeMaster.updaterPool = updaterPool
+	updaterPool.start(0) // initialize the queues without spawning consumer goroutines
+	defer updaterPool.stop()
+
+	require.NoError(t, fakeMaster.nfdAPIUpdateAllNodeFeatureGroups())
+
+	drainNfgQueue(t, updaterPool, nfdCli)
+
+	testCases := []struct {
+		name      string
+		namespace string
+	}{
+		{name: "NFG in nfd-master namespace", namespace: nfgTestMasterNamespace},
+		{name: "NFG in a different namespace", namespace: nfgTestOtherNamespace},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := nfdCli.NfdV1alpha1().NodeFeatureGroups(tc.namespace).Get(
+				context.TODO(), nfgTestName, metav1.GetOptions{})
+			require.NoError(t, err)
+
+			nodeNames := make([]string, 0, len(got.Status.Nodes))
+			for _, n := range got.Status.Nodes {
+				nodeNames = append(nodeNames, n.Name)
+			}
+			assert.ElementsMatch(t, []string{testNodeName}, nodeNames,
+				"NodeFeatureGroup %q in namespace %q should have its own status populated",
+				nfgTestName, tc.namespace)
+		})
+	}
+}
+
+// TestNfdAPIUpdateNodeFeatureGroupTargetsObjectNamespace asserts that the
+// status write targets the NodeFeatureGroup's own namespace rather than
+// nfd-master's namespace.
+//
+// Regression for #2558 (the UpdateStatus namespace pinning). The object lives
+// in nfgTestOtherNamespace while nfd-master's namespace is
+// nfgTestMasterNamespace. On master the write is issued against nfd-master's
+// namespace, which the fake client rejects because the request namespace does
+// not match the object's own namespace; after the fix the write targets the
+// object's namespace and the recorded UpdateStatus action confirms it.
+func TestNfdAPIUpdateNodeFeatureGroupTargetsObjectNamespace(t *testing.T) {
+	node := newTestNode()
+	k8sCli := fakeclient.NewClientset(node)
+
+	nodeFeature := newNfgTestNodeFeature()
+	nfg := newNfgMatchAll(nfgTestOtherNamespace)
+
+	//nolint:staticcheck
+	nfdCli := fakenfdclient.NewSimpleClientset(nodeFeature, nfg)
+
+	fakeMaster := newFakeMaster(WithKubernetesClient(k8sCli), withNFDClient(nfdCli))
+	fakeMaster.namespace = nfgTestMasterNamespace
+	fakeMaster.nfdController = newFakeNfdAPIControllerWithNFG(nfdCli)
+
+	require.NotEqual(t, nfg.Namespace, fakeMaster.namespace,
+		"test precondition: object namespace must differ from nfd-master namespace")
+
+	nfdCli.ClearActions()
+	require.NoError(t, fakeMaster.nfdAPIUpdateNodeFeatureGroup(nfdCli, nfg))
+
+	var updateNamespaces []string
+	for _, action := range nfdCli.Actions() {
+		if action.GetVerb() == "update" &&
+			action.GetResource().Resource == "nodefeaturegroups" &&
+			action.GetSubresource() == "status" {
+			updateNamespaces = append(updateNamespaces, action.GetNamespace())
+		}
+	}
+
+	require.Len(t, updateNamespaces, 1, "expected exactly one NodeFeatureGroup status update")
+	assert.Equal(t, nfgTestOtherNamespace, updateNamespaces[0],
+		"UpdateStatus must target the NodeFeatureGroup's own namespace, not nfd-master's namespace")
+}

--- a/pkg/nfd-master/nfd-master-nfg-namespace_test.go
+++ b/pkg/nfd-master/nfd-master-nfg-namespace_test.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nfdmaster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclient "k8s.io/client-go/kubernetes/fake"
+
+	fakenfdclient "sigs.k8s.io/node-feature-discovery/api/generated/clientset/versioned/fake"
+	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
+)
+
+const (
+	nfgTestMasterNamespace = "node-feature-discovery"
+	nfgTestOtherNamespace  = "other-namespace"
+	nfgTestName            = "test-nfg"
+)
+
+// newNfgTestNodeFeature returns a NodeFeature for testNodeName carrying the
+// system.name/nodename attribute that nfdAPIUpdateNodeFeatureGroup reads when
+// building the matched-node set.
+func newNfgTestNodeFeature() *nfdv1alpha1.NodeFeature {
+	return &nfdv1alpha1.NodeFeature{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testNodeName + "-features",
+			Namespace: nfgTestMasterNamespace,
+			Labels: map[string]string{
+				nfdv1alpha1.NodeFeatureObjNodeNameLabel: testNodeName,
+			},
+		},
+		Spec: nfdv1alpha1.NodeFeatureSpec{
+			Features: nfdv1alpha1.Features{
+				Attributes: map[string]nfdv1alpha1.AttributeFeatureSet{
+					"system.name": {
+						Elements: map[string]string{"nodename": testNodeName},
+					},
+				},
+			},
+		},
+	}
+}
+
+// newNfgMatchAll returns a NodeFeatureGroup in the given namespace with a
+// single rule that has no matchers, which matches every node (see
+// ExecuteGroupRule: IsMatch is true when both MatchAny and MatchFeatures are
+// empty).
+func newNfgMatchAll(namespace string) *nfdv1alpha1.NodeFeatureGroup {
+	return &nfdv1alpha1.NodeFeatureGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nfgTestName,
+			Namespace: namespace,
+		},
+		Spec: nfdv1alpha1.NodeFeatureGroupSpec{
+			Rules: []nfdv1alpha1.GroupRule{
+				{Name: "match-all"},
+			},
+		},
+	}
+}
+
+// drainNfgQueue processes every item currently in the NodeFeatureGroup queue.
+// The updater pool is started with parallelism 0 so no consumer goroutines
+// run; this drains the queue synchronously and deterministically.
+func drainNfgQueue(t *testing.T, u *updaterPool, cli *fakenfdclient.Clientset) {
+	t.Helper()
+	for i := 0; i < 100 && u.nfgQueue.Len() > 0; i++ {
+		u.processNodeFeatureGroupUpdateRequest(cli)
+	}
+	require.Zero(t, u.nfgQueue.Len(), "NodeFeatureGroup queue was not drained")
+}
+
+// TestNodeFeatureGroupNamespaceScoping exercises the full enqueue -> dequeue ->
+// status-write path for NodeFeatureGroups that live in different namespaces.
+//
+// Regression for #2558. On master this fails because:
+//   - the enqueue site keys the queue by bare Name, so two same-name NFGs in
+//     different namespaces collide into a single queue entry, and
+//   - the consumer resolves the NFG only in nfd-master's own namespace, so an
+//     NFG in any other namespace is NotFound and silently skipped, and
+//   - the status write is pinned to nfd-master's namespace.
+//
+// The net effect is that the NFG in nfgTestOtherNamespace never gets its status
+// populated. After the fix both NFGs are processed independently in their own
+// namespaces.
+func TestNodeFeatureGroupNamespaceScoping(t *testing.T) {
+	node := newTestNode()
+	k8sCli := fakeclient.NewClientset(node)
+
+	nodeFeature := newNfgTestNodeFeature()
+	nfgInMaster := newNfgMatchAll(nfgTestMasterNamespace)
+	nfgInOther := newNfgMatchAll(nfgTestOtherNamespace)
+
+	//nolint:staticcheck
+	nfdCli := fakenfdclient.NewSimpleClientset(nodeFeature, nfgInMaster, nfgInOther)
+
+	fakeMaster := newFakeMaster(WithKubernetesClient(k8sCli), withNFDClient(nfdCli))
+	fakeMaster.namespace = nfgTestMasterNamespace
+	fakeMaster.nfdController = newFakeNfdAPIController(nfdCli)
+
+	updaterPool := newUpdaterPool(fakeMaster)
+	fakeMaster.updaterPool = updaterPool
+	updaterPool.start(0) // initialize the queues without spawning consumer goroutines
+	defer updaterPool.stop()
+
+	require.NoError(t, fakeMaster.nfdAPIUpdateAllNodeFeatureGroups())
+
+	drainNfgQueue(t, updaterPool, nfdCli)
+
+	testCases := []struct {
+		name      string
+		namespace string
+	}{
+		{name: "NFG in nfd-master namespace", namespace: nfgTestMasterNamespace},
+		{name: "NFG in a different namespace", namespace: nfgTestOtherNamespace},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := nfdCli.NfdV1alpha1().NodeFeatureGroups(tc.namespace).Get(
+				context.TODO(), nfgTestName, metav1.GetOptions{})
+			require.NoError(t, err)
+
+			nodeNames := make([]string, 0, len(got.Status.Nodes))
+			for _, n := range got.Status.Nodes {
+				nodeNames = append(nodeNames, n.Name)
+			}
+			assert.ElementsMatch(t, []string{testNodeName}, nodeNames,
+				"NodeFeatureGroup %q in namespace %q should have its own status populated",
+				nfgTestName, tc.namespace)
+		})
+	}
+}
+
+// TestNfdAPIUpdateNodeFeatureGroupTargetsObjectNamespace asserts that the
+// status write targets the NodeFeatureGroup's own namespace rather than
+// nfd-master's namespace.
+//
+// Regression for #2558 (the UpdateStatus namespace pinning). The object lives
+// in nfgTestOtherNamespace while nfd-master's namespace is
+// nfgTestMasterNamespace. On master the write is issued against nfd-master's
+// namespace, which the fake client rejects because the request namespace does
+// not match the object's own namespace; after the fix the write targets the
+// object's namespace and the recorded UpdateStatus action confirms it.
+func TestNfdAPIUpdateNodeFeatureGroupTargetsObjectNamespace(t *testing.T) {
+	node := newTestNode()
+	k8sCli := fakeclient.NewClientset(node)
+
+	nodeFeature := newNfgTestNodeFeature()
+	nfg := newNfgMatchAll(nfgTestOtherNamespace)
+
+	//nolint:staticcheck
+	nfdCli := fakenfdclient.NewSimpleClientset(nodeFeature, nfg)
+
+	fakeMaster := newFakeMaster(WithKubernetesClient(k8sCli), withNFDClient(nfdCli))
+	fakeMaster.namespace = nfgTestMasterNamespace
+	fakeMaster.nfdController = newFakeNfdAPIController(nfdCli)
+
+	require.NotEqual(t, nfg.Namespace, fakeMaster.namespace,
+		"test precondition: object namespace must differ from nfd-master namespace")
+
+	nfdCli.ClearActions()
+	require.NoError(t, fakeMaster.nfdAPIUpdateNodeFeatureGroup(nfdCli, nfg))
+
+	var updateNamespaces []string
+	for _, action := range nfdCli.Actions() {
+		if action.GetVerb() == "update" &&
+			action.GetResource().Resource == "nodefeaturegroups" &&
+			action.GetSubresource() == "status" {
+			updateNamespaces = append(updateNamespaces, action.GetNamespace())
+		}
+	}
+
+	require.Len(t, updateNamespaces, 1, "expected exactly one NodeFeatureGroup status update")
+	assert.Equal(t, nfgTestOtherNamespace, updateNamespaces[0],
+		"UpdateStatus must target the NodeFeatureGroup's own namespace, not nfd-master's namespace")
+}

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	k8sclient "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/klog/v2"
@@ -381,8 +382,8 @@ func (m *nfdMaster) nfdAPIUpdateHandler() {
 			updateNodes[nodeName] = struct{}{}
 		case <-m.updateAllNodeFeatureGroupsChan:
 			updateAllNodeFeatureGroups = true
-		case nodeFeatureGroupName := <-m.updateNodeFeatureGroupChan:
-			nodeFeatureGroup[nodeFeatureGroupName] = struct{}{}
+		case nfgKey := <-m.updateNodeFeatureGroupChan:
+			nodeFeatureGroup[nfgKey] = struct{}{}
 		case <-resyncTickerC:
 			klog.V(1).InfoS("periodic reconciliation triggered")
 			updateAll = true
@@ -413,8 +414,8 @@ func (m *nfdMaster) nfdAPIUpdateHandler() {
 					errUpdateAllNFG = true
 				}
 			} else {
-				for nodeFeatureGroupName := range nodeFeatureGroup {
-					m.updaterPool.addNodeFeatureGroup(nodeFeatureGroupName)
+				for nfgKey := range nodeFeatureGroup {
+					m.updaterPool.addNodeFeatureGroup(nfgKey)
 				}
 			}
 
@@ -820,7 +821,12 @@ func (m *nfdMaster) nfdAPIUpdateAllNodeFeatureGroups() error {
 
 	if len(nodeFeatureGroupsList) > 0 {
 		for _, nodeFeatureGroup := range nodeFeatureGroupsList {
-			m.updaterPool.nfgQueue.Add(nodeFeatureGroup.Name)
+			key, err := cache.MetaNamespaceKeyFunc(nodeFeatureGroup)
+			if err != nil {
+				klog.ErrorS(err, "failed to create key for NodeFeatureGroup", "nodeFeatureGroup", klog.KObj(nodeFeatureGroup))
+				continue
+			}
+			m.updaterPool.nfgQueue.Add(key)
 		}
 	} else {
 		klog.V(2).InfoS("no NodeFeatureGroup objects found")
@@ -884,7 +890,7 @@ func (m *nfdMaster) nfdAPIUpdateNodeFeatureGroup(nfdClient nfdclientset.Interfac
 
 	if !apiequality.Semantic.DeepEqual(nodeFeatureGroup, nodeFeatureGroupUpdated) {
 		klog.InfoS("updating NodeFeatureGroup object", "nodeFeatureGroup", klog.KObj(nodeFeatureGroup))
-		nodeFeatureGroupUpdated, err = nfdClient.NfdV1alpha1().NodeFeatureGroups(m.namespace).UpdateStatus(context.TODO(), nodeFeatureGroupUpdated, metav1.UpdateOptions{})
+		nodeFeatureGroupUpdated, err = nfdClient.NfdV1alpha1().NodeFeatureGroups(nodeFeatureGroup.Namespace).UpdateStatus(context.TODO(), nodeFeatureGroupUpdated, metav1.UpdateOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to update NodeFeatureGroup object: %w", err)
 		}

--- a/pkg/nfd-master/updater-pool.go
+++ b/pkg/nfd-master/updater-pool.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/time/rate"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8sclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	nfdclientset "sigs.k8s.io/node-feature-discovery/api/generated/clientset/versioned"
@@ -94,30 +95,38 @@ func (u *updaterPool) runNodeUpdater() {
 }
 
 func (u *updaterPool) processNodeFeatureGroupUpdateRequest(cli nfdclientset.Interface) bool {
-	nfgName, quit := u.nfgQueue.Get()
+	key, quit := u.nfgQueue.Get()
 	if quit {
 		return false
 	}
-	defer u.nfgQueue.Done(nfgName)
+	defer u.nfgQueue.Done(key)
 
 	nodeFeatureGroupUpdateRequests.Inc()
 
+	// The queue key is a namespace/name key: resolve the NodeFeatureGroup in
+	// its own namespace, not in nfd-master's namespace.
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.ErrorS(err, "failed to split NodeFeatureGroup queue key, dropping", "key", key)
+		u.nfgQueue.Forget(key)
+		return true
+	}
+
 	// Check if NodeFeatureGroup exists
 	var nfg *nfdv1alpha1.NodeFeatureGroup
-	var err error
-	if nfg, err = getNodeFeatureGroup(cli, u.nfdMaster.namespace, nfgName); apierrors.IsNotFound(err) {
-		klog.InfoS("NodeFeatureGroup not found, skip update", "NodeFeatureGroupName", nfgName)
+	if nfg, err = getNodeFeatureGroup(cli, namespace, name); apierrors.IsNotFound(err) {
+		klog.InfoS("NodeFeatureGroup not found, skip update", "nodeFeatureGroup", klog.KRef(namespace, name))
 	} else if err := u.nfdMaster.nfdAPIUpdateNodeFeatureGroup(u.nfdMaster.nfdClient, nfg); err != nil {
-		if n := u.nfgQueue.NumRequeues(nfgName); n < 15 {
+		if n := u.nfgQueue.NumRequeues(key); n < 15 {
 			klog.InfoS("retrying NodeFeatureGroup update", "nodeFeatureGroup", klog.KObj(nfg), "lastError", err)
 		} else {
 			klog.ErrorS(err, "failed to update NodeFeatureGroup, queueing for retry", "nodeFeatureGroup", klog.KObj(nfg), "lastError", err, "numRetries", n)
 		}
-		u.nfgQueue.AddRateLimited(nfgName)
+		u.nfgQueue.AddRateLimited(key)
 		return true
 	}
 
-	u.nfgQueue.Forget(nfgName)
+	u.nfgQueue.Forget(key)
 	return true
 }
 
@@ -193,8 +202,8 @@ func (u *updaterPool) addNode(nodeName string) {
 	u.queue.Add(nodeName)
 }
 
-func (u *updaterPool) addNodeFeatureGroup(nodeFeatureGroupName string) {
+func (u *updaterPool) addNodeFeatureGroup(nodeFeatureGroupKey string) {
 	u.RLock()
 	defer u.RUnlock()
-	u.nfgQueue.Add(nodeFeatureGroupName)
+	u.nfgQueue.Add(nodeFeatureGroupKey)
 }


### PR DESCRIPTION
**What this PR does / why we need it:**

nfd-master lists NodeFeatureGroups cluster-wide but processes them pinned to its own namespace: the update queue carried bare names (so same-name NFGs in different namespaces collide), and both the consumer lookup and `UpdateStatus` used nfd-master's namespace — NFGs in any other namespace were enqueued and then silently skipped, their `status.nodes` never populated.

This threads namespace/name through the NFG update queue (`cache.MetaNamespaceKeyFunc` / `cache.SplitMetaNamespaceKey` at every enqueue site, including the informer handlers), resolves and updates each NFG in its own namespace, and keeps the cluster-wide listing.

**Testing:** regression tests that fail on master — same-name NFGs in two namespaces must both get `status.nodes` populated independently, and `UpdateStatus` must target the object's namespace (asserted via fake-client actions). Full `pkg/nfd-master` suite green.

**Fixes #2558**

/cc @PiotrProkop @Xunli-Yang
