### PR TITLE
helm: set explicit namespace on the PodMonitor

### DIFF
--- a/deployment/helm/node-feature-discovery/templates/prometheus.yaml
+++ b/deployment/helm/node-feature-discovery/templates/prometheus.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "node-feature-discovery.fullname" . }}
+  namespace: {{ include "node-feature-discovery.namespace" . }}
   labels:
     {{- include "node-feature-discovery.selectorLabels" . | nindent 4 }}
     {{- with .Values.prometheus.labels }}


### PR DESCRIPTION
The PodMonitor was the only namespaced resource in the chart without an explicit metadata.namespace. Every other namespaced template (master, worker, topology-updater, the ConfigMaps, ServiceAccounts, Roles, RoleBindings, PDBs and NetworkPolicies) already sets it via the node-feature-discovery.namespace helper.

Plain `helm install` was unaffected, since Helm assigns the release namespace to any resource that omits one. Rendering the chart through Kustomize's Helm integration is not: as of Kustomize 5.8.x the parent kustomization's namespace is no longer propagated to resources inflated from a chart (kubernetes-sigs/kustomize#6058, introduced by kubernetes-sigs/kustomize#5940), so the PodMonitor came out with no namespace at all. Argo CD then refuses to sync it:

  InvalidSpecError: Namespace for nfd-node-feature-discovery
  monitoring.coreos.com/v1, Kind=PodMonitor is missing.

Set the namespace from the existing helper, which also keeps the PodMonitor's own namespace consistent with the spec.namespaceSelector just below it and honours namespaceOverride.

Fixes #2576