### PR TITLE
Make Prometheus datasource a template variable in the Grafana dashboard

### DIFF
--- a/examples/grafana-dashboard.json
+++ b/examples/grafana-dashboard.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
   "__requires": [
     {
       "type": "grafana",
@@ -1328,7 +1318,23 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allowCustomValue": true,
+        "current": {
+          "text": "",
+          "value": "${DS_PROMETHEUS}",
+          "selected": true
+        },
+        "label": "Data Source",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-15m",


### PR DESCRIPTION
Changes the example Grafana dashboard to use a template variable instead of import inputs.

Since users only get asked about the `__inputs` when importing the dashboard via the web UI, users who import it via other means (such as in Kubernetes deployments) do not get prompted for the datasource.

Changing it to a template variable allows it to be configured at any time regardless of deployment method.