### PR TITLE
ci: migrate coverage upload to Codecov CLI

### DIFF
--- a/scripts/test-infra/verify.sh
+++ b/scripts/test-infra/verify.sh
@@ -6,6 +6,9 @@ this_dir=`dirname $0`
 GOLANGCI_LINT_VERSION="v2.11.4"
 HELM_VERSION="v3.17.3"
 KUBECTL_VERSION="v1.22.1"
+CODECOV_CLI_URL="https://cli.codecov.io/latest/linux"
+CODECOV_PGP_KEY_URL="https://keybase.io/codecovsecops/pgp_keys.asc"
+CODECOV_PGP_FINGERPRINT="27034E7FDB850E0BBC2C62FF806BB28AED779869"
 
 # Install deps
 gobinpath="$(go env GOPATH)/bin"
@@ -38,21 +41,44 @@ echo "Running unit tests"
 make test
 
 # Upload coverage report (best-effort; coverage reporting must never gate CI).
-# The legacy Codecov uploader is deprecated and its download/key endpoints have
-# proven unreliable (e.g. the Keybase PGP key URL now returns a stub), so any
-# failure here is logged and treated as non-fatal. Migrating to the supported
-# Codecov CLI is tracked separately.
-upload_coverage() {
-    curl -Os https://uploader.codecov.io/latest/linux/codecov
-    chmod +x codecov
-    ./codecov -t "${CODECOV_TOKEN}" \
-              -C "${PULL_PULL_SHA}" \
-              -r "${REPO_OWNER}/${REPO_NAME}" \
-              -P "${PULL_NUMBER}" \
-              -b "${BUILD_ID}" \
-              -B "${PULL_BASE_REF}" \
-              -N "${PULL_BASE_SHA}"
-}
+upload_coverage() (
+    local codecov_dir gpg_home fingerprint repo_dir
+
+    repo_dir="$(pwd)"
+    codecov_dir="$(mktemp -d)" || exit 1
+    trap 'rm -rf "${codecov_dir}"' EXIT
+    gpg_home="${codecov_dir}/gnupg"
+    mkdir -m 700 "${gpg_home}" || exit 1
+
+    curl -fsSL "${CODECOV_PGP_KEY_URL}" -o "${codecov_dir}/pgp_keys.asc" || exit 1
+    gpg --batch --homedir "${gpg_home}" --import "${codecov_dir}/pgp_keys.asc" || exit 1
+
+    fingerprint="$(gpg --batch --homedir "${gpg_home}" --with-colons \
+        --list-keys "${CODECOV_PGP_FINGERPRINT}" | awk -F: '$1 == "fpr" { print $10; exit }')"
+    if [ "${fingerprint}" != "${CODECOV_PGP_FINGERPRINT}" ]; then
+        echo "Codecov signing key fingerprint did not match the expected key" >&2
+        exit 1
+    fi
+
+    curl -fsSL "${CODECOV_CLI_URL}/codecov" -o "${codecov_dir}/codecov" || exit 1
+    curl -fsSL "${CODECOV_CLI_URL}/codecov.SHA256SUM" -o "${codecov_dir}/codecov.SHA256SUM" || exit 1
+    curl -fsSL "${CODECOV_CLI_URL}/codecov.SHA256SUM.sig" -o "${codecov_dir}/codecov.SHA256SUM.sig" || exit 1
+    gpg --batch --homedir "${gpg_home}" --verify \
+        "${codecov_dir}/codecov.SHA256SUM.sig" "${codecov_dir}/codecov.SHA256SUM" || exit 1
+    (cd "${codecov_dir}" && sha256sum --check codecov.SHA256SUM) || exit 1
+    chmod +x "${codecov_dir}/codecov" || exit 1
+
+    "${codecov_dir}/codecov" upload-process \
+        --token "${CODECOV_TOKEN}" \
+        --commit-sha "${PULL_PULL_SHA}" \
+        --slug "${REPO_OWNER}/${REPO_NAME}" \
+        --pull-request-number "${PULL_NUMBER}" \
+        --build "${BUILD_ID}" \
+        --branch "${PULL_BASE_REF}" \
+        --parent-sha "${PULL_BASE_SHA}" \
+        --git-service github \
+        --dir "${repo_dir}"
+)
 
 echo "Uploading coverage report (best-effort, non-gating)"
 if ! upload_coverage; then


### PR DESCRIPTION
## Problem

`scripts/test-infra/verify.sh` still downloads the deprecated legacy Codecov uploader. Its historical key URL has already broken the verify job once, and the legacy uploader no longer receives feature work.

## Approach

- Replace the legacy uploader with the supported Codecov CLI.
- Download the CLI, its SHA256 manifest, and the manifest signature into a temporary directory.
- Verify the imported signing key against Codecov's published fingerprint, verify the signed manifest, and verify the CLI checksum before execution.
- Preserve the existing best-effort behavior: a coverage upload failure logs a warning and does not block the verification job.

## Testing

- `bash -n scripts/test-infra/verify.sh`
- `make gofmt-verify`
- `make test`
- Manual validation: downloaded the current CLI on the remote host, verified the expected signing-key fingerprint, its GPG signature, and `sha256sum --check`, then ran `codecov --version` successfully.
- Manual failure-path check: simulated a failed download under `bash -e`; the script emitted the existing warning and continued successfully.
- Confirmed that `curl`, `gpg`, and `sha256sum` are available in `public.ecr.aws/docker/library/golang:1.25.0`, the Prow `verify-master` image.

## Breaking changes

None.

Fixes #2526
