### PR TITLE
move get+update to a server side patch for topology updater

### DIFF
--- a/deployment/base/rbac-topologyupdater/topologyupdater-clusterrole.yaml
+++ b/deployment/base/rbac-topologyupdater/topologyupdater-clusterrole.yaml
@@ -36,8 +36,7 @@ rules:
   - noderesourcetopologies
   verbs:
   - create
-  - get
-  - update
+  - patch
 - apiGroups:
   - apiextensions.k8s.io
   resources:

--- a/deployment/helm/node-feature-discovery/templates/clusterrole.yaml
+++ b/deployment/helm/node-feature-discovery/templates/clusterrole.yaml
@@ -118,8 +118,7 @@ rules:
   - noderesourcetopologies
   verbs:
   - create
-  - get
-  - update
+  - patch
 - apiGroups:
   - apiextensions.k8s.io
   resources:

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jaypipes/ghw v0.24.0
 	github.com/jedib0t/go-pretty/v6 v6.8.2
-	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.2
+	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.3
 	github.com/k8stopologyawareschedwg/podfingerprint v0.3.0
 	github.com/klauspost/cpuid/v2 v2.4.0
 	github.com/onsi/ginkgo/v2 v2.32.0

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.2 h1:uAwqOtyrFYggq3pVf3hs1XKkBxrQ8dkgjWz3LCLJsiY=
-github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.2/go.mod h1:LBzS4n6GX1C69tzSd5EibZ9cGOXFuHP7GxEMDYVe1sM=
+github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.3 h1:aXkBkkcxBYmr9anRPeaz68tvP2bX2HutrGgqr4hoXE4=
+github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.3/go.mod h1:lWV0gAcHlmZjmGDhVSkoyTcRlwNAZnTQ3LK32R9/EKA=
 github.com/k8stopologyawareschedwg/podfingerprint v0.3.0 h1:xJmXm8vi3qBpMTucRhrF3aEGnp8f5bJrrcsXfzVr7ow=
 github.com/k8stopologyawareschedwg/podfingerprint v0.3.0/go.mod h1:GtO0jO6n3W7A8LEKGDEm9a63IA3ZOJx22RGFV547wE4=
 github.com/karrick/godirwalk v1.17.0 h1:b4kY7nqDdioR/6qnbHQyDvmA17u5G1cZ6J+CZXwSWoI=

--- a/pkg/nfd-topology-updater/nfd-topology-updater.go
+++ b/pkg/nfd-topology-updater/nfd-topology-updater.go
@@ -18,6 +18,7 @@ package nfdtopologyupdater
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -28,10 +29,11 @@ import (
 	"time"
 
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
+	metav1apply "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/informers"
 	k8sclient "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
@@ -40,6 +42,7 @@ import (
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 
 	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+	applyconfigurationtopologyv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/applyconfiguration/topology/v1alpha2"
 	topologyclientset "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -60,6 +63,8 @@ import (
 const nodeScopedPodInformerResync = 0
 
 const (
+	topologyManagerInfoRefreshTimeout = 2 * time.Minute
+
 	// TopologyManagerPolicyAttributeName represents an attribute which defines
 	// Topology Manager Policy
 	TopologyManagerPolicyAttributeName = "topologyManagerPolicy"
@@ -68,7 +73,12 @@ const (
 	TopologyManagerScopeAttributeName = "topologyManagerScope"
 	// NodeResourceTopologyCRDName is the name of the NodeResourceTopology CRD
 	NodeResourceTopologyCRDName = "noderesourcetopologies.topology.node.k8s.io"
+	// nodeResourceTopologyFieldManager is used for server-side apply updates to
+	// NodeResourceTopology objects.
+	nodeResourceTopologyFieldManager = "node-feature-discovery-topology-updater"
 )
+
+var errTopologyManagerInfoUnavailable = errors.New("topology-manager information unavailable")
 
 // Args are the command line arguments
 type Args struct {
@@ -93,18 +103,22 @@ type NfdTopologyUpdater interface {
 }
 
 type nfdTopologyUpdater struct {
-	nodeName            string
-	args                Args
-	topoClient          topologyclientset.Interface
-	resourcemonitorArgs resourcemonitor.Args
-	stop                chan struct{} // channel for signaling stop
-	eventSource         <-chan kubeletnotifier.Info
-	configFilePath      string
-	config              *NFDConfig
-	kubernetesNamespace string
-	ownerRefs           []metav1.OwnerReference
-	k8sClient           k8sclient.Interface
-	kubeletConfigFunc   func() (*kubeletconfigv1beta1.KubeletConfiguration, error)
+	nodeName             string
+	args                 Args
+	topoClient           topologyclientset.Interface
+	resourcemonitorArgs  resourcemonitor.Args
+	stop                 chan struct{} // channel for signaling stop
+	eventSource          <-chan kubeletnotifier.Info
+	configFilePath       string
+	config               *NFDConfig
+	kubernetesNamespace  string
+	ownerRefs            []metav1.OwnerReference
+	k8sClient            k8sclient.Interface
+	kubeletConfigFunc    func(context.Context) (*kubeletconfigv1beta1.KubeletConfiguration, error)
+	discoverCpuCoresFunc func() v1alpha2.AttributeList
+	kubeletConfigMu      sync.RWMutex
+	kubeletConfig        *kubeletconfigv1beta1.KubeletConfiguration
+	cpuCoreAttributes    v1alpha2.AttributeList
 }
 
 // NewTopologyUpdater creates a new NfdTopologyUpdater instance.
@@ -123,15 +137,16 @@ func NewTopologyUpdater(args Args, resourcemonitorArgs resourcemonitor.Args) (Nf
 	}
 
 	nfd := &nfdTopologyUpdater{
-		args:                args,
-		resourcemonitorArgs: resourcemonitorArgs,
-		stop:                make(chan struct{}),
-		nodeName:            utils.NodeName(),
-		eventSource:         eventSource,
-		config:              &NFDConfig{},
-		kubernetesNamespace: utils.GetKubernetesNamespace(),
-		ownerRefs:           []metav1.OwnerReference{},
-		kubeletConfigFunc:   kubeletConfigFunc,
+		args:                 args,
+		resourcemonitorArgs:  resourcemonitorArgs,
+		stop:                 make(chan struct{}),
+		nodeName:             utils.NodeName(),
+		eventSource:          eventSource,
+		config:               &NFDConfig{},
+		kubernetesNamespace:  utils.GetKubernetesNamespace(),
+		ownerRefs:            []metav1.OwnerReference{},
+		kubeletConfigFunc:    kubeletConfigFunc,
+		discoverCpuCoresFunc: discoverCpuCores,
 	}
 	if args.ConfigFile != "" {
 		nfd.configFilePath = filepath.Clean(args.ConfigFile)
@@ -139,10 +154,52 @@ func NewTopologyUpdater(args Args, resourcemonitorArgs resourcemonitor.Args) (Nf
 	return nfd, nil
 }
 
-func (w *nfdTopologyUpdater) detectTopologyPolicyAndScope() (string, string, error) {
-	klConfig, err := w.kubeletConfigFunc()
+// refreshTopologyManagerInfo fetches and caches the inputs used to publish
+// topology-manager information.
+func (w *nfdTopologyUpdater) refreshTopologyManagerInfo(ctx context.Context) error {
+	klConfig, err := w.kubeletConfigFunc(ctx)
 	if err != nil {
-		return "", "", err
+		return err
+	}
+	cpuCoreAttributes := w.discoverCpuCoresFunc()
+
+	w.kubeletConfigMu.Lock()
+	w.kubeletConfig = klConfig
+	w.cpuCoreAttributes = cpuCoreAttributes
+	w.kubeletConfigMu.Unlock()
+	return nil
+}
+
+// getKubeletConfig returns the cached kubelet configuration, or nil if it has
+// not been fetched yet.
+func (w *nfdTopologyUpdater) getKubeletConfig() *kubeletconfigv1beta1.KubeletConfiguration {
+	w.kubeletConfigMu.RLock()
+	defer w.kubeletConfigMu.RUnlock()
+	return w.kubeletConfig
+}
+
+func (w *nfdTopologyUpdater) getCpuCoreAttributes() v1alpha2.AttributeList {
+	w.kubeletConfigMu.RLock()
+	defer w.kubeletConfigMu.RUnlock()
+	return append(v1alpha2.AttributeList(nil), w.cpuCoreAttributes...)
+}
+
+func (w *nfdTopologyUpdater) newTopologyManagerRefreshContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(context.Background(), topologyManagerInfoRefreshTimeout)
+	go func() {
+		select {
+		case <-w.stop:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	return ctx, cancel
+}
+
+func (w *nfdTopologyUpdater) detectTopologyPolicyAndScope() (string, string, error) {
+	klConfig := w.getKubeletConfig()
+	if klConfig == nil {
+		return "", "", fmt.Errorf("kubelet configuration is not cached")
 	}
 
 	return klConfig.TopologyManagerPolicy, klConfig.TopologyManagerScope, nil
@@ -207,6 +264,15 @@ func (w *nfdTopologyUpdater) Run() error {
 
 	if err := w.configure(); err != nil {
 		return fmt.Errorf("faild to configure Node Feature Discovery Topology Updater: %w", err)
+	}
+
+	// Cache topology-manager information once on startup. It is subsequently
+	// refreshed on interval-based events (see the event loop below).
+	refreshCtx, cancelRefresh := w.newTopologyManagerRefreshContext()
+	err = w.refreshTopologyManagerInfo(refreshCtx)
+	cancelRefresh()
+	if err != nil {
+		klog.ErrorS(err, "failed to cache topology-manager information on startup, will retry on next scan")
 	}
 
 	syncCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -281,13 +347,25 @@ func (w *nfdTopologyUpdater) Run() error {
 			}
 			zones = resAggr.Aggregate(scanResponse.PodResources)
 			klog.V(1).InfoS("aggregated resources identified", "resourceZones", utils.DelayedDumper(zones))
-			readKubeletConfig := false
 			if info.Event == kubeletnotifier.IntervalBased {
-				readKubeletConfig = true
+				refreshCtx, cancel := w.newTopologyManagerRefreshContext()
+				err := w.refreshTopologyManagerInfo(refreshCtx)
+				cancel()
+				if err != nil {
+					klog.ErrorS(err, "failed to refresh topology-manager information, keeping cached information")
+				}
 			}
 
 			if !w.args.NoPublish {
-				if err = w.updateNodeResourceTopology(zones, scanResponse, readKubeletConfig); err != nil {
+				if err = w.updateNodeResourceTopology(zones, scanResponse); err != nil {
+					if errors.Is(err, errTopologyManagerInfoUnavailable) {
+						scanErrors.Inc()
+						klog.ErrorS(err, "skipping NodeResourceTopology publish")
+						if w.args.Oneshot {
+							return err
+						}
+						continue
+					}
 					return err
 				}
 			}
@@ -309,7 +387,7 @@ func (w *nfdTopologyUpdater) Stop() {
 	close(w.stop)
 }
 
-func (w *nfdTopologyUpdater) updateNodeResourceTopology(zoneInfo v1alpha2.ZoneList, scanResponse resourcemonitor.ScanResponse, readKubeletConfig bool) error {
+func (w *nfdTopologyUpdater) updateNodeResourceTopology(zoneInfo v1alpha2.ZoneList, scanResponse resourcemonitor.ScanResponse) error {
 
 	if len(w.ownerRefs) == 0 {
 		ns, err := w.k8sClient.CoreV1().Namespaces().Get(context.TODO(), w.kubernetesNamespace, metav1.GetOptions{})
@@ -327,58 +405,65 @@ func (w *nfdTopologyUpdater) updateNodeResourceTopology(zoneInfo v1alpha2.ZoneLi
 		}
 	}
 
-	nrt, err := w.topoClient.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), w.nodeName, metav1.GetOptions{})
-	if errors.IsNotFound(err) {
-		nrtNew := v1alpha2.NodeResourceTopology{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            w.nodeName,
-				OwnerReferences: w.ownerRefs,
-			},
-			Zones:      zoneInfo,
-			Attributes: v1alpha2.AttributeList{},
-		}
-
-		if err := w.updateNRTTopologyManagerInfo(&nrtNew); err != nil {
-			return err
-		}
-
-		updateAttributes(&nrtNew.Attributes, scanResponse.Attributes)
-
-		if _, err := w.topoClient.TopologyV1alpha2().NodeResourceTopologies().Create(context.TODO(), &nrtNew, metav1.CreateOptions{}); err != nil {
-			if errors.IsNotFound(err) {
-				return fmt.Errorf("failed to create NodeResourceTopology: %w. "+
-					"The NodeResourceTopology CRD may not be installed. "+
-					"If using Helm, ensure 'topologyUpdater.createCRDs=true' is set",
-					err)
-			}
-			return fmt.Errorf("failed to create NodeResourceTopology: %w", err)
-		}
-		return nil
-	} else if err != nil {
-		return err
+	nrt := &v1alpha2.NodeResourceTopology{
+		Attributes: v1alpha2.AttributeList{},
 	}
 
-	nrtMutated := nrt.DeepCopy()
-	nrtMutated.Zones = zoneInfo
-	nrtMutated.OwnerReferences = w.ownerRefs
-
-	attributes := scanResponse.Attributes
-
-	if readKubeletConfig {
-		if err := w.updateNRTTopologyManagerInfo(nrtMutated); err != nil {
-			return err
-		}
+	if err := w.applyNRTTopologyManagerInfo(nrt); err != nil {
+		return fmt.Errorf("%w: %w", errTopologyManagerInfoUnavailable, err)
 	}
 
-	updateAttributes(&nrtMutated.Attributes, attributes)
+	updateAttributes(&nrt.Attributes, scanResponse.Attributes)
 
-	nrtUpdated, err := w.topoClient.TopologyV1alpha2().NodeResourceTopologies().Update(context.TODO(), nrtMutated, metav1.UpdateOptions{})
+	nrtApply := applyconfigurationtopologyv1alpha2.NodeResourceTopology(w.nodeName)
+	if len(w.ownerRefs) > 0 {
+		ownerRefApplies := make([]*metav1apply.OwnerReferenceApplyConfiguration, len(w.ownerRefs))
+		for i, ref := range w.ownerRefs {
+			ownerRefApplies[i] = metav1apply.OwnerReference().
+				WithAPIVersion(ref.APIVersion).
+				WithKind(ref.Kind).
+				WithName(ref.Name).
+				WithUID(ref.UID)
+		}
+		nrtApply.WithOwnerReferences(ownerRefApplies...)
+	}
+	nrtApply.WithZones(zoneInfo).
+		WithAttributes(nrt.Attributes).
+		WithTopologyPolicies(nrt.TopologyPolicies...)
+
+	nrtUpdated, err := w.topoClient.TopologyV1alpha2().NodeResourceTopologies().Apply(
+		context.TODO(),
+		nrtApply,
+		metav1.ApplyOptions{
+			FieldManager: nodeResourceTopologyFieldManager,
+			Force:        true,
+		},
+	)
 	if err != nil {
-		return fmt.Errorf("failed to update NodeResourceTopology: %w", err)
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to apply NodeResourceTopology: %w. "+
+				"The NodeResourceTopology CRD may not be installed. "+
+				"If using Helm, ensure 'topologyUpdater.createCRDs=true' is set",
+				err)
+		}
+		return fmt.Errorf("failed to apply NodeResourceTopology: %w", err)
 	}
 
-	klog.V(4).InfoS("NodeResourceTopology object updated", "nodeResourceTopology", utils.DelayedDumper(nrtUpdated))
+	klog.V(4).InfoS("NodeResourceTopology object applied", "nodeResourceTopology", utils.DelayedDumper(nrtUpdated))
 	return nil
+}
+
+func (w *nfdTopologyUpdater) applyNRTTopologyManagerInfo(nrt *v1alpha2.NodeResourceTopology) error {
+	if w.getKubeletConfig() == nil {
+		refreshCtx, cancel := w.newTopologyManagerRefreshContext()
+		err := w.refreshTopologyManagerInfo(refreshCtx)
+		cancel()
+		if err != nil {
+			return err
+		}
+	}
+
+	return w.updateNRTTopologyManagerInfo(nrt)
 }
 
 // Discover E/P cores
@@ -419,7 +504,7 @@ func (w *nfdTopologyUpdater) updateNRTTopologyManagerInfo(nrt *v1alpha2.NodeReso
 	updateAttributes(&nrt.Attributes, tmAttributes)
 	nrt.TopologyPolicies = deprecatedTopologyPolicies
 
-	attrList := discoverCpuCores()
+	attrList := w.getCpuCoreAttributes()
 	updateAttributes(&nrt.Attributes, attrList)
 
 	return nil
@@ -480,13 +565,13 @@ func waitForNodeResourceTopologyCRD(config *restclient.Config, stop <-chan struc
 
 		// If we don't have permission to check CRDs, skip waiting and let the
 		// actual NRT creation fail with a more descriptive error
-		if errors.IsForbidden(err) {
+		if apierrors.IsForbidden(err) {
 			klog.V(2).InfoS("no permission to check CRD existence, skipping wait",
 				"crd", NodeResourceTopologyCRDName, "error", err)
 			return nil
 		}
 
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			klog.InfoS("waiting for NodeResourceTopology CRD to be created. "+
 				"If using Helm, ensure 'topologyUpdater.createCRDs=true' is set",
 				"crd", NodeResourceTopologyCRDName, "retryIn", backoff)
@@ -541,7 +626,7 @@ func updateAttributes(lhs *v1alpha2.AttributeList, rhs v1alpha2.AttributeList) {
 	}
 }
 
-func getKubeletConfigFunc(uri, apiAuthTokenFile string) (func() (*kubeletconfigv1beta1.KubeletConfiguration, error), error) {
+func getKubeletConfigFunc(uri, apiAuthTokenFile string) (func(context.Context) (*kubeletconfigv1beta1.KubeletConfiguration, error), error) {
 	u, err := url.ParseRequestURI(uri)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse -kubelet-config-uri: %w", err)
@@ -551,7 +636,7 @@ func getKubeletConfigFunc(uri, apiAuthTokenFile string) (func() (*kubeletconfigv
 	var klConfig *kubeletconfigv1beta1.KubeletConfiguration
 	switch u.Scheme {
 	case "file":
-		return func() (*kubeletconfigv1beta1.KubeletConfiguration, error) {
+		return func(context.Context) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
 			klConfig, err = kubeconf.GetKubeletConfigFromLocalFile(u.Path)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read kubelet config: %w", err)
@@ -564,8 +649,8 @@ func getKubeletConfigFunc(uri, apiAuthTokenFile string) (func() (*kubeletconfigv
 			return nil, fmt.Errorf("failed to initialize rest config for kubelet config uri: %w", err)
 		}
 
-		return func() (*kubeletconfigv1beta1.KubeletConfiguration, error) {
-			klConfig, err = kubeconf.GetKubeletConfiguration(restConfig)
+		return func(ctx context.Context) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
+			klConfig, err = kubeconf.GetKubeletConfigurationWithContext(ctx, restConfig)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get kubelet config from configz endpoint: %w", err)
 			}

--- a/pkg/nfd-topology-updater/nfd-topology-updater_test.go
+++ b/pkg/nfd-topology-updater/nfd-topology-updater_test.go
@@ -17,11 +17,29 @@ limitations under the License.
 package nfdtopologyupdater
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	fakeclient "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 
 	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+	topologyclientset "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned"
+	faketopologyclientset "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned/fake"
+	"github.com/k8stopologyawareschedwg/podfingerprint"
 	. "github.com/smartystreets/goconvey/convey"
+
+	"sigs.k8s.io/node-feature-discovery/pkg/resourcemonitor"
 )
 
 func TestTopologyUpdater(t *testing.T) {
@@ -109,4 +127,261 @@ func findAttributeByName(attrList v1alpha2.AttributeList, name string) (v1alpha2
 		}
 	}
 	return v1alpha2.AttributeInfo{}, fmt.Errorf("Attribute Not Found name:=%s", name)
+}
+
+func TestUpdateNodeResourceTopologyApplies(t *testing.T) {
+	Convey("When NodeResourceTopology is published", t, func() {
+		topoClient := faketopologyclientset.NewSimpleClientset()
+		topoClient.PrependReactor("patch", "noderesourcetopologies", func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, &v1alpha2.NodeResourceTopology{}, nil
+		})
+		updater := newTestTopologyUpdater(topoClient)
+		zones := v1alpha2.ZoneList{
+			{
+				Name: "node-0",
+				Type: "Node",
+			},
+		}
+		scanResponse := resourcemonitor.ScanResponse{
+			Attributes: v1alpha2.AttributeList{
+				{
+					Name:  podfingerprint.Attribute,
+					Value: "pfp0v001",
+				},
+			},
+		}
+
+		err := updater.updateNodeResourceTopology(zones, scanResponse)
+		So(err, ShouldBeNil)
+
+		actions := topoClient.Actions()
+		So(actions, ShouldHaveLength, 1)
+		patchAction := actions[0].(k8stesting.PatchActionImpl)
+
+		applied := &v1alpha2.NodeResourceTopology{}
+		err = json.Unmarshal(patchAction.GetPatch(), applied)
+		So(err, ShouldBeNil)
+
+		Convey("Then the missing object is created with server-side apply", func() {
+			So(patchAction.GetVerb(), ShouldEqual, "patch")
+			So(patchAction.GetPatchType(), ShouldEqual, types.ApplyPatchType)
+		})
+
+		Convey("Then the apply uses server-side apply", func() {
+			So(patchAction.PatchOptions.FieldManager, ShouldEqual, nodeResourceTopologyFieldManager)
+			So(*patchAction.PatchOptions.Force, ShouldBeTrue)
+		})
+
+		Convey("Then the apply payload contains the desired NRT fields", func() {
+			So(applied.APIVersion, ShouldEqual, v1alpha2.SchemeGroupVersion.String())
+			So(applied.Kind, ShouldEqual, "NodeResourceTopology")
+			So(applied.Name, ShouldEqual, "test-node")
+			So(applied.OwnerReferences, ShouldHaveLength, 1)
+			So(applied.OwnerReferences[0].Name, ShouldEqual, "node-feature-discovery")
+			So(applied.Zones, ShouldResemble, zones)
+			So(applied.TopologyPolicies, ShouldNotBeEmpty)
+
+			policy, err := findAttributeByName(applied.Attributes, TopologyManagerPolicyAttributeName)
+			So(err, ShouldBeNil)
+			So(policy.Value, ShouldEqual, "single-numa-node")
+
+			scope, err := findAttributeByName(applied.Attributes, TopologyManagerScopeAttributeName)
+			So(err, ShouldBeNil)
+			So(scope.Value, ShouldEqual, "container")
+
+			fingerprint, err := findAttributeByName(applied.Attributes, podfingerprint.Attribute)
+			So(err, ShouldBeNil)
+			So(fingerprint.Value, ShouldEqual, "pfp0v001")
+		})
+	})
+}
+
+func TestUpdateNodeResourceTopologyUsesCachedTopologyInfo(t *testing.T) {
+	Convey("When NodeResourceTopology is refreshed after an interval update", t, func() {
+		topoClient := faketopologyclientset.NewSimpleClientset(&v1alpha2.NodeResourceTopology{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+		})
+		updater := newTestTopologyUpdater(topoClient)
+		kubeletConfigReads := 0
+		cpuCoreReads := 0
+		updater.kubeletConfigFunc = func(context.Context) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
+			kubeletConfigReads++
+			return &kubeletconfigv1beta1.KubeletConfiguration{
+				TopologyManagerPolicy: "single-numa-node",
+				TopologyManagerScope:  "container",
+			}, nil
+		}
+		updater.discoverCpuCoresFunc = func() v1alpha2.AttributeList {
+			cpuCoreReads++
+			return v1alpha2.AttributeList{
+				{
+					Name:  "cpu_performance",
+					Value: "0-3",
+				},
+			}
+		}
+		zones := v1alpha2.ZoneList{
+			{
+				Name: "node-0",
+				Type: "Node",
+			},
+		}
+
+		err := updater.refreshTopologyManagerInfo(context.Background())
+		So(err, ShouldBeNil)
+
+		err = updater.updateNodeResourceTopology(zones, resourcemonitor.ScanResponse{
+			Attributes: v1alpha2.AttributeList{
+				{
+					Name:  podfingerprint.Attribute,
+					Value: "pfp0v001",
+				},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		err = updater.updateNodeResourceTopology(zones, resourcemonitor.ScanResponse{
+			Attributes: v1alpha2.AttributeList{
+				{
+					Name:  podfingerprint.Attribute,
+					Value: "pfp0v002",
+				},
+			},
+		})
+
+		Convey("Then cached topology-manager attributes are included without re-reading kubelet config or sysfs", func() {
+			So(err, ShouldBeNil)
+			So(kubeletConfigReads, ShouldEqual, 1)
+			So(cpuCoreReads, ShouldEqual, 1)
+			So(topoClient.Actions(), ShouldHaveLength, 2)
+
+			tracked, err := topoClient.Tracker().Get(
+				v1alpha2.SchemeGroupVersion.WithResource("noderesourcetopologies"),
+				"",
+				"test-node",
+			)
+			So(err, ShouldBeNil)
+			applied := tracked.(*v1alpha2.NodeResourceTopology)
+
+			policy, err := findAttributeByName(applied.Attributes, TopologyManagerPolicyAttributeName)
+			So(err, ShouldBeNil)
+			So(policy.Value, ShouldEqual, "single-numa-node")
+
+			scope, err := findAttributeByName(applied.Attributes, TopologyManagerScopeAttributeName)
+			So(err, ShouldBeNil)
+			So(scope.Value, ShouldEqual, "container")
+
+			cpuCores, err := findAttributeByName(applied.Attributes, "cpu_performance")
+			So(err, ShouldBeNil)
+			So(cpuCores.Value, ShouldEqual, "0-3")
+
+			fingerprint, err := findAttributeByName(applied.Attributes, podfingerprint.Attribute)
+			So(err, ShouldBeNil)
+			So(fingerprint.Value, ShouldEqual, "pfp0v002")
+		})
+	})
+}
+
+func TestUpdateNodeResourceTopologyRetriesMissingTopologyInfo(t *testing.T) {
+	Convey("Given topology-manager information is not cached", t, func() {
+		topoClient := faketopologyclientset.NewSimpleClientset(&v1alpha2.NodeResourceTopology{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+		})
+		updater := newTestTopologyUpdater(topoClient)
+		kubeletConfigReads := 0
+		updater.kubeletConfigFunc = func(context.Context) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
+			kubeletConfigReads++
+			if kubeletConfigReads == 1 {
+				return nil, errors.New("kubelet unavailable")
+			}
+			return &kubeletconfigv1beta1.KubeletConfiguration{
+				TopologyManagerPolicy: "single-numa-node",
+				TopologyManagerScope:  "container",
+			}, nil
+		}
+
+		err := updater.updateNodeResourceTopology(nil, resourcemonitor.ScanResponse{})
+		So(errors.Is(err, errTopologyManagerInfoUnavailable), ShouldBeTrue)
+		So(topoClient.Actions(), ShouldBeEmpty)
+
+		err = updater.updateNodeResourceTopology(nil, resourcemonitor.ScanResponse{})
+		So(err, ShouldBeNil)
+		So(kubeletConfigReads, ShouldEqual, 2)
+		So(topoClient.Actions(), ShouldHaveLength, 1)
+	})
+}
+
+func TestTopologyManagerRefreshContextStops(t *testing.T) {
+	Convey("Given the topology updater is stopped", t, func() {
+		updater := &nfdTopologyUpdater{stop: make(chan struct{})}
+		ctx, cancel := updater.newTopologyManagerRefreshContext()
+		defer cancel()
+
+		close(updater.stop)
+
+		select {
+		case <-ctx.Done():
+			So(ctx.Err(), ShouldEqual, context.Canceled)
+		case <-time.After(time.Second):
+			t.Fatal("refresh context was not canceled")
+		}
+	})
+}
+
+func TestUpdateNodeResourceTopologyApplyErrors(t *testing.T) {
+	const resource = "noderesourcetopologies"
+
+	Convey("Given the NodeResourceTopology resource is unavailable", t, func() {
+		topoClient := faketopologyclientset.NewSimpleClientset(&v1alpha2.NodeResourceTopology{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+		})
+		notFoundErr := apierrors.NewNotFound(
+			v1alpha2.SchemeGroupVersion.WithResource(resource).GroupResource(),
+			"test-node",
+		)
+		topoClient.PrependReactor("patch", resource, func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, notFoundErr
+		})
+
+		err := newTestTopologyUpdater(topoClient).updateNodeResourceTopology(nil, resourcemonitor.ScanResponse{})
+
+		So(apierrors.IsNotFound(err), ShouldBeTrue)
+		So(err.Error(), ShouldContainSubstring, "The NodeResourceTopology CRD may not be installed")
+	})
+
+	Convey("Given applying the NodeResourceTopology fails", t, func() {
+		topoClient := faketopologyclientset.NewSimpleClientset()
+		applyErr := errors.New("apply failed")
+		topoClient.PrependReactor("patch", resource, func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, applyErr
+		})
+
+		err := newTestTopologyUpdater(topoClient).updateNodeResourceTopology(nil, resourcemonitor.ScanResponse{})
+
+		So(errors.Is(err, applyErr), ShouldBeTrue)
+		So(err.Error(), ShouldContainSubstring, "failed to apply NodeResourceTopology")
+	})
+}
+
+func newTestTopologyUpdater(topoClient topologyclientset.Interface) *nfdTopologyUpdater {
+	return &nfdTopologyUpdater{
+		nodeName:            "test-node",
+		kubernetesNamespace: "node-feature-discovery",
+		k8sClient: fakeclient.NewClientset(&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-feature-discovery",
+				UID:  types.UID("namespace-uid"),
+			},
+		}),
+		topoClient: topoClient,
+		kubeletConfigFunc: func(context.Context) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
+			return &kubeletconfigv1beta1.KubeletConfiguration{
+				TopologyManagerPolicy: "single-numa-node",
+				TopologyManagerScope:  "container",
+			}, nil
+		},
+		discoverCpuCoresFunc: func() v1alpha2.AttributeList {
+			return nil
+		},
+	}
 }

--- a/pkg/utils/kubeconf/kubelet_configz.go
+++ b/pkg/utils/kubeconf/kubelet_configz.go
@@ -28,14 +28,22 @@ import (
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 )
 
+const kubeletConfigurationTimeout = 2 * time.Minute
+
 // GetKubeletConfiguration returns the kubelet configuration.
 func GetKubeletConfiguration(restConfig *rest.Config) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), kubeletConfigurationTimeout)
+	defer cancel()
+	return GetKubeletConfigurationWithContext(ctx, restConfig)
+}
+
+// GetKubeletConfigurationWithContext returns the kubelet configuration using the supplied context.
+func GetKubeletConfigurationWithContext(ctx context.Context, restConfig *rest.Config) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	var timeout time.Duration
 	// This hack because /configz reports the following structure:
 	// {"kubeletconfig": {the JSON representation of kubeletconfigv1beta1.KubeletConfiguration}}
 	type configzWrapper struct {
@@ -43,8 +51,7 @@ func GetKubeletConfiguration(restConfig *rest.Config) (*kubeletconfigv1beta1.Kub
 	}
 	bytes, err := discoveryClient.RESTClient().
 		Get().
-		Timeout(timeout).
-		Do(context.TODO()).
+		Do(ctx).
 		Raw()
 	if err != nil {
 		return nil, err

--- a/test/e2e/topology_updater_test.go
+++ b/test/e2e/topology_updater_test.go
@@ -452,7 +452,7 @@ excludeList:
 				if err != nil {
 					if apierrors.IsNotFound(err) {
 						framework.Logf("missing node topology resource for %q", topologyUpdaterNode.Name)
-						return true // intentionally retry
+						return false
 					}
 					framework.Logf("failed to get the node topology resource: %v", err)
 					return false

--- a/test/e2e/utils/rbac.go
+++ b/test/e2e/utils/rbac.go
@@ -323,8 +323,7 @@ func createClusterRoleTopologyUpdater(ctx context.Context, cs clientset.Interfac
 				Resources: []string{"noderesourcetopologies"},
 				Verbs: []string{
 					"create",
-					"get",
-					"update",
+					"patch",
 				},
 			},
 		},


### PR DESCRIPTION
Before this PR, the NFD updater did a get+update to avoid resource
version conflicts. 

With this PR, the nfd updater becomes the owner of the field and uses 
server side apply to patch the field. This comes with performance benefits
as it reduces an unnecessary get before the update.

At scale this will help with reducing CPU usage in kube-apiserver and etcd.