### PR TITLE
cpu: add TDX module version labels

### DIFF
--- a/docs/usage/customization-guide.md
+++ b/docs/usage/customization-guide.md
@@ -944,6 +944,7 @@ The following features are available for matching:
 |                  |              | **`sgx.epc`** | int | The total amount Intel SGX Encrypted Page Cache memory in bytes. It's only present if `sgx.enabled` is `true`. |
 |                  |              | **`se.enabled`** | bool  | `true` if IBM Secure Execution for Linux is available and has been enabled, otherwise does not exist |
 |                  |              | **`tdx.enabled`** | bool | `true` if Intel TDX (Trusted Domain Extensions) is available on the host and has been enabled, otherwise does not exist |
+|                  |              | **`tdx.module-version.<component>`** | string | Version of the loaded Intel TDX module, where component is `full`, `major`, `minor`, or `revision`. |
 |                  |              | **`tdx.total_keys`** | int | The total amount of keys an Intel TDX (Trusted Domain Extensions) host can provide.  It's only present if `tdx.enabled` is `true`. |
 |                  |              | **`tdx.protected`** | bool | `true` if a guest VM was started using Intel TDX (Trusted Domain Extensions), otherwise does not exist. |
 |                  |              | **`sev.enabled`** | bool | `true` if AMD SEV (Secure Encrypted Virtualization) is available on the host and has been enabled, otherwise does not exist |

--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -58,6 +58,7 @@ feature.node.kubernetes.io/<feature> = <value>
 | **`cpu-security.sgx.enabled`**      | true   | Set to 'true' if Intel SGX is enabled in BIOS (based on a non-zero sum value of SGX EPC section sizes). |
 | **`cpu-security.se.enabled`**       | true   | Set to 'true' if IBM Secure Execution for Linux (IBM Z & LinuxONE) is available and enabled (requires `/sys/firmware/uv/prot_virt_host` facility) |
 | **`cpu-security.tdx.enabled`**      | true   | Set to 'true' if Intel TDX is available on the host and has been enabled (requires `/sys/module/kvm_intel/parameters/tdx`). |
+| **`cpu-security.tdx.module-version.<component>`** | string | Version of the loaded Intel TDX module, where component is `full`, `major`, `minor`, or `revision` (requires `/sys/devices/faux/tdx_host/version`). |
 | **`cpu-security.tdx.protected`**    | true   | Set to 'true' if Intel TDX was used to start the guest node, based on the existence of the "TDX_GUEST" information as part of cpuid features. |
 | **`cpu-security.sev.enabled`**      | true   | Set to 'true' if ADM SEV is available on the host and has been enabled (requires `/sys/module/kvm_amd/parameters/sev`). |
 | **`cpu-security.sev.es.enabled`**   | true   | Set to 'true' if ADM SEV-ES is available on the host and has been enabled (requires `/sys/module/kvm_amd/parameters/sev_es`). |

--- a/source/cpu/security_amd64.go
+++ b/source/cpu/security_amd64.go
@@ -22,6 +22,7 @@ import (
 	"bufio"
 	"io"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -56,6 +57,10 @@ func discoverSecurity() map[string]string {
 		elems["tdx.protected"] = "true"
 	}
 
+	for k, v := range discoverTDXVersions() {
+		elems[k] = v
+	}
+
 	if sevParameterEnabled("sev") {
 		elems["sev.enabled"] = "true"
 
@@ -79,6 +84,36 @@ func discoverSecurity() map[string]string {
 	}
 
 	return elems
+}
+
+func discoverTDXVersions() map[string]string {
+	versions := make(map[string]string)
+	raw, err := os.ReadFile(hostpath.SysfsDir.Path("devices/faux/tdx_host/version"))
+	if err != nil {
+		return versions
+	}
+
+	for component, value := range parseTDXVersion(strings.TrimSpace(string(raw))) {
+		versions["tdx.module-version."+component] = value
+	}
+
+	return versions
+}
+
+func parseTDXVersion(raw string) map[string]string {
+	re := regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<revision>\d+)$`)
+	match := re.FindStringSubmatch(raw)
+	if match == nil {
+		return nil
+	}
+
+	version := map[string]string{"full": raw}
+	for i, name := range re.SubexpNames() {
+		if i != 0 && name != "" {
+			version[name] = match[i]
+		}
+	}
+	return version
 }
 
 func sgxEnabled() uint64 {


### PR DESCRIPTION
Linux 7.2 brings TD preserving updates and adds sysfs-devices-faux-tdx-host interface along with firmware upload mechanism for OS initiated TDX module updates.

sysfs-devices-faux-tdx-host exposes the TDX module version that is useful information to be added as a node label. The other sysfs entries are omitted due to:

"Reading them issues a slow, serialized P-SEAMLDR query, so keep them admin-only."

The labeling follows the kernel-version convention (major/minor/revision/full).